### PR TITLE
A few suggestions

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -273,7 +273,7 @@ unsigned int Atom::getDegree() const {
   if (!dp_mol) {
     return 0;
   }
-  return getOwningMol().getAtomDegree(this);
+  return dp_mol->getAtomDegree(this);
 }
 
 unsigned int Atom::getTotalDegree() const {
@@ -288,11 +288,10 @@ unsigned int Atom::getTotalDegree() const {
 unsigned int Atom::getTotalNumHs(bool includeNeighbors) const {
   int res = getNumExplicitHs() + getNumImplicitHs();
   if (includeNeighbors && dp_mol) {
-    for (auto nbr : getOwningMol().atomNeighbors(this)) {
-      if (nbr->getAtomicNum() == 1) {
-        ++res;
-      }
-    }
+    auto nbrs = dp_mol->atomNeighbors(this);
+    res += std::count_if(nbrs.begin(), nbrs.end(), [](const auto nbr) {
+      return (nbr->getAtomicNum() == 1);
+    });
   }
   return res;
 }
@@ -317,9 +316,9 @@ unsigned int Atom::getValence(bool getExplicit) const {
     return 0;
   }
   PRECONDITION((!getExplicit || d_explicitValence > -1),
-               "getValence() called without call to calcExplicitValence()");
+               "getValence(true) called without call to calcExplicitValence()");
   PRECONDITION((getExplicit || df_noImplicit || d_implicitValence > -1),
-               "getValence() called without call to calcImplicitValence()");
+               "getValence(false) called without call to calcImplicitValence()");
   if (getExplicit) {
     return d_explicitValence;
   } else {

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -182,7 +182,7 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   unsigned int getNumImplicitHs() const;
 
   //! returns the valence (explicit or implicit) of this atom
-  unsigned int getValence(bool getExplicit = true) const;
+  unsigned int getValence(bool getExplicit) const;
 
   //! returns the explicit valence (including Hs) of this atom
   [[deprecated("please use getValence(true)")]]

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -141,7 +141,7 @@ AtomPDBResidueInfo *AtomGetPDBResidueInfo(Atom *atom) {
 
 namespace {
 int getExplicitValenceHelper(const Atom *atom) {
-  RDLog::deprecationWarning("please use GetValence()");
+  RDLog::deprecationWarning("please use GetValence(getExplicit=True)");
   return atom->getValence(true);
 };
 int getImplicitValenceHelper(const Atom *atom) {
@@ -223,7 +223,7 @@ struct atom_wrapper {
             python::args("self"),
             "DEPRECATED, please use GetValence(False) instead.\nReturns the number of implicit Hs on the atom.\n")
         .def("GetValence", &Atom::getValence,
-             (python::args("self"), python::args("getExplicit") = true),
+             (python::args("self"), python::args("getExplicit")),
              "Returns the valence (explicit or implicit) of the atom.\n")
         .def("GetTotalValence", &Atom::getTotalValence, python::args("self"),
              "Returns the total valence (explicit + implicit) of the atom.\n\n")

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -272,6 +272,8 @@ class TestCase(unittest.TestCase):
     self.assertTrue([x.GetNumImplicitHs() for x in aList] == [0, 1, 2, 0])
     self.assertTrue([x.GetValence(getExplicit=True) for x in aList] == [3, 3, 2, 3])
     self.assertTrue([x.GetValence(getExplicit=False) for x in aList] == [0, 1, 2, 0])
+    self.assertTrue([x.GetValence(True) for x in aList] == [3, 3, 2, 3])
+    self.assertTrue([x.GetValence(False) for x in aList] == [0, 1, 2, 0])
     self.assertTrue([x.GetFormalCharge() for x in aList] == [0, 0, 0, -1])
     self.assertTrue([x.GetNoImplicit() for x in aList] == [0, 0, 0, 1])
     self.assertTrue([x.GetNumExplicitHs() for x in aList] == [0, 0, 0, 2])


### PR DESCRIPTION
A few suggestions:

- Replace `getOwningMol()` with `dp_mol` after checking non-nullness (you replaced getters with the private data member yourself elsewhere in this PR(
- Replace `for` loop with `std::count_if`
- Remove default parameter from `getValence()` (C++, Python) as I do not think there is an obvious reason why `getExplicit` should default to `true` (and indeed you never took advantage of the default value anywhere in your PR)
