### PR TITLE
Suppress a deprecation warning in pandas >= 2.1.0

### DIFF
--- a/rdkit/Chem/PandasPatcher.py
+++ b/rdkit/Chem/PandasPatcher.py
@@ -88,6 +88,13 @@ except ImportError:
   log.warning("Failed to import pandas")
   raise
 
+dataframe_applymap = pd.DataFrame.applymap
+try:
+  if tuple(map(int, (pd.__version__.split(".")))) >= (2, 1, 0):
+    dataframe_applymap = pd.DataFrame.map
+except:
+  pass
+
 orig_to_html = getattr(to_html_class, "to_html")
 pprint_thing = pandas_formats.printing.pprint_thing
 
@@ -134,7 +141,7 @@ class MolFormatter:
     df_subset = df.select_dtypes("object")
     return {
       col: cls(orig_formatters.get(col, None))
-      for col in df_subset.columns[df_subset.applymap(MolFormatter.is_mol).any()]
+      for col in df_subset.columns[dataframe_applymap(df_subset, MolFormatter.is_mol).any()]
     }
 
   def __call__(self, x):


### PR DESCRIPTION
This suppresses an annoying deprecation warning about `pd.DataFrame.applymap` being deprecated since `pandas 2.1.0` that pops up in Jupyter when a dataframe containing RDKit molecules is visualized:
```python
from rdkit import Chem
from rdkit.Chem import PandasTools
import pandas as pd

df = pd.DataFrame({"mol": [Chem.MolFromSmiles("c1ccccn1")]})
PandasTools.ChangeMoleculeRendering(df)
df
/scratch/toscopa1/.conda/envs/pandas221/lib/python3.10/site-packages/rdkit/Chem/PandasPatcher.py:137:
FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.
  for col in df_subset.columns[df_subset.applymap(MolFormatter.is_mol).any()]
```
![image](https://github.com/greglandrum/rdkit/assets/5244385/0b7e9964-3af8-4b19-81d2-50b95d198c26)
