### PR TITLE
Fix for filter catalog PRECONDITION redundancy

### DIFF
--- a/Code/GraphMol/FilterCatalog/Filters.cpp
+++ b/Code/GraphMol/FilterCatalog/Filters.cpp
@@ -171,6 +171,7 @@ const unsigned int NUM_BRENK =
     static_cast<unsigned int>(sizeof(BRENK) / sizeof(FilterData_t));
 
 const FilterProperty_t BRENK_PROPS[] = {
+    {"FilterSet", "Brenk"}, 
     {"Reference",
      "Brenk R et al. Lessons Learnt from Assembling Screening Libraries for "
      "Drug Discovery for Neglected Diseases. ChemMedChem 3 (2008) 435-444. "
@@ -632,6 +633,7 @@ const unsigned int NUM_NIH =
     static_cast<unsigned int>(sizeof(NIH) / sizeof(FilterData_t));
 
 const FilterProperty_t NIH_PROPS[] = {
+    {"FilterSet", "NIH"},   
     {"Scope", "annotate compounds with problematic functional groups"},
     {"Reference",
      "Doveston R, et al. A Unified Lead-oriented Synthesis of over Fifty "
@@ -659,6 +661,7 @@ const unsigned int NUM_PAINS_A =
     static_cast<unsigned int>(sizeof(PAINS_A) / sizeof(FilterData_t));
 
 const FilterProperty_t PAINS_A_PROPS[] = {
+    {"FilterSet", "PAINS_A"},   
     {"Reference",
      "Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay "
      "Interference Compounds (PAINS) from Screening Libraries and for Their "
@@ -688,6 +691,7 @@ const unsigned int NUM_PAINS_B =
     static_cast<unsigned int>(sizeof(PAINS_B) / sizeof(FilterData_t));
 
 const FilterProperty_t PAINS_B_PROPS[] = {
+    {"FilterSet", "PAINS_B"}, 
     {"Reference",
      "Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay "
      "Interference Compounds (PAINS) from Screening Libraries and for Their "
@@ -713,6 +717,7 @@ const unsigned int NUM_PAINS_C =
     static_cast<unsigned int>(sizeof(PAINS_C) / sizeof(FilterData_t));
 
 const FilterProperty_t PAINS_C_PROPS[] = {
+    {"FilterSet", "PAINS_C"},   
     {"Reference",
      "Baell JB, Holloway GA. New Substructure Filters for Removal of Pan Assay "
      "Interference Compounds (PAINS) from Screening Libraries and for Their "
@@ -783,6 +788,7 @@ const unsigned int NUM_ZINC =
     static_cast<unsigned int>(sizeof(ZINC) / sizeof(FilterData_t));
 
 const FilterProperty_t ZINC_PROPS[] = {
+    {"FilterSet", "ZINC"}, 
     {"Reference", "http://blaster.docking.org/filtering/"},
     {"Scope", "drug-likeness and unwanted functional group filters"}};
 const unsigned int NUM_ZINC_PROPS =

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -153,6 +153,10 @@ class TestCase(unittest.TestCase):
           # http://chemistrycompass.com/chemsearch/58909/
           mol = Chem.MolFromSmiles("O=C(Cn1cnc2c1c(=O)n(C)c(=O)n2C)N/N=C/c1c(O)ccc2c1cccc2")
           entry = catalog.GetFirstMatch(mol)
+          prop_list = entry.GetPropList()
+          self.assertTrue("Reference" in prop_list)
+          self.assertTrue("Scope" in prop_list)
+          self.assertTrue("FilterSet" in prop_list)
           for key in entry.GetPropList():
             if key == "Reference":
               self.assertEquals(
@@ -163,6 +167,8 @@ class TestCase(unittest.TestCase):
                 "doi:10.1021/jm901137j.")
             elif key == "Scope":
               self.assertEquals(entry.GetProp(key), "PAINS filters (family A)")
+            elif key == "FilterSet":
+              self.assertEquals(entry.GetProp(key), "PAINS_A")
 
           self.assertEqual(entry.GetDescription(), "hzone_phenol_A(479)")
           result = catalog.GetMatches(mol)


### PR DESCRIPTION
Fixes redundancy noted by PVS Studio, additionally uses IndexError and ValueError which are more appropriate than PRECONDITION.