### PR TITLE
MIF code cleanup

### DIFF
--- a/Code/DataStructs/RealValueVect.cpp
+++ b/Code/DataStructs/RealValueVect.cpp
@@ -88,7 +88,7 @@ void RealValueVect::initFromText(const char *pkl, const unsigned int len) {
   ss.write(pkl, len);
   boost::int32_t tVers;
   streamRead(ss, tVers);
-  tVers = -tVers;
+  tVers *= -1;
   if (!(tVers == 0x1)) {
     throw ValueErrorException("bad version in RealValueVect pickle");
   }

--- a/Code/DataStructs/RealValueVect.h
+++ b/Code/DataStructs/RealValueVect.h
@@ -67,29 +67,16 @@ class RDKIT_DATASTRUCTS_EXPORT RealValueVect {
   //! compares 2 vectors and returns false if different
   bool compareVectors(const RealValueVect &other);
 
-  //! support rvv3 = rvv1&rvv2
-  /*!
-     operator& returns the minimum value for each element.
-     e.g.:
-       [0,1,2,0] & [0,1,1,1] -> [0,1,1,0]
+  //! in-place operator&
+  RealValueVect &operator&=(const RealValueVect &other);
 
-   */
-  RealValueVect operator&(const RealValueVect &other) const;
+  //! in-place operator|
+  RealValueVect &operator|=(const RealValueVect &other);
 
-  //! support rvv3 = rvv1|rvv2
-  /*!
-
-     operator| returns the maximum value for each element.
-     e.g.:
-       [0,1,2,0] | [0,1,1,1] -> [0,1,2,1]
-
-   */
-  RealValueVect operator|(const RealValueVect &other) const;
-
-  //! sums up vectors
+  //! in-place operator+
   RealValueVect &operator+=(const RealValueVect &other);
 
-  //! subtracts vectors
+  //! in-place operator-
   RealValueVect &operator-=(const RealValueVect &other);
 
   //! returns a binary string representation (pickle)
@@ -103,6 +90,8 @@ class RDKIT_DATASTRUCTS_EXPORT RealValueVect {
   std::vector<double> d_data;
 
   void initFromText(const char *pkl, const unsigned int len);
+  template <typename O>
+  RealValueVect &applyBinaryOp(const RealValueVect &other, O op);
 };  // end of declaration of class RealValueVect
 
 //! returns L1 Norm of vectors
@@ -115,6 +104,27 @@ RDKIT_DATASTRUCTS_EXPORT RealValueVect operator+(const RealValueVect &p1,
 
 //! returns the difference of vectors
 RDKIT_DATASTRUCTS_EXPORT RealValueVect operator-(const RealValueVect &p1,
+                                                 const RealValueVect &p2);
+
+//! support rvv3 = rvv1|rvv2
+/*!
+
+   operator| returns the maximum value for each element.
+   e.g.:
+     [0,1,2,0] | [0,1,1,1] -> [0,1,2,1]
+
+ */
+RDKIT_DATASTRUCTS_EXPORT RealValueVect operator|(const RealValueVect &p1,
+                                                 const RealValueVect &p2);
+
+//! support rvv3 = rvv1&rvv2
+/*!
+   operator& returns the minimum value for each element.
+   e.g.:
+     [0,1,2,0] & [0,1,1,1] -> [0,1,1,0]
+
+ */
+RDKIT_DATASTRUCTS_EXPORT RealValueVect operator&(const RealValueVect &p1,
                                                  const RealValueVect &p2);
 
 }  // end of namespace RDKit

--- a/Code/Geometry/Grid3D.h
+++ b/Code/Geometry/Grid3D.h
@@ -38,7 +38,7 @@ class RDKIT_RDGEOMETRYLIB_EXPORT GridException : public std::exception {
 template <typename VectorType, typename ValueType1, typename ValueType2>
 class RDKIT_RDGEOMETRYLIB_EXPORT Grid3D {
  public:
-  virtual ~Grid3D() {};
+  virtual ~Grid3D(){};
   virtual int getGridPointIndex(const Point3D &point) const = 0;
   virtual ValueType1 getVal(const Point3D &point) const = 0;
   virtual void setVal(const Point3D &point, ValueType2 val) = 0;

--- a/Code/Geometry/UniformRealValueGrid3D.cpp
+++ b/Code/Geometry/UniformRealValueGrid3D.cpp
@@ -288,9 +288,8 @@ void UniformRealValueGrid3D::initFromText(const char *pkl,
   ss.write(pkl, length);
   boost::int32_t tVers;
   streamRead(ss, tVers);
-  tVers = -tVers;
-  if (tVers == 0x1) {
-  } else {
+  tVers *= -1;
+  if (!(tVers == 0x1)) {
     throw ValueErrorException("bad version in UniformRealValueGrid3D pickle");
   }
   boost::uint32_t tInt;

--- a/Code/Geometry/Wrap/testGeometry.py
+++ b/Code/Geometry/Wrap/testGeometry.py
@@ -686,6 +686,7 @@ class TestCase(unittest.TestCase):
     grd1.SetVal(50, 37.37)
     grd2.SetVal(50, 1.03)
     grd3 = copy.deepcopy(grd2)
+    grd4 = geom.UniformRealValueGrid3D(grd2)
 
     grd1 |= grd2
     self.assertTrue(feq(grd1.GetVal(50), 37.37))
@@ -702,6 +703,14 @@ class TestCase(unittest.TestCase):
     grd3 &= grd1
     self.assertTrue(feq(grd1.GetVal(50), 37.37))
     self.assertTrue(feq(grd3.GetVal(50), 1.03))
+
+    grd2 &= grd4
+    self.assertTrue(feq(grd2.GetVal(50), 1.03))
+    self.assertTrue(feq(grd4.GetVal(50), 1.03))
+
+    grd4 &= grd1
+    self.assertTrue(feq(grd1.GetVal(50), 37.37))
+    self.assertTrue(feq(grd4.GetVal(50), 1.03))
 
     grd1 += grd2
     self.assertTrue(feq(grd1.GetVal(50), 38.40))

--- a/Code/GraphMol/MolInteractionFields/MIFDescriptors.h
+++ b/Code/GraphMol/MolInteractionFields/MIFDescriptors.h
@@ -32,9 +32,9 @@ namespace RDMIF {
 //! \brief constructs a UniformRealValueGrid3D which fits to the molecule mol
 /*!
  \returns a pointer to a UniformRealValueGrid which has a spacing of \c spacing
- (default = 0.5 Angstrom) and a spatial extent of conformer \c confId
- (default=-1) of molecule \c mol plus a defined margin \c margin on each side
- (default = 5.0 Angstrom).
+ (default: 0.5 Angstrom) and a spatial extent of conformer \c confId
+ (default: -1) of molecule \c mol plus a defined margin \c margin on each side
+ (default: 5.0 Angstrom).
 
  \param mol		Molecule for which the grid is constructed
  \param confId		Id of Conformer which is used
@@ -64,9 +64,12 @@ template <typename T>
 void calculateDescriptors(RDGeom::UniformRealValueGrid3D &grd, T functor,
                           double thres = -1.0) {
   const RDGeom::Point3D &offSet = grd.getOffset();
-  double oX = offSet.x, oY = offSet.y, z = offSet.z;
-  double x = oX, y = oY;
-  double spacing = grd.getSpacing();
+  auto x = offSet.x;
+  auto y = offSet.y;
+  auto z = offSet.z;
+  auto oX = x;
+  auto oY = y;
+  auto spacing = grd.getSpacing();
   if (thres < 0) {
     thres = spacing * grd.getSize();
   }
@@ -75,9 +78,9 @@ void calculateDescriptors(RDGeom::UniformRealValueGrid3D &grd, T functor,
   unsigned int id = 0;
   auto &data = grd.getData();
 
-  for (unsigned int idZ = 0; idZ < grd.getNumZ(); idZ++) {
-    for (unsigned int idY = 0; idY < grd.getNumY(); idY++) {
-      for (unsigned int idX = 0; idX < grd.getNumX(); idX++) {
+  for (unsigned int idZ = 0; idZ < grd.getNumZ(); ++idZ) {
+    for (unsigned int idY = 0; idY < grd.getNumY(); ++idY) {
+      for (unsigned int idX = 0; idX < grd.getNumX(); ++idX) {
         data[id++] = functor(x, y, z, thres);
         x += spacing;
       }
@@ -89,33 +92,20 @@ void calculateDescriptors(RDGeom::UniformRealValueGrid3D &grd, T functor,
   }
 }
 
-//! \brief class for calculation of distance to closest atom of \c mol from grid
-//! point \c pt
-class RDKIT_MOLINTERACTIONFIELDS_EXPORT DistanceToClosestAtom {
- public:
-  //! construct a distanceToClosestAtom from a ROMol
-  DistanceToClosestAtom(const RDKit::ROMol &mol, int confId = -1);
-
-  //! Calculates the closest distance, \returns distance in Angstrom
-  double operator()(double x, double y, double z, double thres);
-
- private:
-  unsigned int d_nAtoms;
-  std::vector<double> d_pos;
-};
-
 //! \brief class for calculation of electrostatic interaction (Coulomb energy)
-//! between probe and molecule in vaccuum (no dielectric)
+//! between probe and molecule in vacuum (no dielectric)
 /*
  d_nAtoms     No of atoms in molecule
  d_softcore   true if softcore interaction is used, else minimum cutoff distance
- is used d_probe      charge of probe [e] d_absVal     if true, absolute values
- of interactions are calculated d_alpha      softcore interaction parameter
- [A^2] d_cutoff     squared minimum cutoff distance [A^2] d_charges    vector of
- doubles with all partial charges of the atoms in a molecule [e] d_pos vector of
- Point3Ds with all positions of the atoms in a molecule [A] d_prefactor
- prefactor taking into account the geometric factors,natural constants and
- conversion of units
+ is used
+ d_probe      charge of probe [e]
+ d_absVal     if true, absolute values of interactions are calculated
+ d_alpha      softcore interaction parameter [A^2]
+ d_cutoff     squared minimum cutoff distance [A^2]
+ d_charges    vector of doubles with all partial charges of the atoms in a
+ molecule [e] d_pos        vector of doubles with all positions of the atoms in
+ a molecule [A] d_prefactor  prefactor taking into account the geometric
+ factors,natural constants and conversion of units
  */
 class RDKIT_MOLINTERACTIONFIELDS_EXPORT Coulomb {
  public:
@@ -126,18 +116,17 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT Coulomb {
   /*!
    \param charges     vector of charges [e]
    \param pos         vector of postions [A]
-   \param probecharge charge of probe [e] (default: 1.0)
+   \param probeCharge charge of probe [e] (default: 1.0)
    \param absVal      if true, negative (favored) values of interactions are
    calculated (default: false)
-   \param alpha       softcore interaction parameter
-   [A^2], if zero, a minimum cutoff distance is used (default=0.0)
-   \param cutoff
-   minimum cutoff distance [A] (default:1.0)
+   \param alpha       softcore interaction parameter [A^2]; if zero,
+   a minimum cutoff distance is used (default: 0.0)
+   \param cutoff      minimum cutoff distance [A] (default: 1.0)
 
    */
   Coulomb(const std::vector<double> &charges,
           const std::vector<RDGeom::Point3D> &positions,
-          double probecharge = 1.0, bool absVal = false, double alpha = 0.0,
+          double probeCharge = 1.0, bool absVal = false, double alpha = 0.0,
           double cutoff = 1.0);
 
   //! \brief constructs Coulomb object from a molecule object
@@ -149,16 +138,15 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT Coulomb {
    (default=-1)
    \param absVal      if true, absolute values of interactions are
    calculated (default: false)
-   \param probecharge charge of probe [e]
-   (default: 1.0)
+   \param probeCharge charge of probe [e] (default: 1.0)
    \param prop	     property key for retrieving partial charges
-   of atoms (default="_GasteigerCharge")
+   of atoms (default: "_GasteigerCharge")
    \param alpha       softcore interaction parameter [A^2], if zero, a minimum
-   cutoff distance is used (default=0.0)
-   \param cutoff      minimum cutoff distance [A] (default:1.0)
+   cutoff distance is used (default: 0.0)
+   \param cutoff      minimum cutoff distance [A] (default: 1.0)
 
    */
-  Coulomb(const RDKit::ROMol &mol, int confId = -1, double probecharge = 1.0,
+  Coulomb(const RDKit::ROMol &mol, int confId = -1, double probeCharge = 1.0,
           bool absVal = false, const std::string &prop = "_GasteigerCharge",
           double alpha = 0.0, double cutoff = 1.0);
 
@@ -196,16 +184,21 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT Coulomb {
  member variables:
  d_nAtoms:     No of atoms in molecule
  d_softcore:   true if softcore interaction is used, else minimum cutoff
- distance is used d_dielectric: factor of dielectric constants d_probe: charge
- of probe [e] d_absVal:     if true, negative (favored) values of interactions
- are calculated (default: false) d_epsilon:    relative permittivity of solvent
+ distance is used
+ d_dielectric: factor of dielectric constants
+ d_probe:      charge of probe [e]
+ d_absVal:     if true, negative (favored) values of interactions
+ are calculated (default: false)
+ d_epsilon:    relative permittivity of solvent
  d_xi:         relative permittivity of solute
  d_alpha:      softcore interaction parameter [A^2]
  d_cutoff:     squared minimum cutoff distance [A^2]
- d_charges:    vector of doubles with all partial charges of the atoms in a
- molecule [e] d_pos:        vector of Point3Ds with all positions of the atoms
- in a molecule [A] d_prefactor:  prefactor taking into account the geometric
- factors,natural constants and conversion of units
+ d_charges:    vector of doubles with all partial charges of the atoms
+ in a molecule [e]
+ d_pos:        vector of Point3Ds with all positions of the atoms
+ in a molecule [A]
+ d_prefactor:  prefactor taking into account the geometric factors,
+ natural constants and conversion of units
  */
 class RDKIT_MOLINTERACTIONFIELDS_EXPORT CoulombDielectric {
  public:
@@ -226,19 +219,19 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT CoulombDielectric {
   /*!
    \param charges     vector of charges [e]
    \param pos         vector of postions [A]
-   \param probecharge charge of probe [e] (default: 1.0)
+   \param probeCharge charge of probe [e] (default: 1.0)
    \param absVal      if true, negative (favored) values of interactions are
    calculated (default: false)
-   \param alpha     softcore interaction parameter
-   [A^2], if zero, a minimum cutoff distance is used (default=0.0)
-   \param cutoff    minimum cutoff distance [A] (default:1.0)
-   \param epsilon   relative permittivity of solvent (default=80.0)
-   \param xi        relative  permittivity of solute (default=4.0)
+   \param alpha       softcore interaction parameter [A^2]; if zero,
+   a minimum cutoff distance is used (default: 0.0)
+   \param cutoff      minimum cutoff distance [A] (default: 1.0)
+   \param epsilon     relative permittivity of solvent (default: 80.0)
+   \param xi          relative permittivity of solute (default: 4.0)
 
    */
   CoulombDielectric(const std::vector<double> &charges,
                     const std::vector<RDGeom::Point3D> &positions,
-                    double probecharge = 1.0, bool absVal = false,
+                    double probeCharge = 1.0, bool absVal = false,
                     double alpha = 0.0, double cutoff = 1.0,
                     double epsilon = 80.0, double xi = 4.0);
 
@@ -249,19 +242,19 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT CoulombDielectric {
    \param mol         molecule object
    \param confId      conformation id which is used to get positions of atoms
    (default=-1)
-   \param probecharge charge of probe [e] (default: 1.0)
+   \param probeCharge charge of probe [e] (default: 1.0)
    \param absVal      if true, negative (favored) values of interactions are
    calculated (default: false)
    \param prop	       property key for retrieving partial charges of atoms
-   (default="_GasteigerCharge")
+   (default: "_GasteigerCharge")
    \param alpha       softcore interaction parameter [A^2], if zero, a minimum
-   cutoff distance is used (default=0.0)
-   \param cutoff      minimum cutoff distance [A] (default:1.0)
-   \param epsilon     relative permittivity of solvent (default=80.0)
-   \param xi          relative permittivity of solute (default=4.0)
+   cutoff distance is used (default: 0.0)
+   \param cutoff      minimum cutoff distance [A] (default: 1.0)
+   \param epsilon     relative permittivity of solvent (default: 80.0)
+   \param xi          relative permittivity of solute (default: 4.0)
    */
   CoulombDielectric(const RDKit::ROMol &mol, int confId = -1,
-                    double probecharge = 1.0, bool absVal = false,
+                    double probeCharge = 1.0, bool absVal = false,
                     const std::string &prop = "_GasteigerCharge",
                     double alpha = 0.0, double cutoff = 1.0,
                     double epsilon = 80.0, double xi = 4.0);
@@ -287,24 +280,25 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT CoulombDielectric {
   std::vector<double> d_dists;
 };
 
-//! \brief class for calculation of Van der Waals interaction between probe and
-//! molecule at gridpoint \c pt
+//! \brief Abstract class for calculation of Van der Waals interaction between
+//! probe and molecule at gridpoint \c pt
 /*
- Either the MMFF94 or the UFF VdW term can be calculated with a defined probe
- atom and molecule. d_cutoff:     minimum cutoff distance [A] d_nAtoms:     No
- of atoms in molecule d_R_star_ij   vector of Lennard Jones parameters for every
- interaction (vdW-radii) d_wellDepth   vector of Lennard Jones parameters for
- every interaction (well depths) d_pos	        vector of positions of atoms in
- molecule
+ * Either the MMFF94 or the UFF VdW term can be calculated with a defined probe
+ * atom and molecule.
+ * d_cutoff: minimum cutoff distance [A]
+ * d_nAtoms: No of atoms in molecule
+ * d_R_star_ij: vector of Lennard Jones parameters for every
+ * interaction (vdW-radii)
+ * d_wellDepth: vector of Lennard Jones parameters for
+ * every interaction (well depths)
+ * d_pos: vector of positions of atoms in  molecule
  */
 class RDKIT_MOLINTERACTIONFIELDS_EXPORT VdWaals {
  public:
-  VdWaals() : d_cutoff(1), d_nAtoms(0), d_getEnergy(nullptr) {};
-  VdWaals(RDKit::ROMol &mol, int confId, unsigned int probeAtomTypeMMFF,
-          const std::string &probeAtomTypeUFF, const std::string &FF,
-          bool scaling, double cutoff);
-  ~VdWaals() {};
-
+  VdWaals() : d_cutoff(1.0), d_nAtoms(0){};
+  VdWaals(const RDKit::ROMol &mol, int confId = -1, double cutoff = 1.0);
+  VdWaals(const VdWaals &other);
+  virtual ~VdWaals(){};
   //! \brief returns the VdW interaction at point \c pt in the molecules field
   //! in [kJ mol^-1]
   /*!
@@ -315,51 +309,67 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT VdWaals {
    */
   double operator()(double x, double y, double z, double thres);
 
- private:
+ protected:
+  void fillVectors();
+  virtual double calcEnergy(double, double, double) const = 0;
+  virtual void fillVdwParamVectors(unsigned int atomIdx) = 0;
   double d_cutoff;
   unsigned int d_nAtoms;
-  std::vector<double> d_R_star_ij, d_wellDepth;
   std::vector<double> d_pos;
-
-  double (*d_getEnergy)(double, double,
-                        double);  // pointer to energy function (MMFF94 or UFF)
-  static double d_calcUFFEnergy(double, double, double);  // UFF energy function
-  static double d_calcMMFFEnergy(double, double,
-                                 double);  // MMFF energy function
+  std::vector<double> d_R_star_ij;
+  std::vector<double> d_wellDepth;
+  std::unique_ptr<RDKit::ROMol> d_mol;
 };
 
-// Factory functions for VdWaals
+class RDKIT_MOLINTERACTIONFIELDS_EXPORT MMFFVdWaals : public VdWaals {
+ public:
+  //! \brief constructs VdWaals object which uses MMFF94 from a molecule object
+  /*!
+  \param mol           molecule object
+  \param confId        conformation id which is used to get positions of atoms
+  (default: -1)
+  \param probeAtomType MMFF94 atom type for the probe atom
+  (default: 6, sp3 oxygen)
+  \param cutoff        minimum cutoff distance [A] (default: 1.0)
+  \param scaling       scaling of VdW parameters to take hydrogen bonds into
+  account (default: false)
+  */
+  MMFFVdWaals(const RDKit::ROMol &mol, int confId = -1,
+              unsigned int probeAtomType = 6, bool scaling = false,
+              double cutoff = 1.0);
+  MMFFVdWaals(const MMFFVdWaals &other);
 
-//! \brief constructs VdWaals object which uses MMFF94 from a molecule object
-/*!
- The molecule \c mol needs to have partial charges set as property of atoms.
- \param mol           molecule object
- \param confId        conformation id which is used to get positions of atoms
- (default=-1)
- \param probeAtomType MMFF94 atom type for the probe atom
- (default=6, sp3 oxygen)
- \param scaling       scaling of VdW parameters to take hydrogen bonds into
- account (default=false)
- \param cutoff        minimum cutoff distance [A] (default:1.0)
- */
-RDKIT_MOLINTERACTIONFIELDS_EXPORT VdWaals constructVdWaalsMMFF(
-    RDKit::ROMol &mol, int confId = -1, unsigned int probeAtomType = 6,
-    bool scaling = false, double cutoff = 1.0);
+ private:
+  double calcEnergy(double, double, double) const;  // MMFF energy function
+  void fillVdwParamVectors(unsigned int atomIdx);
+  bool d_scaling;
+  std::unique_ptr<RDKit::MMFF::MMFFMolProperties> d_props;
+  const ForceFields::MMFF::MMFFVdWCollection *d_mmffVdW;
+  const ForceFields::MMFF::MMFFVdW *d_probeParams;
+};
 
-//! \brief constructs VdWaals object which uses UFF from a molecule object
-/*!
- The molecule \c mol needs to have partial charges set as property of atoms.
- \param mol           molecule object
- \param confId        conformation id which is used to get positions of atoms
- (default=-1)
- \param probeAtomType UFF atom type for the probe atom (eg. "O_3", i.e. a
- tetrahedral oxygen)
- \param cutoff        minimum cutoff distance [A] (default:1.0)
- */
-RDKIT_MOLINTERACTIONFIELDS_EXPORT VdWaals
-constructVdWaalsUFF(RDKit::ROMol &mol, int confId = -1,
-                    const std::string &probeAtomType = "O_3",
-                    double cutoff = 1.0);  // constructor for UFF LJ interaction
+class RDKIT_MOLINTERACTIONFIELDS_EXPORT UFFVdWaals : public VdWaals {
+ public:
+  //! \brief constructs VdWaals object which uses UFF from a molecule object
+  /*!
+  \param mol           molecule object
+  \param confId        conformation id which is used to get positions of atoms
+  (default: -1)
+  \param probeAtomType UFF atom type for the probe atom (e.g. "O_3", i.e. a
+  tetrahedral oxygen)
+  \param cutoff        minimum cutoff distance [A] (default: 1.0)
+  */
+  UFFVdWaals(const RDKit::ROMol &mol, int confId = -1,
+             const std::string &probeAtomType = "O_3", double cutoff = 1.0);
+  UFFVdWaals(const UFFVdWaals &other);
+
+ private:
+  double calcEnergy(double, double, double) const;  // UFF energy function
+  void fillVdwParamVectors(unsigned int atomIdx);
+  const ForceFields::UFF::ParamCollection *d_uffParamColl;
+  const ForceFields::UFF::AtomicParams *d_probeParams;
+  RDKit::UFF::AtomicParamVect d_params;
+};
 
 //! \brief class for calculation of hydrogen bond potential between probe and
 //! molecule
@@ -378,12 +388,12 @@ constructVdWaalsUFF(RDKit::ROMol &mol, int confId = -1,
  d_pos:          vector of positions of target atoms in molecule
  d_direction:    if target accepting, vector of directions of lone pairs on
  target atoms (if there are two lone pairs, the resulting direction is used) if
- target donating, the X-H bond direction is saved d_plane:        vector of
- plane vectors in which the lone pairs are
+ target donating, the X-H bond direction is saved
+ d_plane:        vector of plane vectors in which the lone pairs are
  */
 class RDKIT_MOLINTERACTIONFIELDS_EXPORT HBond {
  public:
-  HBond() : d_cutoff(1.0), d_probetype(O), d_nInteract(0) {};
+  HBond() : d_cutoff(1.0), d_probetype(O), d_nInteract(0){};
 
   //! \brief constructs HBond object from a molecule object
   /*!
@@ -391,20 +401,18 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT HBond {
    \param mol           molecule object
    \param confId        conformation id which is used to get positions of atoms
    (default=-1)
-   \param probeType     atom type for the probe atom (either, "OH",
-   "O", "NH" or "N")
+   \param probeAtomType atom type for the probe atom ("OH", "O", "NH", "N")
    \param fixed         for some groups, two different angle
    dependencies are defined in GRID: one which takes some flexibility of groups
    (rotation/swapping of lone pairs and hydrogen) into account and one for
    strictly fixed conformations if true, strictly fixed conformations
-   (default=fixed)
-   \param cutoff        minimum cutoff distance [A]
-   (default:1.0)
+   (default: fixed)
+   \param cutoff        minimum cutoff distance [A] (default: 1.0)
    */
   HBond(const RDKit::ROMol &mol, int confId = -1,
-        const std::string &probeType = "OH", bool fixed = true,
+        const std::string &probeAtomType = "OH", bool fixed = true,
         double cutoff = 1.0);
-  ~HBond() {};
+  ~HBond(){};
 
   //! \brief returns the hydrogen bonding interaction at point \c pt in the
   //! molecules field in [kJ mol^-1]
@@ -444,10 +452,10 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT HBond {
                              const std::vector<unsigned int> &specials);
   unsigned int findDonors(const RDKit::ROMol &mol, int confId,
                           const std::vector<unsigned int> &specials);
-  unsigned int findAcceptors_unfixed(const RDKit::ROMol &mol, int confId,
-                                     const std::vector<unsigned int> &specials);
-  unsigned int findDonors_unfixed(const RDKit::ROMol &mol, int confId,
-                                  const std::vector<unsigned int> &specials);
+  unsigned int findAcceptorsUnfixed(const RDKit::ROMol &mol, int confId,
+                                    const std::vector<unsigned int> &specials);
+  unsigned int findDonorsUnfixed(const RDKit::ROMol &mol, int confId,
+                                 const std::vector<unsigned int> &specials);
 
   void addVectElements(atomtype type, double (*funct)(double, double, double),
                        const RDGeom::Point3D &pos, const RDGeom::Point3D &dir,
@@ -476,17 +484,17 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT Hydrophilic {
    params:
    \param mol           		 molecule object
    \param confId        		 conformation id which is used to get
-   positions of atoms (default=-1)
+   positions of atoms (default: -1)
    \param fixed         		 for some groups, two different angle
    dependencies are defined in GRID: one which takes some flexibility of groups
    (rotation/swapping of lone pairs and hydrogen) into account and one for
    strictly fixed conformations if true, strictly fixed conformations
-   (default=fixed)
-   \param cutoff  minimum cutoff distance [A] (default:1.0)
+   (default: fixed)
+   \param cutoff  minimum cutoff distance [A] (default: 1.0)
    */
   Hydrophilic(const RDKit::ROMol &mol, int confId = -1, bool fixed = true,
               double cutoff = 1.0);
-  ~Hydrophilic() {};
+  ~Hydrophilic(){};
 
   double operator()(double x, double y, double z, double thres);
 
@@ -495,37 +503,39 @@ class RDKIT_MOLINTERACTIONFIELDS_EXPORT Hydrophilic {
 };
 
 //! \brief writes the contents of the MIF to a stream
-/*
+/*!
  The Grid \c grd is written in Gaussian Cube format
- A molecule \c mol has to be specified
+ A molecule \c mol and a \c confId can optionally be provided
  */
 RDKIT_MOLINTERACTIONFIELDS_EXPORT void writeToCubeStream(
-    const RDGeom::UniformRealValueGrid3D &grd, const RDKit::ROMol &mol,
-    std::ostream &outStrm, int confid = -1);
+    const RDGeom::UniformRealValueGrid3D &grd, std::ostream &outStrm,
+    const RDKit::ROMol *mol = nullptr, int confid = -1);
 
 //! \brief writes the contents of the MIF to a file
-/*
+/*!
  The Grid \c grd is written in Gaussian Cube format
- A molecule \c mol has to be specified
+ A molecule \c mol and a \c confId can optionally be provided
  */
 RDKIT_MOLINTERACTIONFIELDS_EXPORT void writeToCubeFile(
-    const RDGeom::UniformRealValueGrid3D &grd, const RDKit::ROMol &mol,
-    const std::string &filename, int confid = -1);
+    const RDGeom::UniformRealValueGrid3D &grd, const std::string &filename,
+    const RDKit::ROMol *mol = nullptr, int confid = -1);
 
 //! \brief reads the contents of the MIF from a stream in Gaussian cube format
-/*
+/*!
  The Grid \c grd is modified according to input values
- A pointer to a molecule is returned with all atoms and its positions but NO
- bond information!
+ If a molecule was associated to the grid on write, a non-null pointer to a
+ molecule is returned with atoms and a conformer, but NO bond information.
+ If there is no atom information in the cube file, a null pointer is returned.
  */
 RDKIT_MOLINTERACTIONFIELDS_EXPORT std::unique_ptr<RDKit::RWMol>
 readFromCubeStream(RDGeom::UniformRealValueGrid3D &grd, std::istream &inStrm);
 
 //! \brief reads the contents of the MIF from a file in Gaussian cube format
-/*
+/*!
  The Grid \c grd is modified according to input values
- A pointer to a molecule is returned with all atoms and its positions but NO
- bond information!
+ If a molecule was associated to the grid on write, a non-null pointer to a
+ molecule is returned with atoms and a conformer, but NO bond information.
+ If there is no atom information in the cube file, a null pointer is returned.
  */
 RDKIT_MOLINTERACTIONFIELDS_EXPORT std::unique_ptr<RDKit::RWMol>
 readFromCubeFile(RDGeom::UniformRealValueGrid3D &grd,

--- a/Code/GraphMol/MolInteractionFields/Wrap/rdMIF.cpp
+++ b/Code/GraphMol/MolInteractionFields/Wrap/rdMIF.cpp
@@ -93,12 +93,15 @@ CoulombDielectric *makeAltCoulombDielectric(const python::object &charges,
 }
 
 python::tuple readCubeFile(const std::string &filename) {
-  RDGeom::UniformRealValueGrid3D grd;
-  auto res = readFromCubeFile(grd, filename);
-  boost::python::manage_new_object::apply<RDKit::ROMol *>::type converter;
-  return python::make_tuple(
-      grd,
-      python::handle<>(converter(static_cast<RDKit::ROMol *>(res.release()))));
+  std::unique_ptr<RDGeom::UniformRealValueGrid3D> grd(
+      new RDGeom::UniformRealValueGrid3D());
+  auto res = readFromCubeFile(*grd, filename);
+  boost::python::manage_new_object::apply<
+      RDGeom::UniformRealValueGrid3D *>::type grdConverter;
+  boost::python::manage_new_object::apply<RDKit::ROMol *>::type molConverter;
+  return python::make_tuple(python::handle<>(grdConverter(grd.release())),
+                            python::handle<>(molConverter(
+                                static_cast<RDKit::ROMol *>(res.release()))));
 }
 
 struct mif_wrapper {

--- a/Code/GraphMol/MolInteractionFields/Wrap/rdMIF.cpp
+++ b/Code/GraphMol/MolInteractionFields/Wrap/rdMIF.cpp
@@ -44,154 +44,95 @@ RDGeom::UniformRealValueGrid3D *constructGridHelper(const RDKit::ROMol &mol,
   return constructGrid(mol, confId, margin, spacing).release();
 }
 
-Coulomb *make_coulomb(const python::object &charges,
-                      const python::object &positions, double probecharge,
-                      bool absVal, double alpha, double cutoff) {
-  PyObject *pyObj = positions.ptr();
-  std::vector<RDGeom::Point3D> pos;
-  std::vector<double> ch;
-  unsigned int nrows;
-  if (PySequence_Check(pyObj)) {
-    nrows = PySequence_Size(pyObj);
-    if (nrows <= 0) {
-      throw_value_error("Empty sequence passed in");
-    }
-    python::extract<RDGeom::Point3D> ptOk(positions[0]);
-    if (!ptOk.check()) {
-      for (unsigned int i = 0; i < nrows; i++) {
-        PySequenceHolder<double> row(positions[i]);
-        if (row.size() != 3) {
-          throw_value_error("Wrong number of entries in the list of lists");
-        }
-        RDGeom::Point3D pt(row[0], row[1], row[2]);
-        pos.push_back(pt);
-        ch.push_back(python::extract<double>(charges[i]));
-      }
-    } else {
-      for (unsigned int i = 0; i < nrows; i++) {
-        python::extract<RDGeom::Point3D> pt(positions[i]);
-        ch.push_back(python::extract<double>(charges[i]));
-        if (pt.check()) {
-          pos.push_back(pt);
-        } else {
-          throw_value_error("non-Point3D found in sequence of points");
-        }
-      }
-    }
+std::pair<std::vector<double>, std::vector<RDGeom::Point3D>>
+extractChargesAndPositions(const python::object &charges,
+                           const python::object &positions) {
+  const auto pyPos = positions.ptr();
+  const auto pyCharges = charges.ptr();
+  if (!pyPos || !PySequence_Check(pyPos)) {
+    throw_value_error("positions argument must be a sequence");
   }
-
-  auto *coul = new Coulomb(ch, pos, probecharge, absVal, alpha, cutoff);
-  return coul;
-}
-
-CoulombDielectric *make_coulomb_dielectric(const python::object &charges,
-                                           const python::object &positions,
-                                           double probecharge, bool absVal,
-                                           double alpha, double cutoff,
-                                           double epsilon, double xi) {
-  PyObject *pyObj = positions.ptr();
-  std::vector<RDGeom::Point3D> pos;
-  std::vector<double> ch;
-  unsigned int nrows;
-  if (PySequence_Check(pyObj)) {
-    nrows = PySequence_Size(pyObj);
-    if (nrows <= 0) {
-      throw_value_error("Empty sequence passed in");
-    }
-    python::extract<RDGeom::Point3D> ptOk(positions[0]);
-    if (!ptOk.check()) {
-      for (unsigned int i = 0; i < nrows; i++) {
-        PySequenceHolder<double> row(positions[i]);
-        if (row.size() != 3) {
-          throw_value_error("Wrong number of entries in the list of lists");
-        }
-        RDGeom::Point3D pt(row[0], row[1], row[2]);
-        pos.push_back(pt);
-        ch.push_back(python::extract<double>(charges[i]));
-      }
-    } else {
-      for (unsigned int i = 0; i < nrows; i++) {
-        python::extract<RDGeom::Point3D> pt(positions[i]);
-        ch.push_back(python::extract<double>(charges[i]));
-        if (pt.check()) {
-          pos.push_back(pt);
-        } else {
-          throw_value_error("non-Point3D found in sequence of points");
-        }
-      }
-    }
+  if (!pyCharges || !PySequence_Check(pyCharges)) {
+    throw_value_error("charges argument must be a sequence");
   }
-
-  auto *coul = new CoulombDielectric(ch, pos, probecharge, absVal, alpha,
-                                     cutoff, epsilon, xi);
-  return coul;
+  auto nrows = PySequence_Size(pyPos);
+  if (nrows != PySequence_Size(pyCharges)) {
+    throw_value_error("positions and charges must have the same length");
+  }
+  std::vector<RDGeom::Point3D> pos(nrows);
+  std::vector<double> ch(nrows);
+  for (unsigned int i = 0; i < nrows; ++i) {
+    const auto pyXyz = PySequence_GetItem(pyPos, i);
+    if (!pyXyz || !PySequence_Check(pyXyz) || PySequence_Size(pyXyz) != 3) {
+      throw_value_error(
+          "all elements in positions argument must be x,y,z sequences");
+    }
+    pos[i].x = python::extract<double>(PySequence_GetItem(pyXyz, 0));
+    pos[i].y = python::extract<double>(PySequence_GetItem(pyXyz, 1));
+    pos[i].z = python::extract<double>(PySequence_GetItem(pyXyz, 2));
+    ch[i] = python::extract<double>(PySequence_GetItem(pyCharges, i));
+  }
+  return std::make_pair(std::move(ch), std::move(pos));
 }
 
-VdWaals *constructVdWMMFF(RDKit::ROMol &mol, int confId,
-                          unsigned int probeAtomType, bool scaling,
-                          double cutoff) {
-  auto *res =
-      new VdWaals(mol, confId, probeAtomType, "", "MMFF94", scaling, cutoff);
-  return res;
+Coulomb *makeAltCoulomb(const python::object &charges,
+                        const python::object &positions, double probecharge,
+                        bool absVal, double alpha, double cutoff) {
+  const auto [ch, pos] = extractChargesAndPositions(charges, positions);
+  return new Coulomb(ch, pos, probecharge, absVal, alpha, cutoff);
 }
 
-VdWaals *constructVdWUFF(RDKit::ROMol &mol, int confId,
-                         const std::string &probeAtomType, double cutoff) {
-  auto *res = new VdWaals(mol, confId, 0, probeAtomType, "UFF", false, cutoff);
-  return res;
+CoulombDielectric *makeAltCoulombDielectric(const python::object &charges,
+                                            const python::object &positions,
+                                            double probecharge, bool absVal,
+                                            double alpha, double cutoff,
+                                            double epsilon, double xi) {
+  const auto [ch, pos] = extractChargesAndPositions(charges, positions);
+  return new CoulombDielectric(ch, pos, probecharge, absVal, alpha, cutoff,
+                               epsilon, xi);
 }
 
-RDKit::ROMol *readCubeFile(RDGeom::UniformRealValueGrid3D &grd,
-                           const std::string &filename) {
+python::tuple readCubeFile(const std::string &filename) {
+  RDGeom::UniformRealValueGrid3D grd;
   auto res = readFromCubeFile(grd, filename);
-  return res.release();
+  boost::python::manage_new_object::apply<RDKit::ROMol *>::type converter;
+  return python::make_tuple(
+      grd,
+      python::handle<>(converter(static_cast<RDKit::ROMol *>(res.release()))));
 }
 
 struct mif_wrapper {
   static void wrap() {
     std::string docStringClass =
-        "Class for calculation of the closest distance of a point to a molecule.\n\n";
-    std::string docStringConst =
-        "Constructor for DistaceToClosestAtom class.\n\n\
-				ARGUMENTS:\n\
-				    - mol:    the molecule of interest\n\
-				    - confId: the ID of the conformer to be used (defaults to -1)\n";
-    std::string docString =
-        "Calculates the closest distance from a point to a the molecule\n\n\
-				ARGUMENTS:\n\
-				    - pt: Point3D from which the distance to the molecule is calculated\n\
-				RETURNS:\n\
-				    - closest distance in [A]\n";
-    python::class_<DistanceToClosestAtom>(
-        "DistanceToClosestAtom", docStringClass.c_str(),
-        python::init<const RDKit::ROMol, int>(
-            (python::arg("mol"), python::arg("confId") = -1),
-            docStringConst.c_str()))
-        .def("__call__", &DistanceToClosestAtom::operator(),
-             (python::arg("x"), python::arg("y"), python::arg("z")),
-             docString.c_str());
-
-    docStringClass =
         "Class for calculation of electrostatic interaction (Coulomb energy) between probe and molecule in\n\
-						vaccuum (no dielectric).\n\n";
-    docStringConst =
+        vacuum (no dielectric).\n\n";
+    std::string docStringConst =
         "Constructor for Coulomb class.\n\n\
-				ARGUMENTS:\n\
-				- mol:           the molecule of interest\n\
-				- confId:        the ID of the conformer to be used (defaults to -1)\n\
-				- probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
-			      	- absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
-			        - chargeKey	 property key for retrieving partial charges of atoms from molecule (defaults to '_GasteigerCharge')\n\
-			        - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
-			        - cutoffDist     minimum cutoff distance [A] (defaults to 1.0)\n";
-    docString =
+        ARGUMENTS:\n\
+        - mol:           the molecule of interest\n\
+        - confId:        the ID of the conformer to be used (defaults to -1)\n\
+        - probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
+        - absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
+        - chargeKey      property key for retrieving partial charges of atoms from molecule (defaults to '_GasteigerCharge')\n\
+        - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
+        - cutoff         minimum cutoff distance [A] (defaults to 1.0)\n";
+    std::string docStringConstAlt =
+        "Alternative constructor for Coulomb class.\n\n\
+        ARGUMENTS:\n\
+        - charges:       array of partial charges of a molecule's atoms\n\
+        - positions:     array of positions of a molecule's atoms\n\
+        - probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
+        - absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
+        - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
+        - cutoff         minimum cutoff distance [A] (defaults to 1.0)\n";
+    std::string docString =
         "Calculates the electrostatic interaction (Coulomb energy) between probe and molecule in\n\
-						vaccuum (no dielectric).\n\n\
-				ARGUMENTS:\n\
-				    - x, y, z:	 coordinates of probe position for energy calculation\n\
-                                    - threshold: maximal distance until which interactions are calculated\n\
-				RETURNS:\n\
-					- electrostatic potential in [kJ mol^-1]\n";
+        vacuum (no dielectric).\n\n\
+        ARGUMENTS:\n\
+        - x, y, z:   coordinates of probe position for energy calculation\n\
+        - threshold: maximal distance until which interactions are calculated\n\
+        RETURNS:\n\
+        - electrostatic potential in [kJ mol^-1]\n";
     python::class_<Coulomb>(
         "Coulomb", docStringClass.c_str(),
         python::init<const RDKit::ROMol &, int, double, bool,
@@ -200,57 +141,60 @@ struct mif_wrapper {
              python::arg("probeCharge") = 1.0, python::arg("absVal") = false,
              python::arg("chargeKey") = "_GasteigerCharge",
              python::arg("softcoreParam") = 0.0,
-             python::arg("cutoffDist") = 1.0),
+             python::arg("cutoff") = 1.0),
             docStringConst.c_str()))
+        .def("__init__",
+             python::make_constructor(
+                 makeAltCoulomb, python::default_call_policies(),
+                 (python::arg("charges"), python::arg("positions"),
+                  python::arg("probeCharge") = 1.0,
+                  python::arg("absVal") = false,
+                  python::arg("softcoreParam") = 0.0,
+                  python::arg("cutoff") = 1.0)),
+             docStringConstAlt.c_str())
         .def("__call__", &Coulomb::operator(),
              (python::arg("x"), python::arg("y"), python::arg("z"),
               python::arg("threshold")),
              docString.c_str());
 
-    docStringConst =
-        "Alternative constructor for Coulomb class.\n\n\
-						ARGUMENTS:\n\
-						- charges:       array of partial charges of a molecule's atoms\n\
-						- positions:     array of positions of a molecule's atoms\n\
-					        - probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
-					      	- absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
-					        - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
-					        - cutoffDist     minimum cutoff distance [A] (defaults to 1.0)\n";
-    python::def(
-        "Coulomb_", make_coulomb,
-        (python::arg("charges"), python::arg("positions"),
-         python::arg("probeCharge") = 1.0, python::arg("absVal") = false,
-         python::arg("softcoreParam") = 0.0, python::arg("cutoffDist") = 1.0),
-        docStringConst.c_str(),
-        python::return_value_policy<python::manage_new_object>());
-
     docStringClass =
         "Class for calculation of electrostatic interaction (Coulomb energy) between probe and molecule in\n\
-						by taking a distance-dependent dielectric into account:\n\
-                        Same energy term as used in GRID MIFs\n\
-			            References:\n\
-                        J. Med. Chem. 1985, 28, 849.\n\
-                        J. Comp. Chem. 1983, 4, 187.\n\n";
+        by taking a distance-dependent dielectric into account.\n\
+        Same energy term as used in GRID MIFs.\n\
+        References:\n\
+        - J. Med. Chem. 1985, 28, 849.\n\
+        - J. Comp. Chem. 1983, 4, 187.\n\n";
     docStringConst =
         "Constructor for CoulombDielectric class.\n\n\
-				ARGUMENTS:\n\
-				    - mol:           the molecule of interest\n\
-				    - confId:        the ID of the conformer to be used (defaults to -1)\n\
-				    - probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
-			      	    - absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
-			            - chargeKey	     property key for retrieving partial charges of atoms from molecule (defaults to '_GasteigerCharge')\n\
-			            - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
-			            - cutoffDist     minimum cutoff distance [A] (defaults to 1.0)\n\
-				    - epsilon        relative permittivity of solvent (defaults to 80.0)\n\
-	  	                    - xi             relative permittivity of solute (defaults to 4.0)\n";
+        ARGUMENTS:\n\
+        - mol:           the molecule of interest\n\
+        - confId:        the ID of the conformer to be used (defaults to -1)\n\
+        - probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
+        - absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
+        - chargeKey       property key for retrieving partial charges of atoms from molecule (defaults to '_GasteigerCharge')\n\
+        - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
+        - cutoff         minimum cutoff distance [A] (defaults to 1.0)\n\
+        - epsilon        relative permittivity of solvent (defaults to 80.0)\n\
+        - xi             relative permittivity of solute (defaults to 4.0)\n";
+    docStringConstAlt =
+        "Alternative constructor for CoulombDielectric class.\n\n\
+        ARGUMENTS:\n\
+      - charges:       array of partial charges of a molecule's atoms\n\
+      - positions:     array of positions of a molecule's atoms\n\
+      - probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
+      - absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
+      - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
+      - cutoff         minimum cutoff distance [A] (defaults to 1.0)\n\
+      - epsilon        relative permittivity of solvent (defaults to 80.0)\n\
+      - xi             relative permittivity of solute (defaults to 4.0)\n";
     docString =
         "Calculates the electrostatic interaction (Coulomb energy) between probe and molecule in\n\
-						by taking a distance-dependent dielectric into account.\n\n\
-				ARGUMENTS:\n\
-				    - x, y, z:	 coordinates of probe position for energy calculation\n\
-                                    - threshold: maximal distance until which interactions are calculated\n\
-                                RETURNS:\n\
-					- electrostatic potential in [kJ mol^-1]\n";
+        by taking a distance-dependent dielectric into account.\n\n\
+        ARGUMENTS:\n\
+        - x, y, z:   coordinates of probe position for energy calculation\n\
+        - threshold: maximal distance until which interactions are calculated\n\
+        RETURNS:\n\
+        - electrostatic potential in [kJ mol^-1]\n";
     python::class_<CoulombDielectric>(
         "CoulombDielectric", docStringClass.c_str(),
         python::init<const RDKit::ROMol &, int, double, bool,
@@ -259,110 +203,107 @@ struct mif_wrapper {
              python::arg("probeCharge") = 1.0, python::arg("absVal") = false,
              python::arg("chargeKey") = "_GasteigerCharge",
              python::arg("softcoreParam") = 0.0,
-             python::arg("cutoffDist") = 1.0, python::arg("epsilon") = 80.0,
+             python::arg("cutoff") = 1.0, python::arg("epsilon") = 80.0,
              python::arg("xi") = 4.0),
             docStringConst.c_str()))
+        .def("__init__",
+             python::make_constructor(
+                 makeAltCoulombDielectric, python::default_call_policies(),
+                 (python::arg("charges"), python::arg("positions"),
+                  python::arg("probeCharge") = 1.0,
+                  python::arg("absVal") = false,
+                  python::arg("softcoreParam") = 0.0,
+                  python::arg("cutoff") = 1.0,
+                  python::arg("epsilon") = 80.0, python::arg("xi") = 4.0)),
+             docStringConstAlt.c_str())
+        .def(python::init<const std::string &>(
+            python::args("self", "pklString")))
         .def("__call__", &CoulombDielectric::operator(),
              (python::arg("x"), python::arg("y"), python::arg("z"),
               python::arg("threshold")),
              docString.c_str());
 
-    docStringConst =
-        "Alternative constructor for CoulombDielectric class.\n\n\
-								ARGUMENTS:\n\
-								    - charges:       array of partial charges of a molecule's atoms\n\
-								    - positions:     array of positions of a molecule's atoms\n\
-							            - probeCharge    charge of probe [e] (defaults to 1.0 e)\n\
-							      	    - absVal:        if True, absolute values of interactions are calculated (defaults to False)\n\
-							            - softcoreParam  softcore interaction parameter [A^2], if zero, a minimum cutoff distance is used (defaults to 0.0)\n\
-							            - cutoffDist     minimum cutoff distance [A] (defaults to 1.0)\n\
-								    - epsilon 	     relative permittivity of solvent (defaults to 80.0)\n\
-								    - xi             relative permittivity of solute (defaults to 4.0)\n";
-    python::def(
-        "CoulombDielectric_", make_coulomb_dielectric,
-        (python::arg("charges"), python::arg("positions"),
-         python::arg("probeCharge") = 1.0, python::arg("absVal") = false,
-         python::arg("softcoreParam") = 0.0, python::arg("cutoffDist") = 1.0,
-         python::arg("epsilon") = 80.0, python::arg("xi") = 4.0),
-        docStringConst.c_str(),
-        python::return_value_policy<python::manage_new_object>());
-
     docStringClass =
-        "Class for calculation van der Waals interaction between molecule and a probe at a gridpoint.\n\n";
+        "Class for calculating van der Waals interactions between molecule and a probe at a gridpoint\
+        based on the MMFF forcefield.\n";
+    docStringConst =
+        "ARGUMENTS:\n\
+        - mol           molecule object\n\
+        - confId        conformation id which is used to get positions of atoms (default=-1)\n\
+        - probeAtomType MMFF94 atom type for the probe atom (default=6, sp3 oxygen)\n\
+        - cutoff        minimum cutoff distance [A] (default:1.0)\n\
+        - scaling       scaling of VdW parameters to take hydrogen bonds into account (default=False)\n";
     docString =
         "Calculates the van der Waals interaction between molecule and a probe at a gridpoint.\n\n\
-				ARGUMENTS:\n\
-				    - x, y, z:	 coordinates of probe position for energy calculation\n\
-                                    - threshold: maximal distance until which interactions are calculated\n\
-                                RETURNS:\n\
-					- van der Waals potential in [kJ mol^-1]\n";
-    python::class_<VdWaals>("VdWaals", "",
-                            python::init<>("Default Constructor"))
-        .def("__call__", &VdWaals::operator(),
+        ARGUMENTS:\n\
+        - x, y, z:   coordinates of probe position for energy calculation\n\
+        - threshold: maximal distance until which interactions are calculated\n\
+        RETURNS:\n\
+        - van der Waals potential in [kJ mol^-1]\n";
+    python::class_<MMFFVdWaals>(
+        "MMFFVdWaals", docStringClass.c_str(),
+        python::init<const RDKit::ROMol &, int, unsigned int, bool, double>(
+            (python::arg("self"), python::arg("mol"),
+             python::arg("confId") = -1, python::arg("probeAtomType") = 6,
+             python::arg("scaling") = false, python::arg("cutoff") = 1.0),
+            docStringConst.c_str()))
+        .def("__call__", &MMFFVdWaals::operator(),
              (python::arg("x"), python::arg("y"), python::arg("z"),
               python::arg("threshold")),
              docString.c_str());
 
+    docStringClass =
+        "Class for calculating van der Waals interactions between molecule and a probe at a gridpoint\
+        based on the UFF forcefield.\n";
     docStringConst =
-        "Constructs VdWaals class which uses MMFF94 force field parameters.\n\n\
-				ARGUMENTS:\n\
-				    - mol:           the molecule of interest\n\
-				    - confId:        the ID of the conformer to be used (defaults to -1)\n\
-				    - probeType      MMFF94 atom type (integer) used as probe atom (defaults to 6)\n\
-			      	    - scaling:       scales interaction to take hydrogen bonds into account (MMFF94-specific) (defaults to False)\n\
-			            - cutoffDist     minimum cutoff distance [A] (defaults to 1.0)\n";
-    python::def("ConstructVdWaalsMMFF", &constructVdWMMFF,
-                (python::arg("mol"), python::arg("confId") = -1,
-                 python::arg("probeType") = 6, python::arg("scaling") = false,
-                 python::arg("cutoffDist") = 1.0),
-                docStringConst.c_str(),
-                python::return_value_policy<python::manage_new_object>());
-
-    docStringConst =
-        "Constructs VdWaals class which uses UFF force field parameters.\n\n\
-				ARGUMENTS:\n\
-				    - mol:           the molecule of interest\n\
-				    - confId:        the ID of the conformer to be used (defaults to -1)\n\
-				    - probeType	     UFF atom type (string) used as probe atom (defaults to 'O_3')\n\
-			            - cutoffDist     minimum cutoff distance [A] (defaults to 1.0)\n";
-    python::def(
-        "ConstructVdWaalsUFF", &constructVdWUFF,
-        (python::arg("mol"), python::arg("confId") = -1,
-         python::arg("probeType") = "O_3", python::arg("cutoffDist") = 1.0),
-        docStringConst.c_str(),
-        python::return_value_policy<python::manage_new_object>());
+        "ARGUMENTS:\n\
+        - mol           molecule object\n\
+        - confId        conformation id which is used to get positions of atoms (default=-1)\n\
+        - probeAtomType UFF atom type for the probe atom (default='O_3', sp3 oxygen)\n\
+        - cutoff        minimum cutoff distance [A] (default:1.0)\n";
+    python::class_<UFFVdWaals>(
+        "UFFVdWaals", docStringClass.c_str(),
+        python::init<const RDKit::ROMol &, int, const std::string &, double>(
+            (python::arg("self"), python::arg("mol"),
+             python::arg("confId") = -1, python::arg("probeAtomType") = "O_3",
+             python::arg("cutoff") = 1.0),
+            docStringConst.c_str()))
+        .def("__call__", &UFFVdWaals::operator(),
+             (python::arg("x"), python::arg("y"), python::arg("z"),
+              python::arg("threshold")),
+             docString.c_str());
 
     docStringClass =
         "Class for calculation of hydrogen bonding energy between a probe and a molecule.\n\n\
-				Similar to GRID hydrogen bonding descriptors\n\
-				References:\n\
-				  - J.Med.Chem. 1989, 32, 1083.\n\
-				  - J.Med.Chem. 1993, 36, 140.\n\
-				  - J.Med.Chem. 1993, 36, 148.\n";
+        Similar to GRID hydrogen bonding descriptors.\n\
+        References:\n\
+        - J.Med.Chem. 1989, 32, 1083.\n\
+        - J.Med.Chem. 1993, 36, 140.\n\
+        - J.Med.Chem. 1993, 36, 148.\n";
     docStringConst =
         "Constructor for HBond class.\n\n\
-				ARGUMENTS:\n\
-				    - mol:           the molecule of interest\n\
-				    - confId:        the ID of the conformer to be used (defaults to -1)\n\
-	                            - probeType:     atom type for the probe atom (either 'OH', 'O', 'NH' or 'N') (defaults to 'OH')\n\
-	                            - fixed:         for some groups, two different angle dependencies are defined:\n\
-	      	                         one which takes some flexibility of groups (rotation/swapping of lone pairs and hydrogen)\n\
-	      	                         into account and one for strictly fixed conformations\n\
-	      	                         if True, strictly fixed conformations (defaults to True)\n\
-			            - cutoffDist     minimum cutoff distance [A] (defaults to 1.0)\n";
+        ARGUMENTS:\n\
+        - mol:           the molecule of interest\n\
+        - confId:        the ID of the conformer to be used (defaults to -1)\n\
+        - probeAtomType: atom type for the probe atom (either 'OH', 'O', 'NH' or 'N') (defaults to 'OH')\n\
+        - fixed:         for some groups, two different angle dependencies are defined:\n\
+                         one which takes some flexibility of groups (rotation/swapping of lone pairs and hydrogen)\n\
+                         into account and one for strictly fixed conformations\n\
+                         if True, strictly fixed conformations (defaults to True)\n\
+        - cutoff         minimum cutoff distance [A] (defaults to 1.0)\n";
     docString =
         "Calculates the hydrogen bonding energy between probe and molecule in\n\n\
-				ARGUMENTS:\n\
-				    - x, y, z:	 coordinates of probe position for energy calculation\n\
-                                    - threshold: maximal distance until which interactions are calculated\n\
-                                RETURNS:\n\
-					hydrogen bonding energy in [kJ mol^-1]\n";
+        ARGUMENTS:\n\
+        - x, y, z:   coordinates of probe position for energy calculation\n\
+        - threshold: maximal distance until which interactions are calculated\n\
+        RETURNS:\n\
+        hydrogen bonding energy in [kJ mol^-1]\n";
     python::class_<HBond>(
         "HBond", docStringClass.c_str(),
         python::init<RDKit::ROMol &, int, const std::string &, bool, double>(
             (python::arg("mol"), python::arg("confId") = -1,
-             python::arg("probeType") = "OH", python::arg("fixed") = true,
-             python::arg("cutoffDist") = 1.0),
+             python::arg("probeAtomType") = "OH", python::arg("fixed") = true,
+             python::arg("cutoff") = 1.0),
             docStringConst.c_str()))
         .def("__call__", &HBond::operator(),
              (python::arg("x"), python::arg("y"), python::arg("z"),
@@ -371,30 +312,30 @@ struct mif_wrapper {
 
     docStringClass =
         "Class for calculation of a hydrophilic potential of a molecule at a point.\n\n\
-			      The interaction energy of hydrogen and oxygen of water is calculated at each point as a \n\
-                              hydrogen bond interaction (either OH or O probe). The favored interaction is returned.\n";
+        The interaction energy of hydrogen and oxygen of water is calculated at each point as a \n\
+        hydrogen bond interaction (either OH or O probe). The favored interaction is returned.\n";
     docStringConst =
         "Constructor for Hydrophilic class.\n\n\
-				ARGUMENTS:\n\
-				    - mol:               the molecule of interest\n\
-				    - confId:        	 the ID of the conformer to be used (defaults to -1)\n\
-	                            - fixed:         	 for some groups, two different angle dependencies are defined:\n\
-	      	                             one which takes some flexibility of groups (rotation/swapping of lone pairs and hydrogen)\n\
-	      	                             into account and one for strictly fixed conformations\n\
-	      	                             if True, strictly fixed conformations (defaults to True)\n\
-	                            - cutoffDist	 minimum cutoff distance [A] (default:1.0)\n";
+        ARGUMENTS:\n\
+        - mol:         the molecule of interest\n\
+        - confId:      the ID of the conformer to be used (defaults to -1)\n\
+        - fixed:       for some groups, two different angle dependencies are defined:\n\
+                       one which takes some flexibility of groups (rotation/swapping of lone pairs and hydrogen)\n\
+                       into account and one for strictly fixed conformations\n\
+                       if True, strictly fixed conformations (defaults to True)\n\
+        - cutoff       minimum cutoff distance [A] (default:1.0)\n";
     docString =
         "Calculates the hydrophilic field energy at a point.\n\n\
-				ARGUMENTS:\n\
-				    - x, y, z:	 coordinates of probe position for energy calculation\n\
-                                    - threshold: maximal distance until which interactions are calculated\n\
-                                RETURNS:\n\
-					hydrophilic field energy in [kJ mol^-1]\n";
+        ARGUMENTS:\n\
+        - x, y, z:   coordinates of probe position for energy calculation\n\
+        - threshold: maximal distance until which interactions are calculated\n\
+        RETURNS:\n\
+        hydrophilic field energy in [kJ mol^-1]\n";
     python::class_<Hydrophilic>(
         "Hydrophilic", docStringClass.c_str(),
         python::init<RDKit::ROMol &, int, bool, double>(
             (python::arg("mol"), python::arg("confId") = -1,
-             python::arg("fixed") = true, python::arg("cutoffDist") = 1.0),
+             python::arg("fixed") = true, python::arg("cutoff") = 1.0),
             docStringConst.c_str()))
         .def("__call__", &Hydrophilic::operator(),
              (python::arg("x"), python::arg("y"), python::arg("z"),
@@ -403,11 +344,11 @@ struct mif_wrapper {
 
     docString =
         "Constructs a UniformRealValueGrid3D (3D grid with real values at gridpoints) fitting to a molecule.\n\n\
-				ARGUMENTS:\n\
-				    - mol:     molecule of interest\n\
-				    - confId:  the ID of the conformer to be used (defaults to -1)\n\
-				    - margin:  minimum distance of molecule to surface of grid [A] (defaults to 5.0 A)\n\
-				    - spacing: grid spacing [A] (defaults to 0.5 A)\n";
+        ARGUMENTS:\n\
+        - mol:     molecule of interest\n\
+        - confId:  the ID of the conformer to be used (defaults to -1)\n\
+        - margin:  minimum distance of molecule to surface of grid [A] (defaults to 5.0 A)\n\
+        - spacing: grid spacing [A] (defaults to 0.5 A)\n";
     python::def("ConstructGrid", constructGridHelper,
                 (python::arg("mol"), python::arg("confId") = -1,
                  python::arg("margin") = 5.0, python::arg("spacing") = 0.5),
@@ -416,13 +357,9 @@ struct mif_wrapper {
 
     docString =
         "Calculates descriptors (to be specified as parameter) of a molecule at every gridpoint of a grid.\n\n\
-				ARGUMENTS:\n\
-				    - grid: 	   UniformRealValueGrid3D which get the MIF values\n\
-				    - descriptor:  Descriptor class which is used to calculate values\n";
-    python::def(
-        "CalculateDescriptors", calculateDescriptors<DistanceToClosestAtom>,
-        (python::arg("grid"), python::arg("descriptor")), docString.c_str());
-
+        ARGUMENTS:\n\
+        - grid:      UniformRealValueGrid3D which get the MIF values\n\
+        - descriptor:  Descriptor class which is used to calculate values\n";
     python::def("CalculateDescriptors", calculateDescriptors<Coulomb>,
                 (python::arg("grid"), python::arg("descriptor"),
                  python::arg("threshold") = -1.0),
@@ -433,7 +370,12 @@ struct mif_wrapper {
                  python::arg("threshold") = -1.0),
                 docString.c_str());
 
-    python::def("CalculateDescriptors", calculateDescriptors<VdWaals>,
+    python::def("CalculateDescriptors", calculateDescriptors<MMFFVdWaals>,
+                (python::arg("grid"), python::arg("descriptor"),
+                 python::arg("threshold") = -1.0),
+                docString.c_str());
+
+    python::def("CalculateDescriptors", calculateDescriptors<UFFVdWaals>,
                 (python::arg("grid"), python::arg("descriptor"),
                  python::arg("threshold") = -1.0),
                 docString.c_str());
@@ -450,27 +392,27 @@ struct mif_wrapper {
 
     docString =
         "Writes Grid to a file in Gaussian CUBE format.\n\n\
-				ARGUMENTS:\n\
-				    - grid: 	UniformRealValueGrid3D to be stored\n\
-				    - mol:	respective molecule\n\
-				    - filename:	filename of file to be written\n\
-				    - confId:	the ID of the conformer to be used (defaults to -1)\n";
+        ARGUMENTS:\n\
+        - grid:      UniformRealValueGrid3D to be stored\n\
+        - filename:  filename of file to be written\n\
+        - mol:       associated molecule (defaults to None)\n\
+        - confId:    the ID of the conformer to be used (defaults to -1)\n";
     python::def("WriteToCubeFile", writeToCubeFile,
-                (python::arg("grid"), python::arg("mol"),
-                 python::arg("filename"), python::arg("confId") = -1),
+                (python::arg("grid"), python::arg("filename"),
+                 python::arg("mol") = python::object(), python::arg("confId") = -1),
                 docString.c_str());
 
     docString =
         "Reads Grid from a file in Gaussian CUBE format.\n\n\
-				ARGUMENTS:\n\
-				    - grid: 	UniformRealValueGrid3D where data is read in\n\
-				 	- filename:	filename of file to be read\n\
-				RETURNS:\n\
-				    a molecule object (only atoms and coordinates, no bonds!)\n";
-    python::def("ReadFromCubeFile", readCubeFile,
-                (python::arg("grid"), python::arg("filename")),
-                docString.c_str(),
-                python::return_value_policy<python::manage_new_object>());
+        ARGUMENTS:\n\
+        - filename:  filename of file to be read\n\
+        RETURNS:\n\
+        a tuple where the first element is the grid and\n\
+        the second element is the molecule object associated to the grid\n\
+        (only atoms and coordinates, no bonds;\n\
+        None if no molecule was associated to the grid)\n";
+    python::def("ReadFromCubeFile", readCubeFile, (python::arg("filename")),
+                docString.c_str());
   }
 };
 }  // namespace RDMIF

--- a/Code/GraphMol/MolInteractionFields/testMIF.cpp
+++ b/Code/GraphMol/MolInteractionFields/testMIF.cpp
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include <iostream>
 #include <fstream>
-#include <stdlib.h>
 
 using namespace RDGeom;
 using namespace RDKit;
@@ -48,18 +47,19 @@ TEST_CASE("constructGrid") {
   path += "/Code/GraphMol/MolInteractionFields/test_data/";
   //	//Generate Molecule with 3D Coordinates and Partial Charges
   //	RWMol mol=*SmilesToMol("Cl");
-  //	MolOps::addHs(mol);
-  //	DGeomHelpers::EmbedMolecule(mol);
+  //	MolOps::addHs(*mol);
+  //	DGeomHelpers::EmbedMolecule(*mol);
 
-  //	MolToMolFile(mol, path + "HCl.mol");
+  //	MolToMolFile(*mol, path + "HCl.mol");
 
   auto fopts = v2::FileParsers::MolFileParserParams();
   fopts.removeHs = false;
-  auto mol = *v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
-  auto grd = *constructGrid(mol, 0, 5.0, 0.5);
+  auto mol = v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  REQUIRE(mol);
+  auto grd = *constructGrid(*mol, 0, 5.0, 0.5);
 
   Point3D bond =
-      mol.getConformer().getAtomPos(1) - mol.getConformer().getAtomPos(0);
+      mol->getConformer().getAtomPos(1) - mol->getConformer().getAtomPos(0);
   CHECK(feq(grd.getSpacing(), 0.5));
   CHECK(feq(grd.getNumX(), std::floor((fabs(bond.x) + 10.0) / 0.5 + 0.5)));
   CHECK(feq(grd.getNumY(), std::floor((fabs(bond.y) + 10.0) / 0.5 + 0.5)));
@@ -81,16 +81,17 @@ TEST_CASE("CubeFiles") {
 
   auto fopts = v2::FileParsers::MolFileParserParams();
   fopts.removeHs = false;
-  RWMol mol = *v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  auto mol = v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  REQUIRE(mol);
   auto *data = new RealValueVect(0.0, 125);
   Point3D o(0.0, 0.0, 0.0);
   UniformRealValueGrid3D grd(5.0, 5.0, 5.0, 1.0, &o, data);
   for (unsigned int i = 0; i < grd.getSize(); i++) {
     grd.setVal(i, double(i / 10.0));
   }
-  writeToCubeFile(grd, mol, path + "test3.cube");
+  writeToCubeFile(grd, path + "test3.cube", mol.get());
   UniformRealValueGrid3D grd2;
-  auto mol2 = *readFromCubeFile(grd2, path + "test3.cube");
+  auto mol2 = readFromCubeFile(grd2, path + "test3.cube");
 
   CHECK(grd.getSize() == grd2.getSize());
   for (unsigned int i = 0; i < grd2.getSize(); i++) {
@@ -105,16 +106,16 @@ TEST_CASE("CubeFiles") {
   CHECK(grd.compareParams(grd2));
   CHECK(grd.compareGrids(grd2));
 
-  CHECK(mol.getNumAtoms() == mol2.getNumAtoms());
-  for (unsigned int i = 0; i < mol.getNumAtoms(); i++) {
-    CHECK(mol.getAtomWithIdx(i)->getAtomicNum() ==
-          mol2.getAtomWithIdx(i)->getAtomicNum());
-    CHECK(feq(mol.getConformer().getAtomPos(i).x,
-              mol2.getConformer().getAtomPos(i).x));
-    CHECK(feq(mol.getConformer().getAtomPos(i).y,
-              mol2.getConformer().getAtomPos(i).y));
-    CHECK(feq(mol.getConformer().getAtomPos(i).z,
-              mol2.getConformer().getAtomPos(i).z));
+  CHECK(mol->getNumAtoms() == mol2->getNumAtoms());
+  for (unsigned int i = 0; i < mol->getNumAtoms(); i++) {
+    CHECK(mol->getAtomWithIdx(i)->getAtomicNum() ==
+          mol2->getAtomWithIdx(i)->getAtomicNum());
+    CHECK(feq(mol->getConformer().getAtomPos(i).x,
+              mol2->getConformer().getAtomPos(i).x));
+    CHECK(feq(mol->getConformer().getAtomPos(i).y,
+              mol2->getConformer().getAtomPos(i).y));
+    CHECK(feq(mol->getConformer().getAtomPos(i).z,
+              mol2->getConformer().getAtomPos(i).z));
   }
 }
 
@@ -124,23 +125,24 @@ TEST_CASE("Coulomb") {
 
   auto fopts = v2::FileParsers::MolFileParserParams();
   fopts.removeHs = false;
-  auto mol = *v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  auto mol = v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  REQUIRE(mol);
 
-  computeGasteigerCharges(mol);
+  computeGasteigerCharges(*mol);
 
   std::vector<double> charges;
   std::vector<Point3D> pos;
-  Conformer conf = mol.getConformer(0);
-  for (auto i = 0u; i < mol.getNumAtoms(); ++i) {
+  Conformer conf = mol->getConformer(0);
+  for (auto i = 0u; i < mol->getNumAtoms(); ++i) {
     charges.push_back(
-        mol.getAtomWithIdx(i)->getProp<double>("_GasteigerCharge"));
+        mol->getAtomWithIdx(i)->getProp<double>("_GasteigerCharge"));
     pos.push_back(conf.getAtomPos(i));
   }
 
-  auto grd = *constructGrid(mol);
-  auto grd2 = *constructGrid(mol);
+  auto grd = *constructGrid(*mol);
+  auto grd2 = *constructGrid(*mol);
 
-  Coulomb coul(mol);
+  Coulomb coul(*mol);
 
   calculateDescriptors<Coulomb>(grd, coul);
   calculateDescriptors<Coulomb>(grd2, Coulomb(charges, pos));
@@ -151,19 +153,19 @@ TEST_CASE("Coulomb") {
   CHECK(coul(-2.0, 0.0, 0.0, 1000) > 0);
   CHECK(feq(coul(0.0, 0.0, 0.0, 0.1), 0.0));
 
-  calculateDescriptors<Coulomb>(grd, Coulomb(mol, 0, 1.0, true));
+  calculateDescriptors<Coulomb>(grd, Coulomb(*mol, 0, 1.0, true));
   for (unsigned int i = 0; i < grd.getSize(); i++) {
     CHECK(grd.getVal(i) <= 0.0);
   }
 
-  Coulomb coul1(mol, 0, -1.0, false, "_GasteigerCharge", 0.0, 0.01);
+  Coulomb coul1(*mol, 0, -1.0, false, "_GasteigerCharge", 0.0, 0.01);
   CHECK(coul1(-2.0, 0.0, 0.0, 1000) < 0);
   CHECK(coul1(2.0, 0.0, 0.0, 1000) > 0);
 
-  Coulomb coul2 = Coulomb(mol, 0, -.5, false, "_GasteigerCharge", 0.0, 0.01);
+  Coulomb coul2 = Coulomb(*mol, 0, -.5, false, "_GasteigerCharge", 0.0, 0.01);
   CHECK(coul1(-2.0, 0.0, 0.0, 1000) < coul2(-2.0, 0.0, 0.0, 1000));
 
-  Coulomb coul3(mol, 0, 1.0, false, "_GasteigerCharge", 0.01, 1.0);
+  Coulomb coul3(*mol, 0, 1.0, false, "_GasteigerCharge", 0.01, 1.0);
   CHECK(coul3(0.0, 0.0, 0.0, 1000) > coul3(0.1, 0.0, 0.0, 1000));
   CHECK(coul3(0.66, 0.0, 0.0, 1000) > coul3(0.68, 0.0, 0.0, 1000));
   CHECK(coul3(0.70, 0.0, 0.0, 1000) > coul3(0.68, 0.0, 0.0, 1000));
@@ -176,23 +178,24 @@ TEST_CASE("CoulombDielectric") {
 
   auto fopts = v2::FileParsers::MolFileParserParams();
   fopts.removeHs = false;
-  RWMol mol = *v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  auto mol = v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  REQUIRE(mol);
 
-  computeGasteigerCharges(mol);
+  computeGasteigerCharges(*mol);
 
   std::vector<double> charges;
   std::vector<Point3D> pos;
-  Conformer conf = mol.getConformer(0);
-  for (auto i = 0u; i < mol.getNumAtoms(); ++i) {
+  Conformer conf = mol->getConformer(0);
+  for (auto i = 0u; i < mol->getNumAtoms(); ++i) {
     charges.push_back(
-        mol.getAtomWithIdx(i)->getProp<double>("_GasteigerCharge"));
+        mol->getAtomWithIdx(i)->getProp<double>("_GasteigerCharge"));
     pos.push_back(conf.getAtomPos(i));
   }
 
-  auto grd = *constructGrid(mol);
-  auto grd2 = *constructGrid(mol);
+  auto grd = *constructGrid(*mol);
+  auto grd2 = *constructGrid(*mol);
 
-  CoulombDielectric couldiele(mol);
+  CoulombDielectric couldiele(*mol);
 
   calculateDescriptors<CoulombDielectric>(grd, couldiele);
   calculateDescriptors<CoulombDielectric>(grd2,
@@ -203,8 +206,8 @@ TEST_CASE("CoulombDielectric") {
   CHECK(couldiele(2.0, 0.0, 0.0, 1000) < 0);
   CHECK(couldiele(-2.0, 0.0, 0.0, 1000) > 0);
 
-  calculateDescriptors<CoulombDielectric>(grd,
-                                          CoulombDielectric(mol, 0, 1.0, true));
+  calculateDescriptors<CoulombDielectric>(
+      grd, CoulombDielectric(*mol, 0, 1.0, true));
   for (unsigned int i = 0; i < grd.getSize(); i++) {
     CHECK(grd.getVal(i) <= 0.0);
   }
@@ -213,34 +216,35 @@ TEST_CASE("CoulombDielectric") {
   CHECK(couldiele(2.0, 0.0, 0.0, 1000) < 0);
   CHECK(couldiele(-2.0, 0.0, 0.0, 1000) > 0);
 
-  calculateDescriptors<CoulombDielectric>(grd,
-                                          CoulombDielectric(mol, 0, 1.0, true));
+  calculateDescriptors<CoulombDielectric>(
+      grd, CoulombDielectric(*mol, 0, 1.0, true));
   for (unsigned int i = 0; i < grd.getSize(); i++) {
     CHECK(grd.getVal(i) <= 0.0);
   }
 
-  CoulombDielectric couldiele1(mol, 0, -1.0);
+  CoulombDielectric couldiele1(*mol, 0, -1.0);
   CHECK(couldiele1(-2.0, 0.0, 0.0, 1000) < 0);
   CHECK(couldiele1(2.0, 0.0, 0.0, 1000) > 0);
 
-  CoulombDielectric couldiele2(mol, 0, -.5);
+  CoulombDielectric couldiele2(*mol, 0, -.5);
 
   CHECK(couldiele1(-2.0, 0.0, 0.0, 1000) < couldiele2(-2.0, 0.0, 0.0, 1000));
 
-  CoulombDielectric couldiele3(mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
+  CoulombDielectric couldiele3(*mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
                                1.0);
   CHECK(couldiele3(0.0, 0.0, 0.0, 1000) > couldiele3(0.1, 0.0, 0.0, 1000));
   CHECK(couldiele3(0.66, 0.0, 0.0, 1000) > couldiele3(0.68, 0.0, 0.0, 1000));
   CHECK(couldiele3(0.70, 0.0, 0.0, 1000) > couldiele3(0.68, 0.0, 0.0, 1000));
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "glucose.mol", fopts);
-  computeGasteigerCharges(mol);
+  mol = v2::FileParsers::MolFromMolFile(path + "glucose.mol", fopts);
+  REQUIRE(mol);
+  computeGasteigerCharges(*mol);
 
-  CoulombDielectric couldiele4(mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
+  CoulombDielectric couldiele4(*mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
                                1.0, 80.0, 4.0);
-  CoulombDielectric couldiele5(mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
+  CoulombDielectric couldiele5(*mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
                                1.0, 200.0, 4.0);
-  CoulombDielectric couldiele6(mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
+  CoulombDielectric couldiele6(*mol, 0, 1.0, false, "_GasteigerCharge", 0.01,
                                1.0, 80.0, 10.0);
   CHECK(couldiele5(-1.0, 0.0, 0.0, 1000) < couldiele4(-1.0, 0.0, 0.0, 1000));
 
@@ -253,31 +257,36 @@ TEST_CASE("VdWaals") {
 
   auto fopts = v2::FileParsers::MolFileParserParams();
   fopts.removeHs = false;
-  auto mol = *v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  auto mol = v2::FileParsers::MolFromMolFile(path + "HCl.mol", fopts);
+  REQUIRE(mol);
   try {
-    VdWaals vdw = constructVdWaalsMMFF(mol, 0, 6, false, 1.0);
+    MMFFVdWaals vdw(*mol, 0, 6, false, 1.0);
   } catch (ValueErrorException &dexp) {
     BOOST_LOG(rdInfoLog) << "Expected failure: " << dexp.what() << "\n";
   }
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "HCN.mol", fopts);
-  VdWaals vdw = constructVdWaalsMMFF(mol, 0, 6, false, 1.0);
+  mol = v2::FileParsers::MolFromMolFile(path + "HCN.mol", fopts);
+  REQUIRE(mol);
+  {
+    MMFFVdWaals vdw(*mol, 0, 6, false, 1.0);
 
-  CHECK(vdw(-5.0, 0, 0, 1000) < 0);
-  CHECK(vdw(-1.68, 0, 0, 1000) > vdw(-5.0, 0, 0, 1000));
-  CHECK(vdw(-5.0, 0, 0, 1000) < vdw(-10.0, 0, 0, 1000));
+    CHECK(vdw(-5.0, 0, 0, 1000) < 0);
+    CHECK(vdw(-1.68, 0, 0, 1000) > vdw(-5.0, 0, 0, 1000));
+    CHECK(vdw(-5.0, 0, 0, 1000) < vdw(-10.0, 0, 0, 1000));
+  }
 
-  auto mol2 = *v2::FileParsers::MolFromMolFile(path + "h2o.mol", fopts);
-  vdw = constructVdWaalsMMFF(mol2, 0, 6, false, 1.0);
-  VdWaals vdw2 = constructVdWaalsMMFF(mol2, 0, 6, true, 1.0);
+  auto mol2 = v2::FileParsers::MolFromMolFile(path + "h2o.mol", fopts);
+  REQUIRE(mol2);
+  MMFFVdWaals vdw(*mol2, 0, 6, false, 1.0);
+  MMFFVdWaals vdw2(*mol2, 0, 6, true, 1.0);
   CHECK(fabs(vdw2(-3.0, 0, 0, 1000) - vdw(-3.0, 0, 0, 1000)) > 0.0001);
 
-  VdWaals vdw3 = constructVdWaalsUFF(mol, 0, "O_3", 1.0);
+  UFFVdWaals vdw3(*mol, 0, "O_3", 1.0);
   CHECK(vdw3(-5.0, 0, 0, 1000) < 0);
   CHECK(vdw3(-1.68, 0, 0, 1000) > vdw3(-5.0, 0, 0, 1000));
   CHECK(vdw3(-5.0, 0, 0, 1000) < vdw3(-10.0, 0, 0, 1000));
 
-  std::string names[] = {
+  std::vector<std::string> names{
       "acetone",       "aceticacid",    "phenol",       "phenolate",
       "serine",        "threonine",     "ethanol",      "diethylether",
       "h2o",           "ammonia",       "ethylamine",   "imine",
@@ -285,11 +294,12 @@ TEST_CASE("VdWaals") {
       "fluoromethane", "chloromethane", "bromomethane", "glycine",
       "glyphe",        "glysergly",     "glythrgly",    "glucose"};
   for (const auto &name : names) {
-    mol = *v2::FileParsers::MolFromMolFile(path + name + ".mol", fopts);
-    vdw = constructVdWaalsMMFF(mol);
-    CHECK(vdw(0.0, 0.0, 0.0, 1000));
-    vdw = constructVdWaalsUFF(mol);
-    CHECK(vdw(0.0, 0.0, 0.0, 1000));
+    mol = v2::FileParsers::MolFromMolFile(path + name + ".mol", fopts);
+    REQUIRE(mol);
+    MMFFVdWaals mmffVdw(*mol);
+    CHECK(mmffVdw(0.0, 0.0, 0.0, 1000));
+    UFFVdWaals uffVdw(*mol);
+    CHECK(uffVdw(0.0, 0.0, 0.0, 1000));
   }
 }
 
@@ -301,15 +311,16 @@ TEST_CASE("HBond") {
   auto fopts = v2::FileParsers::MolFileParserParams();
   fopts.removeHs = false;
   auto mol =
-      *v2::FileParsers::MolFromMolFile(path + "ethane.mol", fopts);  // Ethane
-  auto grd = *constructGrid(mol, 0, 5.0, 1);
+      v2::FileParsers::MolFromMolFile(path + "ethane.mol", fopts);  // Ethane
+  REQUIRE(mol);
+  auto grd = *constructGrid(*mol, 0, 5.0, 1);
   for (unsigned int i = 0; i < grd.getSize(); i++) {
     grd.setVal(i, 1.0);
   }
 
   UniformRealValueGrid3D grd1(grd);
 
-  HBond hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  HBond hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
@@ -318,7 +329,7 @@ TEST_CASE("HBond") {
   const RealValueVect *vect1 = grd1.getOccupancyVect();
   CHECK((unsigned int)fabs(((*vect1 - *vect).getTotalVal())) == grd.getSize());
 
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
 
   for (unsigned int i = 0; i < grd.getSize(); i++) {
@@ -328,148 +339,162 @@ TEST_CASE("HBond") {
   TEST_ASSERT(!grd.compareGrids(grd1));
   CHECK((unsigned int)fabs(((*vect1 - *vect).getTotalVal())));
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "aceticacid.mol",
-                                         fopts);  // Acetic Acid
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "aceticacid.mol",
+                                        fopts);  // Acetic Acid
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 2);
   calculateDescriptors<HBond>(grd, hbonddes);
-  HBond hbonddes1(mol, 0, "O", true, 0.001);
+  HBond hbonddes1(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes1.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes1);
-  HBond hbonddes2(mol, 0, "O", false, 0.001);
+  HBond hbonddes2(*mol, 0, "O", false, 0.001);
   CHECK(hbonddes1(4.0, 0.0, 1.0, 1000) > hbonddes2(4.0, 0.0, 1.0, 1000));
-  HBond hbonddes3(mol, 0, "NH", true, 0.001);
+  HBond hbonddes3(*mol, 0, "NH", true, 0.001);
   CHECK(hbonddes3.getNumInteractions() == 2);
   CHECK(hbonddes(2.0, 2.0, 2.0, 1000) < hbonddes3(2.0, 2.0, 2.0, 1000));
-  HBond hbonddes4(mol, 0, "N", true, 0.001);
+  HBond hbonddes4(*mol, 0, "N", true, 0.001);
   CHECK(hbonddes4.getNumInteractions() == 1);
   CHECK(hbonddes1(3.0, 0.0, 0.0, 1000) < hbonddes4(3.0, 0.0, 0.0, 1000));
 
   mol =
-      *v2::FileParsers::MolFromMolFile(path + "acetone.mol", fopts);  // Acetone
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+      v2::FileParsers::MolFromMolFile(path + "acetone.mol", fopts);  // Acetone
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "diethylether.mol",
-                                         fopts);  // Et2O
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "diethylether.mol",
+                                        fopts);  // Et2O
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "h2o.mol", fopts);  // H2O
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "h2o.mol", fopts);  // H2O
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 2);
   calculateDescriptors<HBond>(grd, hbonddes);
 
   mol =
-      *v2::FileParsers::MolFromMolFile(path + "ammonia.mol", fopts);  // ammonia
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+      v2::FileParsers::MolFromMolFile(path + "ammonia.mol", fopts);  // ammonia
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 3);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "imine.mol", fopts);  // imine
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "imine.mol", fopts);  // imine
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "methylammonium.mol",
-                                         fopts);  // methylammonium
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "methylammonium.mol",
+                                        fopts);  // methylammonium
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 3);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "chloromethane.mol",
-                                         fopts);  // Chloromethane
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "chloromethane.mol",
+                                        fopts);  // Chloromethane
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "phosphonate.mol",
-                                         fopts);  // Phosphonate
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "phosphonate.mol",
+                                        fopts);  // Phosphonate
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 3);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "phosphatediester.mol",
-                                         fopts);  // Phosphatediester
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "phosphatediester.mol",
+                                        fopts);  // Phosphatediester
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 4);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "hydrogenphosphatediester.mol",
-                                         fopts);  // Hydrogenphosphatediester
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "hydrogenphosphatediester.mol",
+                                        fopts);  // Hydrogenphosphatediester
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 4);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "mustardgas.mol",
-                                         fopts);  // mustard gas
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "mustardgas.mol",
+                                        fopts);  // mustard gas
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 2);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "alicin.mol", fopts);  // Alicin
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "alicin.mol", fopts);  // Alicin
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 1);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 0);
   calculateDescriptors<HBond>(grd, hbonddes);
 
-  mol = *v2::FileParsers::MolFromMolFile(path + "sulfanilamide.mol",
-                                         fopts);  // Sulfanilamide
-  grd = *constructGrid(mol, 0, 5.0, 1);
-  hbonddes = HBond(mol, 0, "OH", true, 0.001);
+  mol = v2::FileParsers::MolFromMolFile(path + "sulfanilamide.mol",
+                                        fopts);  // Sulfanilamide
+  REQUIRE(mol);
+  grd = *constructGrid(*mol, 0, 5.0, 1);
+  hbonddes = HBond(*mol, 0, "OH", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 3);
   calculateDescriptors<HBond>(grd, hbonddes);
-  hbonddes = HBond(mol, 0, "O", true, 0.001);
+  hbonddes = HBond(*mol, 0, "O", true, 0.001);
   CHECK(hbonddes.getNumInteractions() == 4);
   calculateDescriptors<HBond>(grd, hbonddes);
 }
@@ -480,11 +505,12 @@ TEST_CASE("Hydrophilic") {
 
   auto fopts = v2::FileParsers::MolFileParserParams();
   fopts.removeHs = false;
-  auto mol = *v2::FileParsers::MolFromMolFile(path + "h2o.mol", fopts);
+  auto mol = v2::FileParsers::MolFromMolFile(path + "h2o.mol", fopts);
+  REQUIRE(mol);
 
-  Hydrophilic hydro(mol);
-  HBond hbondOH(mol, 0, "OH");
-  HBond hbondO(mol, 0, "O");
+  Hydrophilic hydro(*mol);
+  HBond hbondOH(*mol, 0, "OH");
+  HBond hbondO(*mol, 0, "O");
 
   double hyd = hydro(0.0, 0.0, 0.0, 1000), hOH = hbondOH(0.0, 0.0, 0.0, 1000),
          hO = hbondO(0.0, 0.0, 0.0, 1000);


### PR DESCRIPTION
Note: this is only cleanup work. I will carry out a scientific validation later, not before the Xmas break.

- Replace explicit loops with `stdlib` implicit equivalents
- Replace explicit types with `auto` where possible
- Avoid unnecessary copy operations where possible
- Replace raw pointers with exception-safe `unique_ptr`
- Replace C-style `#define` with `constexpr`
- Replace C-style casts with C++ casts
- Replace C-style arrays with `std::vector`
- Avoid code duplication with templated operators
- Replace `VdWaals` class taking multiple atom type definitions and force-field name as string parameter with force-field-specific classes deriving from an abstract `VdWaals` class
- Replace x,y,z doubles with `Point3D` class where possible
- Removed unused (and untested) `DistanceToClosestAtom` class
- Renamed some variables and functions for better clarity
- Converted tabs to spaces
- Made the `mol` parameter in cube read/write functions optional for convenience
- Made the Python wrappers more pythonic (e.g., avoid C++-style passing objects as parameters which are modified in place)
- Implemented alternative Python class constructors using `boost::python::make_constructor` rather than with external non-class functions
- The Python wrappers taking a sequence of `Point3D` now take a sequence of sequences, such that the output of `Conformer.GetPositions()` can be passed
- Made the Python wrapper sequence parsing more robust
- Removed duplicated code from Python wrappers
