### PR TITLE
Feat/add cistrans dbl bonds

### DIFF
--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -277,7 +277,23 @@ class Bond : public RDProps {
   BondDir getBondDir() const { return static_cast<BondDir>(d_dirTag); };
 
   //! sets our stereo code
-  void setStereo(BondStereo what) { d_stereo = what; };
+  /*!
+      STEREONONE, STEREOANY, STEREOE and STEREOZ can be set without
+      neighboring atoms specified in getStereoAtoms since they are
+      defined by the topology of the molecular graph. In order to set
+      STEREOCIS or STEREOTRANS the neighboring atoms must be set first
+      to know what atoms are being considered.
+
+      <b>Notes:</b>
+        - Bond::setStereoAtoms(int bgnIdx, int endIdx) is not yet created, need to create this
+        - MolOps::findPotentialStereoBonds can be used to set
+          getStereoAtoms before setting CIS/TRANS
+  */
+  void setStereo(BondStereo what) {
+    PRECONDITION(what <= STEREOE || getStereoAtoms().size() == 2,
+                 "Stereo atoms should be specified before specifying CIS/TRANS bond stereochemistry")
+    d_stereo = what;
+  };
   //! returns our stereo code
   BondStereo getStereo() const { return static_cast<BondStereo>(d_stereo); };
 

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -240,7 +240,7 @@ void canonicalizeDoubleBond(Bond *dblBond, INT_VECT &bondVisitOrders,
 
   // now set the directionality on the other side:
   if (setFromBond1) {
-    if (dblBond->getStereo() == Bond::STEREOE || dblBond->getStereo() ==Bond::STEREOTRANS ) {
+    if (dblBond->getStereo() == Bond::STEREOE || dblBond->getStereo() == Bond::STEREOTRANS ) {
       atom2Dir = atom1Dir;
     } else if (dblBond->getStereo() == Bond::STEREOZ || dblBond->getStereo() == Bond::STEREOCIS) {
       atom2Dir = (atom1Dir == Bond::ENDUPRIGHT) ? Bond::ENDDOWNRIGHT

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -127,14 +127,13 @@ struct bond_wrapper {
              "Set the type of the bond as a BondDir\n")
 
         .def("GetStereo", &Bond::getStereo,
-             "Returns the CIP-classification of the bond as a BondStereo\n")
-        // this is no longer exposed because it requires that stereo atoms
-        // be set. This is a task that is tricky and "dangerous".
-        //.def("SetStereo",&Bond::setStereo,
-        //	   "Set the CIP-classification of the bond as a BondStereo\n")
+             "Returns the stereo configuration of the bond as a BondStereo\n")
+        .def("SetStereo", &Bond::setStereo,
+             "Set the stereo configuration of the bond as a BondStereo\n")
         .def("GetStereoAtoms", getBondStereoAtoms,
              "Returns the indices of the atoms setting this bond's "
              "stereochemistry.")
+
         .def("GetValenceContrib",
              (double (Bond::*)(const Atom *) const) & Bond::getValenceContrib,
              "Returns the contribution of the bond to the valence of an "

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -1636,6 +1636,212 @@ M  END
     self.assertDoesNotHaveDoubleBondStereo("C=C")
     self.assertDoesNotHaveDoubleBondStereo("C1CCCCC1C(C1CCCCC1)=CC1CCCCC1")
 
+  def assertDoubleBondStereo(self, smi, stereo):
+    mol = Chem.MolFromSmiles(smi)
+
+    bond = mol.GetBondWithIdx(1)
+    self.assertEquals(bond.GetBondType(), Chem.BondType.DOUBLE)
+    self.assertEquals(bond.GetStereo(), stereo)
+    self.assertEquals(list(bond.GetStereoAtoms()), [0, 3])
+
+  def allStereoBonds(self, bonds):
+    for bond in bonds:
+      self.assertEquals(len(list(bond.GetStereoAtoms())), 2)
+
+  def testBondSetStereo(self):
+    for testAssignStereo in [False, True]:
+      mol = Chem.MolFromSmiles("FC=CF")
+      Chem.FindPotentialStereoBonds(mol)
+
+      for bond in mol.GetBonds():
+        if (bond.GetBondType() == Chem.BondType.DOUBLE and
+            bond.GetStereo() == Chem.BondStereo.STEREOANY):
+          break
+      self.assertEquals(bond.GetBondType(), Chem.BondType.DOUBLE)
+      self.assertEquals(bond.GetStereo(), Chem.BondStereo.STEREOANY)
+      self.assertEquals(list(bond.GetStereoAtoms()), [0, 3])
+
+      bond.SetStereo(Chem.BondStereo.STEREOTRANS)
+      self.assertEquals(bond.GetStereo(), Chem.BondStereo.STEREOTRANS)
+      if testAssignStereo: # should be invariant of Chem.AssignStereochemistry being called
+        Chem.AssignStereochemistry(mol, force=True)
+      smi = Chem.MolToSmiles(mol, isomericSmiles=True)
+      self.allStereoBonds([bond])
+      self.assertEquals(smi, "F/C=C/F")
+      self.assertDoubleBondStereo(smi, Chem.BondStereo.STEREOE)
+
+      bond.SetStereo(Chem.BondStereo.STEREOCIS)
+      self.assertEquals(bond.GetStereo(), Chem.BondStereo.STEREOCIS)
+      if testAssignStereo:
+        Chem.AssignStereochemistry(mol, force=True)
+      smi = Chem.MolToSmiles(mol, isomericSmiles=True)
+      self.allStereoBonds([bond])
+      self.assertEquals(smi, "F/C=C\F")
+      self.assertDoubleBondStereo(smi, Chem.BondStereo.STEREOZ)
+
+  def recursive_enumerate_stereo_bonds(self, mol, done_bonds, bonds):
+    if not bonds:
+      yield done_bonds, Chem.Mol(mol)
+      return
+
+    bond = bonds[0]
+    child_bonds = bonds[1:]
+    self.assertEquals(len(list(bond.GetStereoAtoms())), 2)
+    bond.SetStereo(Chem.BondStereo.STEREOTRANS)
+    for isomer in self.recursive_enumerate_stereo_bonds(mol, done_bonds + [Chem.BondStereo.STEREOE], child_bonds):
+      yield isomer
+
+    self.assertEquals(len(list(bond.GetStereoAtoms())), 2)
+    bond.SetStereo(Chem.BondStereo.STEREOCIS)
+    for isomer in self.recursive_enumerate_stereo_bonds(mol, done_bonds + [Chem.BondStereo.STEREOZ], child_bonds):
+      yield isomer
+
+  def testBondSetStereoDifficultCase(self):
+    unspec_smiles = "CCC=CC(CO)=C(C)CC"
+    mol = Chem.MolFromSmiles(unspec_smiles)
+    Chem.FindPotentialStereoBonds(mol)
+
+    stereo_bonds = []
+    for bond in mol.GetBonds():
+      if bond.GetStereo() == Chem.BondStereo.STEREOANY:
+        stereo_bonds.append(bond)
+
+    isomers = set()
+    for bond_stereo, isomer in self.recursive_enumerate_stereo_bonds(mol, [], stereo_bonds):
+      self.allStereoBonds(stereo_bonds)
+      isosmi = Chem.MolToSmiles(isomer, isomericSmiles=True)
+      self.allStereoBonds(stereo_bonds)
+
+      self.assertNotIn(isosmi, isomers)
+      isomers.add(isosmi)
+
+      isomol = Chem.MolFromSmiles(isosmi)
+      round_trip_stereo = [b.GetStereo() for b in isomol.GetBonds() if b.GetStereo() != Chem.BondStereo.STEREONONE]
+
+      self.assertEquals(bond_stereo, round_trip_stereo)
+
+    self.assertEqual(len(isomers), 4)
+
+
+  def getNumUnspecifiedBondStereo(self, smi):
+    mol = Chem.MolFromSmiles(smi)
+    Chem.FindPotentialStereoBonds(mol)
+
+    count = 0
+    for bond in mol.GetBonds():
+      if bond.GetStereo() == Chem.BondStereo.STEREOANY:
+        count += 1
+
+    return count
+
+  def testBondSetStereoReallyDifficultCase(self):
+    # this one is much trickier because a double bond can gain and
+    # lose it's stereochemistry based upon whether 2 other double
+    # bonds have the same or different stereo chemistry.
+
+    unspec_smiles = "CCC=CC(C=CCC)=C(CO)CC"
+    mol = Chem.MolFromSmiles(unspec_smiles)
+    Chem.FindPotentialStereoBonds(mol)
+
+    stereo_bonds = []
+    for bond in mol.GetBonds():
+      if bond.GetStereo() == Chem.BondStereo.STEREOANY:
+        stereo_bonds.append(bond)
+
+    self.assertEquals(len(stereo_bonds), 2)
+
+    isomers = set()
+    for bond_stereo, isomer in self.recursive_enumerate_stereo_bonds(mol, [], stereo_bonds):
+      isosmi = Chem.MolToSmiles(isomer, isomericSmiles=True)
+      isomers.add(isosmi)
+
+    self.assertEquals(len(isomers), 3)
+
+    # one of these then gains a new stereo bond due to the
+    # introduction of a new symmetry
+    counts = {}
+    for isosmi in isomers:
+      num_unspecified = self.getNumUnspecifiedBondStereo(isosmi)
+      counts[num_unspecified] = counts.get(num_unspecified, 0) + 1
+
+    # 2 of the isomers don't have any unspecified bond stereo centers
+    # left, 1 does
+    self.assertEquals(counts, {0 : 2, 1 : 1})
+
+  def assertBondSetStereoIsAlwaysEquivalent(self, all_smiles, desired_stereo, bond_idx):
+    refSmiles = None
+    for smi in all_smiles:
+      mol = Chem.MolFromSmiles(smi)
+
+      doubleBond = None
+      for bond in mol.GetBonds():
+        if bond.GetBondType() == Chem.BondType.DOUBLE:
+          doubleBond = bond
+
+      self.assertTrue(doubleBond is not None)
+
+      Chem.FindPotentialStereoBonds(mol)
+      doubleBond.SetStereo(desired_stereo)
+
+      isosmi = Chem.MolToSmiles(mol, isomericSmiles=True)
+
+      if refSmiles is None:
+        refSmiles = isosmi
+
+      self.assertEquals(refSmiles, isosmi)
+
+  def testBondSetStereoAllHalogens(self):
+    # can't get much more brutal than this test
+    from itertools import combinations, permutations
+    halogens = ['F', 'Cl', 'Br', 'I']
+
+    # binary double bond stereo
+    for unique_set in combinations(halogens, 2):
+      all_smiles = []
+      for fmt in ['%sC=C%s', 'C(%s)=C%s']:
+        for ordering in permutations(unique_set):
+          all_smiles.append(fmt % ordering)
+
+      #print(fmt, all_smiles)
+      for desired_stereo in [Chem.BondStereo.STEREOTRANS, Chem.BondStereo.STEREOCIS]:
+        self.assertBondSetStereoIsAlwaysEquivalent(all_smiles, desired_stereo, 1)
+
+    # tertiary double bond stereo
+    for unique_set in combinations(halogens, 3):
+      for mono_side in unique_set:
+        halogens_left = list(unique_set)
+        halogens_left.remove(mono_side)
+        for binary_side in combinations(halogens_left, 2):
+          all_smiles = []
+
+          for binary_side_permutation in permutations(binary_side):
+            all_smiles.append('%sC=C(%s)%s' % ((mono_side,) + binary_side_permutation))
+            all_smiles.append('C(%s)=C(%s)%s' % ((mono_side,) + binary_side_permutation))
+
+            all_smiles.append('%sC(%s)=C%s' % (binary_side_permutation + (mono_side,)))
+            all_smiles.append('C(%s)(%s)=C%s' % (binary_side_permutation + (mono_side,)))
+
+          #print(all_smiles)
+          for desired_stereo in [Chem.BondStereo.STEREOTRANS, Chem.BondStereo.STEREOCIS]:
+            self.assertBondSetStereoIsAlwaysEquivalent(all_smiles, desired_stereo, 1)
+
+
+    # quaternary double bond stereo
+    for unique_ordering in permutations(halogens):
+      left_side = unique_ordering[:2]
+      rght_side = unique_ordering[2:]
+
+      all_smiles = []
+      for left_side_permutation in permutations(left_side):
+        for rght_side_permutation in permutations(rght_side):
+          for smifmt in ['%sC(%s)=C(%s)%s', 'C(%s)(%s)=C(%s)%s']:
+            all_smiles.append(smifmt % (left_side_permutation + rght_side_permutation))
+
+      #print(all_smiles)
+      for desired_stereo in [Chem.BondStereo.STEREOTRANS, Chem.BondStereo.STEREOCIS]:
+        self.assertBondSetStereoIsAlwaysEquivalent(all_smiles, desired_stereo, 1)
+
+
   def test36SubstructMatchStr(self):
     """ test the _SubstructMatchStr function """
     query = Chem.MolFromSmarts('[n,p]1ccccc1')


### PR DESCRIPTION
C++ and Python test cases for Bond::setStereo with STEREOCIS and STEREOTRANS. 

I think the only thing left we still need is Bond::setStereoAtoms(int bgnIdx, int endIdx). Want to add that? or shall I?