### PR TITLE
Some changes to the kekulization and additional testing

### DIFF
--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4139,4 +4139,116 @@ TEST_CASE("Try not to set wedged bonds as double in the kekulization") {
     CHECK(m->getBondBetweenAtoms(7, 13)->getBondType() ==
           Bond::BondType::DOUBLE);
   }
+  SECTION("preserve wedged bonds from ctab input") {
+    // consider two equivalent structures, with the same numbering
+    // of atoms and bonds, but different arrangement of single and
+    // double bonds in the aromatic ring that includes a wedged bond.
+    // verify that in both cases the kekulization results in assigning
+    // a single bond order to the wedged bonds.
+    auto mblock1 = R"(
+  Mrv2311 05242408112D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 14 15 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 2.0006 -1.54 0 0
+M  V30 2 N 2.0006 -3.08 0 0
+M  V30 3 C 0.6669 -3.85 0 0
+M  V30 4 C -0.6668 -3.08 0 0
+M  V30 5 C -0.6668 -1.54 0 0
+M  V30 6 C -2.0006 -0.77 0 0
+M  V30 7 C 0.6669 -0.77 0 0
+M  V30 8 C 0.6669 0.77 0 0
+M  V30 9 C -0.6668 1.54 0 0
+M  V30 10 C -2.0006 0.77 0 0
+M  V30 11 C -0.6668 3.08 0 0
+M  V30 12 C 0.6669 3.85 0 0
+M  V30 13 C 2.0006 3.08 0 0
+M  V30 14 C 2.0006 1.54 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 2 1 2
+M  V30 2 1 2 3
+M  V30 3 2 3 4
+M  V30 4 1 4 5
+M  V30 5 1 5 6
+M  V30 6 2 5 7
+M  V30 7 1 7 1 CFG=1
+M  V30 8 1 7 8
+M  V30 9 2 8 9
+M  V30 10 1 9 10
+M  V30 11 1 9 11
+M  V30 12 2 11 12
+M  V30 13 1 12 13
+M  V30 14 2 13 14
+M  V30 15 1 8 14
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)";
+    std::unique_ptr<RWMol> m1(MolBlockToMol(mblock1));
+    REQUIRE(m1);
+    Chirality::reapplyMolBlockWedging(*m1);
+    MolOps::Kekulize(*m1);
+    CHECK(m1->getBondBetweenAtoms(0, 6)->getBondType() ==
+          Bond::BondType::SINGLE);
+    CHECK(m1->getBondBetweenAtoms(0, 6)->getBondDir() ==
+          Bond::BondDir::BEGINWEDGE);
+    CHECK(m1->getBondBetweenAtoms(4, 6)->getBondType() ==
+          Bond::BondType::DOUBLE);
+
+    auto mblock2 = R"(
+  Mrv2311 05242408162D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 14 15 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 2.0006 -1.54 0 0
+M  V30 2 N 2.0006 -3.08 0 0
+M  V30 3 C 0.6669 -3.85 0 0
+M  V30 4 C -0.6668 -3.08 0 0
+M  V30 5 C -0.6668 -1.54 0 0
+M  V30 6 C -2.0006 -0.77 0 0
+M  V30 7 C 0.6669 -0.77 0 0
+M  V30 8 C 0.6669 0.77 0 0
+M  V30 9 C -0.6668 1.54 0 0
+M  V30 10 C -2.0006 0.77 0 0
+M  V30 11 C -0.6668 3.08 0 0
+M  V30 12 C 0.6669 3.85 0 0
+M  V30 13 C 2.0006 3.08 0 0
+M  V30 14 C 2.0006 1.54 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 1 7 5 CFG=3
+M  V30 7 2 7 1
+M  V30 8 1 7 8
+M  V30 9 2 8 9
+M  V30 10 1 9 10
+M  V30 11 1 9 11
+M  V30 12 2 11 12
+M  V30 13 1 12 13
+M  V30 14 2 13 14
+M  V30 15 1 8 14
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)";
+    std::unique_ptr<RWMol> m2(MolBlockToMol(mblock2));
+    REQUIRE(m2);
+    Chirality::reapplyMolBlockWedging(*m2);
+    MolOps::Kekulize(*m2);
+    CHECK(m2->getBondBetweenAtoms(0, 6)->getBondType() ==
+          Bond::BondType::DOUBLE);
+    CHECK(m2->getBondBetweenAtoms(4, 6)->getBondType() ==
+          Bond::BondType::SINGLE);
+    CHECK(m2->getBondBetweenAtoms(4, 6)->getBondDir() ==
+          Bond::BondDir::BEGINDASH);
+  }
 }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
For now I added only one test case, not very different from the one you already added, but implemented more similarly to the code I'm using.

My test was failing at first, and when I started exploring some changes and it passed, your test broke. I eventually modified how the traversal depends from the occurrence of wedged bonds, so that both tests should now pass (and the kekulization of structures that do not include any wedged bonds should still produce the same output).

I hope the changes to the algorithm make sense (I'll add some annotations to the diff in this PR), but in any case please feel free to also just look at them as part of the discussion in case you'd like to implement things differently.