### PR TITLE
fix Windows DLL build

### DIFF
--- a/Code/GraphMol/MolInterchange/CMakeLists.txt
+++ b/Code/GraphMol/MolInterchange/CMakeLists.txt
@@ -3,6 +3,7 @@ rdkit_library(MolInterchange
               Parser.cpp Writer.cpp
               LINK_LIBRARIES GraphMol)
 target_compile_definitions(MolInterchange PRIVATE RDKIT_MOLINTERCHANGE_BUILD)
+target_compile_definitions(MolInterchange PRIVATE BOOST_JSON_STATIC_LINK)
 
 rdkit_headers(MolInterchange.h details.h
               DEST GraphMol/MolInterchange)


### PR DESCRIPTION
After looking at `boost/json/detail/config.hpp`, I figured out that since we define `BOOST_JSON_NO_LIB` to use the header-only version of `boost::JSON`, we need to also define `BOOST_JSON_STATIC_LINK` in order to avoid using any of the `dllimport/dllexport` directives, which do not apply to the header-only version.