### PR TITLE
Adding more examples of aromatic and non-aromatic compounds under the OpenEye MDL model

### DIFF
--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4483,12 +4483,30 @@ M  END
 
   def testGithub1622(self):
       nonaromatics = (
-      "C1=C[Se]C=C1",   # not outside the second rows
       "C1=C[N]C=C1",    # radicals are not two electron donors
       "O=C1C=CNC=C1",   # exocyclic double bonds don't steal electrons
       "C1=CS(=O)C=C1",  # not sure how to classify this example from the
                         # OEChem docs
       "C1#CC=CC=C1"     # benzyne
+      # 5-membered heterocycles
+      "C1=COC=C1",           # furan
+      "C1=CSC=C1",           # thiophene
+      "C1=CNC=C1",        #pyrrole
+      "C1=COC=N1",  # oxazole
+      "C1=CSC=N1",  # thiazole
+      "C1=CNC=N1",  # imidzole
+      "C1=CNN=C1",  # pyrazole
+      "C1=CON=C1",  # isoxazole
+      "C1=CSN=C1",  # isothiazole
+      "C1=CON=N1",  # 1,2,3-oxadiazole
+      "C1=CNN=N1",  # 1,2,3-triazole
+      "N1=CSC=N1",   # 1,3,4-thiadiazole
+      # not outside the second rows
+      "C1=CC=C[Si]=C1",
+      "C1=CC=CC=P1",
+      # 5-membered heterocycles outside the second row
+      "C1=C[Se]C=C1",
+      'C1=C[Te]C=C1'
       )
       for smi in nonaromatics:
           m = Chem.MolFromSmiles(smi,sanitize=False)
@@ -4497,9 +4515,24 @@ M  END
           self.assertFalse(m.GetAtomWithIdx(0).GetIsAromatic())
       aromatics = (
       "C1=CC=CC=C1",         # benzene, of course
-      "C1=COC=C1",           # furan
-      "C1=CSC=C1",           # thiophene
-      "C1=CC2=CC=CC=CC2=C1"  # azulene
+      # hetrocyclics
+      "N1=CC=CC=C1",          # pyridine
+      "N1=CC=CC=N1",   # pyridazine
+      "N1=CC=CN=C1",   # pyrimidine
+      "N1=CC=NC=C1",   # pyrazine
+      "N1=CN=CN=C1",   # 1,3,5-triazine
+      # polycyclic aromatics
+      "C1=CC2=CC=CC=CC2=C1",  # azulene
+      "C1=CC=CC2=CC=CC=C12",
+      "C1=CC2=CC=CC=CC=C12",
+      "C1=CC=C2C(=C1)N=CC=N2",
+      "C1=CN=CC2C=CC=CC1=2",
+      "C1=CC=C2C(=C1)N=C3C=CC=CC3=N2",
+      "C1=CN=NC2C=CC=CC1=2",
+      # macrocycle aromatics
+      "C1=CC=CC=CC=CC=C1",
+      "C1=CC=CC=CC=CC=CC=CC=CC=CC=C1",
+      "N1=CN=NC=CC=CC=CC=CC=CC=CC=CC=CC=CC=CC=CC=CC=C1"
       )
       for smi in aromatics:
           m = Chem.MolFromSmiles(smi,sanitize=False)


### PR DESCRIPTION
I've extended the list of aromatic and non-aromatic compounds. 

Something to point out, the OpenEye MDL model does not consider furan or thiophene aromatic. Previously these were under the aromatic list, I moved them to the nonaromatic list. 

To organize myself, I made categories for the types of compounds, azulene, is still in the aromatics list, but under the `# polycyclic aromatics` comment. The same is true for `"C1=C[Se]C=C1"` which  is at the bottom of the nonaromatics under the `# 5-membered heterocycles outside the second row` comment. 