### PR TITLE
pr/SHARED-12362: Implement nanobind for MolEnumerator

### DIFF
--- a/Code/GraphMol/MolEnumerator/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/CMakeLists.txt
@@ -12,3 +12,7 @@ LINK_LIBRARIES MolEnumerator SmilesParse FileParsers )
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/MolEnumerator/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/nbWrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+remove_definitions(-DRDKIT_MOLENUMERATOR_BUILD)
+rdkit_python_extension(rdMolEnumerator
+                       rdMolEnumerator.cpp
+                       DEST Chem
+                       LINK_LIBRARIES
+                       MolEnumerator )
+
+add_pytest(pyMolEnumerator ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/MolEnumerator/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolEnumerator/nbWrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 remove_definitions(-DRDKIT_MOLENUMERATOR_BUILD)
-rdkit_python_extension(rdMolEnumerator
-                       rdMolEnumerator.cpp
-                       DEST Chem
-                       LINK_LIBRARIES
-                       MolEnumerator )
+rdkit_nanobind_extension(rdMolEnumerator
+                         rdMolEnumerator.cpp
+                         DEST Chem
+                         LINK_LIBRARIES
+                         MolEnumerator)
 
-add_pytest(pyMolEnumerator ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)
+add_pytest(pyMolEnumerator ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/rough_test.py)

--- a/Code/GraphMol/MolEnumerator/nbWrap/rdMolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/nbWrap/rdMolEnumerator.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2020-2021 Greg Landrum and T5 Informatics GmbH
+//  Copyright (C) 2020-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,95 +8,87 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/python.h>
+#include <nanobind/nanobind.h>
 #include <GraphMol/MolEnumerator/MolEnumerator.h>
 
-#include <RDBoost/Wrap.h>
-
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
+
 namespace {
 
 enum class EnumeratorTypes { LinkNode, PositionVariation, RepeatUnit };
 
 std::shared_ptr<MolEnumerator::MolEnumeratorOp> opFromName(
     EnumeratorTypes typ) {
-  std::shared_ptr<MolEnumerator::MolEnumeratorOp> res;
   switch (typ) {
     case EnumeratorTypes::LinkNode:
-      res.reset(new MolEnumerator::LinkNodeOp());
-      break;
+      return std::make_shared<MolEnumerator::LinkNodeOp>();
     case EnumeratorTypes::PositionVariation:
-      res.reset(new MolEnumerator::PositionVariationOp());
-      break;
+      return std::make_shared<MolEnumerator::PositionVariationOp>();
     case EnumeratorTypes::RepeatUnit:
-      res.reset(new MolEnumerator::RepeatUnitOp());
-      break;
+      return std::make_shared<MolEnumerator::RepeatUnitOp>();
     default:
-      throw ValueErrorException("unrecognized operator type");
+      throw std::invalid_argument("unrecognized operator type");
   }
-  return res;
 }
-MolEnumerator::MolEnumeratorParams *createParamsFromName(EnumeratorTypes typ) {
-  auto res = new MolEnumerator::MolEnumeratorParams();
-  res->dp_operation = opFromName(typ);
-  return res;
-}
-void setEnumerationHelper(MolEnumerator::MolEnumeratorParams *self,
-                          EnumeratorTypes typ) {
-  self->dp_operation = opFromName(typ);
-}
-MolBundle *enumerateHelper1(const ROMol &mol, unsigned int maxPerOperation) {
-  auto res = MolEnumerator::enumerate(mol, maxPerOperation);
-  return new MolBundle(res);
-}
-MolBundle *enumerateHelper2(const ROMol &mol,
-                            const MolEnumerator::MolEnumeratorParams &ps) {
-  auto res = MolEnumerator::enumerate(mol, ps);
-  return new MolBundle(res);
-}
+
 }  // namespace
-BOOST_PYTHON_MODULE(rdMolEnumerator) {
-  python::scope().attr("__doc__") =
-      "Module containing classes and functions for enumerating molecules";
-  python::enum_<EnumeratorTypes>("EnumeratorType")
+
+NB_MODULE(rdMolEnumerator, m) {
+  m.doc() = "Module containing classes and functions for enumerating molecules";
+
+  nb::enum_<EnumeratorTypes>(m, "EnumeratorType")
       .value("LinkNode", EnumeratorTypes::LinkNode)
       .value("PositionVariation", EnumeratorTypes::PositionVariation)
       .value("RepeatUnit", EnumeratorTypes::RepeatUnit);
 
-  python::class_<MolEnumerator::MolEnumeratorParams>(
-      "MolEnumeratorParams", "Molecular enumerator parameters",
-      python::init<>(python::args("self")))
-      .def("__init__", python::make_constructor(createParamsFromName))
-      .def_readwrite("sanitize", &MolEnumerator::MolEnumeratorParams::sanitize,
-                     "sanitize molecules after enumeration")
-      .def_readwrite("maxToEnumerate",
-                     &MolEnumerator::MolEnumeratorParams::maxToEnumerate,
-                     "maximum number of molecules to enumerate")
-      .def_readwrite("doRandom", &MolEnumerator::MolEnumeratorParams::doRandom,
-                     "do random enumeration (not yet implemented")
-      .def_readwrite("randomSeed",
-                     &MolEnumerator::MolEnumeratorParams::randomSeed,
-                     "seed for the random enumeration (not yet implemented")
-      .def("SetEnumerationOperator", &setEnumerationHelper,
-           python::args("self", "typ"),
-           "set the operator to be used for enumeration")
-      .def("__setattr__", &safeSetattr);
-  python::def("Enumerate", &enumerateHelper1,
-              (python::arg("mol"), python::arg("maxPerOperation") = 0),
-              python::return_value_policy<python::manage_new_object>(),
-              R"DOC(do an enumeration and return a MolBundle.
-  If maxPerOperation is >0 that will be used as the maximum number of molecules which 
+  nb::class_<MolEnumerator::MolEnumeratorParams>(m, "MolEnumeratorParams",
+                                                  "Molecular enumerator parameters")
+      .def(nb::init<>())
+      .def("__init__",
+           [](MolEnumerator::MolEnumeratorParams *self, EnumeratorTypes typ) {
+             new (self) MolEnumerator::MolEnumeratorParams();
+             self->dp_operation = opFromName(typ);
+           },
+           "typ"_a)
+      .def_rw("sanitize", &MolEnumerator::MolEnumeratorParams::sanitize,
+              "sanitize molecules after enumeration")
+      .def_rw("maxToEnumerate",
+              &MolEnumerator::MolEnumeratorParams::maxToEnumerate,
+              "maximum number of molecules to enumerate")
+      .def_rw("doRandom", &MolEnumerator::MolEnumeratorParams::doRandom,
+              "do random enumeration (not yet implemented)")
+      .def_rw("randomSeed", &MolEnumerator::MolEnumeratorParams::randomSeed,
+              "seed for the random enumeration (not yet implemented)")
+      .def(
+          "SetEnumerationOperator",
+          [](MolEnumerator::MolEnumeratorParams *self, EnumeratorTypes typ) {
+            self->dp_operation = opFromName(typ);
+          },
+          "typ"_a, "set the operator to be used for enumeration");
+
+  m.def(
+      "Enumerate",
+      [](const ROMol &mol, unsigned int maxPerOperation) {
+        return MolEnumerator::enumerate(mol, maxPerOperation);
+      },
+      "mol"_a, "maxPerOperation"_a = 0u,
+      R"DOC(do an enumeration and return a MolBundle.
+  If maxPerOperation is >0 that will be used as the maximum number of molecules which
     can be returned by any given operation.
 Limitations:
   - the current implementation does not support molecules which include both
     SRUs and LINKNODEs
   - Overlapping SRUs, i.e. where one monomer is contained within another, are
     not supported)DOC");
-  python::def(
-      "Enumerate", &enumerateHelper2,
-      (python::arg("mol"), python::arg("enumParams")),
-      python::return_value_policy<python::manage_new_object>(),
+
+  m.def(
+      "Enumerate",
+      [](const ROMol &mol, const MolEnumerator::MolEnumeratorParams &ps) {
+        return MolEnumerator::enumerate(mol, ps);
+      },
+      "mol"_a, "enumParams"_a,
       R"DOC(do an enumeration for the supplied parameter type and return a MolBundle
 Limitations:
   - Overlapping SRUs, i.e. where one monomer is contained within another, are

--- a/Code/GraphMol/MolEnumerator/nbWrap/rdMolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/nbWrap/rdMolEnumerator.cpp
@@ -1,0 +1,104 @@
+//
+//  Copyright (C) 2020-2021 Greg Landrum and T5 Informatics GmbH
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDBoost/python.h>
+#include <GraphMol/MolEnumerator/MolEnumerator.h>
+
+#include <RDBoost/Wrap.h>
+
+namespace python = boost::python;
+using namespace RDKit;
+namespace {
+
+enum class EnumeratorTypes { LinkNode, PositionVariation, RepeatUnit };
+
+std::shared_ptr<MolEnumerator::MolEnumeratorOp> opFromName(
+    EnumeratorTypes typ) {
+  std::shared_ptr<MolEnumerator::MolEnumeratorOp> res;
+  switch (typ) {
+    case EnumeratorTypes::LinkNode:
+      res.reset(new MolEnumerator::LinkNodeOp());
+      break;
+    case EnumeratorTypes::PositionVariation:
+      res.reset(new MolEnumerator::PositionVariationOp());
+      break;
+    case EnumeratorTypes::RepeatUnit:
+      res.reset(new MolEnumerator::RepeatUnitOp());
+      break;
+    default:
+      throw ValueErrorException("unrecognized operator type");
+  }
+  return res;
+}
+MolEnumerator::MolEnumeratorParams *createParamsFromName(EnumeratorTypes typ) {
+  auto res = new MolEnumerator::MolEnumeratorParams();
+  res->dp_operation = opFromName(typ);
+  return res;
+}
+void setEnumerationHelper(MolEnumerator::MolEnumeratorParams *self,
+                          EnumeratorTypes typ) {
+  self->dp_operation = opFromName(typ);
+}
+MolBundle *enumerateHelper1(const ROMol &mol, unsigned int maxPerOperation) {
+  auto res = MolEnumerator::enumerate(mol, maxPerOperation);
+  return new MolBundle(res);
+}
+MolBundle *enumerateHelper2(const ROMol &mol,
+                            const MolEnumerator::MolEnumeratorParams &ps) {
+  auto res = MolEnumerator::enumerate(mol, ps);
+  return new MolBundle(res);
+}
+}  // namespace
+BOOST_PYTHON_MODULE(rdMolEnumerator) {
+  python::scope().attr("__doc__") =
+      "Module containing classes and functions for enumerating molecules";
+  python::enum_<EnumeratorTypes>("EnumeratorType")
+      .value("LinkNode", EnumeratorTypes::LinkNode)
+      .value("PositionVariation", EnumeratorTypes::PositionVariation)
+      .value("RepeatUnit", EnumeratorTypes::RepeatUnit);
+
+  python::class_<MolEnumerator::MolEnumeratorParams>(
+      "MolEnumeratorParams", "Molecular enumerator parameters",
+      python::init<>(python::args("self")))
+      .def("__init__", python::make_constructor(createParamsFromName))
+      .def_readwrite("sanitize", &MolEnumerator::MolEnumeratorParams::sanitize,
+                     "sanitize molecules after enumeration")
+      .def_readwrite("maxToEnumerate",
+                     &MolEnumerator::MolEnumeratorParams::maxToEnumerate,
+                     "maximum number of molecules to enumerate")
+      .def_readwrite("doRandom", &MolEnumerator::MolEnumeratorParams::doRandom,
+                     "do random enumeration (not yet implemented")
+      .def_readwrite("randomSeed",
+                     &MolEnumerator::MolEnumeratorParams::randomSeed,
+                     "seed for the random enumeration (not yet implemented")
+      .def("SetEnumerationOperator", &setEnumerationHelper,
+           python::args("self", "typ"),
+           "set the operator to be used for enumeration")
+      .def("__setattr__", &safeSetattr);
+  python::def("Enumerate", &enumerateHelper1,
+              (python::arg("mol"), python::arg("maxPerOperation") = 0),
+              python::return_value_policy<python::manage_new_object>(),
+              R"DOC(do an enumeration and return a MolBundle.
+  If maxPerOperation is >0 that will be used as the maximum number of molecules which 
+    can be returned by any given operation.
+Limitations:
+  - the current implementation does not support molecules which include both
+    SRUs and LINKNODEs
+  - Overlapping SRUs, i.e. where one monomer is contained within another, are
+    not supported)DOC");
+  python::def(
+      "Enumerate", &enumerateHelper2,
+      (python::arg("mol"), python::arg("enumParams")),
+      python::return_value_policy<python::manage_new_object>(),
+      R"DOC(do an enumeration for the supplied parameter type and return a MolBundle
+Limitations:
+  - Overlapping SRUs, i.e. where one monomer is contained within another, are
+    not supported)DOC");
+}

--- a/Code/GraphMol/MolEnumerator/nbWrap/rdMolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/nbWrap/rdMolEnumerator.cpp
@@ -75,8 +75,8 @@ NB_MODULE(rdMolEnumerator, m) {
       },
       "mol"_a, "maxPerOperation"_a = 0u,
       R"DOC(do an enumeration and return a MolBundle.
-  If maxPerOperation is >0 that will be used as the maximum number of molecules which
-    can be returned by any given operation.
+If maxPerOperation is >0 that will be used as the maximum number of molecules which
+can be returned by any given operation.
 Limitations:
   - the current implementation does not support molecules which include both
     SRUs and LINKNODEs


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to MolEnumerator.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.
