### PR TITLE
improve reactant highlighting in rxn drawing

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -479,10 +479,12 @@ void get2DCoordsForReaction(ChemicalReaction &rxn, const MolDrawOptions &opts,
 
   arrowBegin.y = arrowEnd.y = minY + (maxY - minY) / 2;
 }
+
 }
 
 void MolDraw2D::drawReaction(const ChemicalReaction &rxn,
                              bool highlightByReactant,
+                             const std::vector<DrawColour>* highlightColorsReactants,
                              const std::vector<int> *confIds) {
   ChemicalReaction nrxn(rxn);
   double spacing = 1.0;
@@ -528,13 +530,10 @@ void MolDraw2D::drawReaction(const ChemicalReaction &rxn,
   std::vector<int> *bond_highlights = NULL;
   std::map<int, DrawColour> *bond_highlight_colors = NULL;
   if (highlightByReactant) {
-    // FIX: these really should be defined elsewhere
-    std::vector<DrawColour> highlightColors;
-    highlightColors.push_back(DrawColour(.9, .6, .6));
-    highlightColors.push_back(DrawColour(.6, .6, .9));
-    highlightColors.push_back(DrawColour(.8, .8, .3));
-    highlightColors.push_back(DrawColour(.8, .6, .8));
-
+    const std::vector<DrawColour>* colors = &drawOptions().highlightColourPalette;
+    if(highlightColorsReactants){
+      colors = highlightColorsReactants;
+    }
     std::vector<int> atomfragmap;
     MolOps::getMolFrags(*tmol, atomfragmap);
 
@@ -550,8 +549,8 @@ void MolDraw2D::drawReaction(const ChemicalReaction &rxn,
           atom->getAtomMapNum()) {
         atommap_fragmap[atom->getAtomMapNum()] = atomfragmap[aidx];
         atom_highlights->push_back(aidx);
-        (*atom_highlight_colors)[aidx] =
-            highlightColors[atomfragmap[aidx] % highlightColors.size()];
+        (*atom_highlight_colors)[aidx] = (*colors)[atomfragmap[aidx]%colors->size()];
+
         atom->setAtomMapNum(0);
         // add highlighted bonds to lower-numbered
         // (and thus already covered) neighbors
@@ -579,8 +578,8 @@ void MolDraw2D::drawReaction(const ChemicalReaction &rxn,
               atommap_fragmap.end()) {
         atom_highlights->push_back(aidx);
         (*atom_highlight_colors)[aidx] =
-            highlightColors[atommap_fragmap[atom->getAtomMapNum()] %
-                            highlightColors.size()];
+            (*colors)[atommap_fragmap[atom->getAtomMapNum()]%colors->size()];
+
         atom->setAtomMapNum(0);
         // add highlighted bonds to lower-numbered
         // (and thus already covered) neighbors

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -66,6 +66,9 @@ struct MolDrawOptions {
   std::vector<std::vector<int> > atomRegions;  // regions
   DrawColour
       symbolColour;  // color to be used for the symbols and arrows in reactions
+  std::vector<DrawColour> highlightColourPalette; // defining 10 default colors
+                                                 // for highlighting atoms and bonds
+                                                 //or reactants in a reactions
 
   MolDrawOptions()
       : atomLabelDeuteriumTritium(false),
@@ -82,7 +85,19 @@ struct MolDrawOptions {
         multipleBondOffset(0.15),
         padding(0.05),
         additionalAtomLabelPadding(0.0),
-        symbolColour(0, 0, 0){};
+        symbolColour(0, 0, 0){
+    highlightColourPalette.push_back(DrawColour(1., 1., .67)); // popcorn yellow
+    highlightColourPalette.push_back(DrawColour(1., .8, .6)); // sand
+    highlightColourPalette.push_back(DrawColour(1., .71, .76)); // light pink
+    highlightColourPalette.push_back(DrawColour(.8, 1., .8)); // offwhitegreen
+    highlightColourPalette.push_back(DrawColour(.87, .63, .87)); // plum
+    highlightColourPalette.push_back(DrawColour(.76, .94, .96)); // pastel blue
+    highlightColourPalette.push_back(DrawColour(.67, .67, 1.)); // periwinkle
+    highlightColourPalette.push_back(DrawColour(.64, .76, .34)); // avocado
+    highlightColourPalette.push_back(DrawColour(.56, .93, .56)); // light green
+    highlightColourPalette.push_back(DrawColour(.20, .63, .79)); // peacock
+  };
+
 };
 
 //! MolDraw2D is the base class for doing 2D renderings of molecules
@@ -198,13 +213,16 @@ class MolDraw2D {
   /*!
     \param rxn                 : the reaction to draw
     \param highlightByReactant : (optional) if this is set, atoms and bonds will
-    be highlighted baesed on which reactant they come from. Atom map numbers
+    be highlighted based on which reactant they come from. Atom map numbers
     will not be shown.
+    \param highlightColorsReactants : (optional) provide a vector of colors for the
+    reactant highlighting.
     \param confIds   : (optional) vector of confIds to use for rendering. These
     are numbered by reactants, then agents, then products.
   */
   virtual void drawReaction(const ChemicalReaction &rxn,
                             bool highlightByReactant = false,
+                            const std::vector<DrawColour>* highlightColorsReactants = NULL,
                             const std::vector<int> *confIds = NULL);
 
   //! \name Transformations

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -62,7 +62,34 @@ std::map<int, double> *pyDictToDoubleMap(python::object pyo) {
   }
   return res;
 }
+
+void pyListToColourVec(python::object pyo, std::vector<DrawColour> &res) {
+  res.clear();
+  python::list tList = python::extract<python::list>(pyo);
+  for (unsigned int i = 0;
+       i < python::extract<unsigned int>(tList.attr("__len__")()); ++i) {
+    python::tuple tpl = python::extract<python::tuple>(tList[i]);
+    float r = python::extract<float>(tpl[0]);
+    if (r > 1 || r < 0) {
+      throw ValueErrorException(
+          "RGB color value needs to be between 0 and 1.");
+    }
+    float g = python::extract<float>(tpl[1]);
+    if (g > 1 || g < 0) {
+      throw ValueErrorException(
+          "RGB color value needs to be between 0 and 1.");
+    }
+    float b = python::extract<float>(tpl[2]);
+    if (b > 1 || b < 0) {
+      throw ValueErrorException(
+          "RGB color value needs to be between 0 and 1.");
+    }
+    DrawColour clr(r, g, b);
+    res.push_back(clr);
+  }
 }
+}
+
 void drawMoleculeHelper1(MolDraw2D &self, const ROMol &mol,
                          python::object highlight_atoms,
                          python::object highlight_atom_map,
@@ -198,10 +225,18 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
 }
 
 void drawReactionHelper(MolDraw2D &self, const ChemicalReaction &rxn,
-                        bool highlightByReactant, python::object pconfIds) {
+                        bool highlightByReactant, python::object phighlightColorsReactants,
+                        python::object pconfIds) {
+
+  rdk_auto_ptr<std::vector<DrawColour> > highlightColorsReactants;
+  if(phighlightColorsReactants){
+    highlightColorsReactants.reset(new std::vector<DrawColour>);
+    pyListToColourVec(phighlightColorsReactants, *highlightColorsReactants);
+  }
+
   rdk_auto_ptr<std::vector<int> > confIds = pythonObjectToVect<int>(pconfIds);
 
-  self.drawReaction(rxn, highlightByReactant, confIds.get());
+  self.drawReaction(rxn, highlightByReactant, highlightColorsReactants.get(), confIds.get());
 }
 
 #ifdef RDK_CAIRO_BUILD
@@ -300,6 +335,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("DrawReaction", RDKit::drawReactionHelper,
            (python::arg("self"), python::arg("rxn"),
             python::arg("highlightByReactant") = false,
+            python::arg("highlightColorsReactants") = python::object(),
             python::arg("confIds") = python::object()),
            "renders a reaction\n")
       .def("Width", &RDKit::MolDraw2D::width,

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -204,6 +204,22 @@ M  END""")
     self.assertTrue(txt.find("<svg:svg") != -1)
     self.assertTrue(txt.find("</svg:svg>") != -1)
     #print(txt,file=open('blah2.svg','w+'))
+    
+  def testReaction3(self):
+    rxn = AllChem.ReactionFromSmarts('[CH3:1][C:2](=[O:3])[OH:4].[CH3:5][NH2:6]>CC(O)C.[Pt]>[CH3:1][C:2](=[O:3])[NH:6][CH3:5].[OH2:4]',useSmiles=True)
+    colors=[(0.3,0.7,0.9),(0.9,0.7,0.9),(0.6,0.9,0.3),(0.9,0.9,0.1)]
+    d = Draw.MolDraw2DSVG(900, 300)
+    d.DrawReaction(rxn,highlightByReactant=True,highlightColorsReactants=colors)
+    d.FinishDrawing()
+    txt = d.GetDrawingText()
+    self.assertTrue(txt.find("<svg:svg") != -1)
+    self.assertTrue(txt.find("</svg:svg>") != -1)
+    
+  def testReaction4(self):
+    rxn = AllChem.ReactionFromSmarts('[CH3:1][C:2](=[O:3])[OH:4].[CH3:5][NH2:6]>CC(O)C.[Pt]>[CH3:1][C:2](=[O:3])[NH:6][CH3:5].[OH2:4]',useSmiles=True)
+    colors=[(100,155,245),(0,45,155)]
+    d = Draw.MolDraw2DSVG(900, 300)
+    self.assertRaises(ValueError, d.DrawReaction, rxn, True, colors)
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolDraw2D/rxn_test1.cpp
+++ b/Code/GraphMol/MolDraw2D/rxn_test1.cpp
@@ -39,7 +39,8 @@ using namespace RDKit;
 
 namespace {
 void drawit(ChemicalReaction *rxn, std::string nameBase,
-            bool highlight_map = false) {
+            bool highlight_map = false,
+            const std::vector<DrawColour>* highlight_colors = NULL) {
   double panex = 200, paney = 150;
   double width = panex * (rxn->getNumReactantTemplates() +
                           rxn->getNumProductTemplates() + 1);
@@ -47,7 +48,7 @@ void drawit(ChemicalReaction *rxn, std::string nameBase,
 #ifdef RDK_CAIRO_BUILD
   {
     MolDraw2DCairo drawer(width, height);
-    drawer.drawReaction(*rxn, highlight_map);
+    drawer.drawReaction(*rxn, highlight_map, highlight_colors);
     drawer.finishDrawing();
     drawer.writeDrawingText(nameBase + ".png");
   }
@@ -55,7 +56,7 @@ void drawit(ChemicalReaction *rxn, std::string nameBase,
   {
     std::ofstream outs((nameBase + ".svg").c_str());
     MolDraw2DSVG drawer(width, height, outs);
-    drawer.drawReaction(*rxn, highlight_map);
+    drawer.drawReaction(*rxn, highlight_map, highlight_colors);
     drawer.finishDrawing();
     outs.flush();
   }
@@ -205,10 +206,36 @@ C3)c4cccc(c4Cl)Cl	CCc1nc(c(n1c2ccccc2)C)C(=O)NCCN3CCN(CC3)c4cccc(c4Cl)Cl\n\
   std::cout << " Done" << std::endl;
 }
 
+void test3() {
+  std::cout << " ----------------- Test 3: test reactant highlighting"
+            << std::endl;
+  {  // from the reaction role assignment paper
+    std::string smiles =
+        "[cH:5]1[cH:6][c:7]2[cH:8][n:9][cH:10][cH:11][c:12]2[c:3]([cH:4]1)[C:2]"
+        "(=[O:1])O.[N-:13]=[N+:14]=[N-:15]>C(Cl)Cl.C(=O)(C(=O)Cl)Cl>[cH:5]1["
+        "cH:6][c:7]2[cH:8][n:9][cH:10][cH:11][c:12]2[c:3]([cH:4]1)[C:2](=[O:1])"
+        "[N:13]=[N+:14]=[N-:15]";
+    std::string nameBase = "rxn_test3_1";
+    bool useSmiles = true;
+    ChemicalReaction *rxn =
+        RxnSmartsToChemicalReaction(smiles, NULL, useSmiles);
+    TEST_ASSERT(rxn);
+    std::vector<DrawColour> highlight_colors;
+    highlight_colors.push_back(DrawColour(1., 1., .67));
+    highlight_colors.push_back(DrawColour(1., .71, .76));
+    highlight_colors.push_back(DrawColour(.8, 1., .8));
+    highlight_colors.push_back(DrawColour(.67, .67, 1.));
+    drawit(rxn, nameBase, true, &highlight_colors);
+    delete rxn;
+  }
+  std::cout << " Done" << std::endl;
+}
+
 int main() {
   RDLog::InitLogs();
 #if 1
   test1();
   test2();
+  test3();
 #endif
 }


### PR DESCRIPTION
- define default colors for highlighting of reactants, atom or bonds
in the drawing options
- make highlighting colors customizable through the API