### PR TITLE
pr/SHARED-12364: Implement nanobind for EnumerateStereoisomers

### DIFF
--- a/Code/GraphMol/EnumerateStereoisomers/CMakeLists.txt
+++ b/Code/GraphMol/EnumerateStereoisomers/CMakeLists.txt
@@ -12,3 +12,7 @@ rdkit_catch_test(testEnumerateStereoisomers catch_tests.cpp
 if (RDK_BUILD_BOOST_PYTHON_WRAPPERS)
     add_subdirectory(Wrap)
 endif ()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/EnumerateStereoisomers/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/EnumerateStereoisomers/nbWrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+remove_definitions(-DRDKIT_ENUMERATESTEREOISOMERS_BUILD)
+
+rdkit_python_extension(rdEnumerateStereoisomers
+        rdEnumerateStereoisomers.cpp
+        DEST Chem
+        LINK_LIBRARIES EnumerateStereoisomers)
+
+add_pytest(pyNewEnumerateStereoisomers ${CMAKE_CURRENT_SOURCE_DIR}/testEnumerateStereoisomers.py)

--- a/Code/GraphMol/EnumerateStereoisomers/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/EnumerateStereoisomers/nbWrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 remove_definitions(-DRDKIT_ENUMERATESTEREOISOMERS_BUILD)
 
-rdkit_python_extension(rdEnumerateStereoisomers
+rdkit_nanobind_extension(rdEnumerateStereoisomers
         rdEnumerateStereoisomers.cpp
         DEST Chem
         LINK_LIBRARIES EnumerateStereoisomers)
 
-add_pytest(pyNewEnumerateStereoisomers ${CMAKE_CURRENT_SOURCE_DIR}/testEnumerateStereoisomers.py)
+add_pytest(pyNewEnumerateStereoisomers ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testEnumerateStereoisomers.py)

--- a/Code/GraphMol/EnumerateStereoisomers/nbWrap/rdEnumerateStereoisomers.cpp
+++ b/Code/GraphMol/EnumerateStereoisomers/nbWrap/rdEnumerateStereoisomers.cpp
@@ -1,0 +1,118 @@
+//
+// Copyright (C) David Cosgrove 2025.
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDBoost/python.h>
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/EnumerateStereoisomers/EnumerateStereoisomers.h>
+
+namespace python = boost::python;
+
+namespace {
+class LocalStereoEnumerator {
+ public:
+  LocalStereoEnumerator() = delete;
+  LocalStereoEnumerator(python::object &py_mol, python::object &py_options,
+                        const bool verbose) {
+    RDKit::EnumerateStereoisomers::StereoEnumerationOptions opts;
+    if (!py_options.is_none()) {
+      opts = python::extract<
+          RDKit::EnumerateStereoisomers::StereoEnumerationOptions>(py_options);
+    }
+    RDKit::ROMol mol = python::extract<RDKit::ROMol>(py_mol);
+    dp_enumerator.reset(
+        new RDKit::EnumerateStereoisomers::StereoisomerEnumerator(mol, opts,
+                                                                  verbose));
+  }
+  LocalStereoEnumerator(const LocalStereoEnumerator &other) = delete;
+  LocalStereoEnumerator(LocalStereoEnumerator &&other) = delete;
+  LocalStereoEnumerator &operator=(const LocalStereoEnumerator &other) = delete;
+  LocalStereoEnumerator &operator=(LocalStereoEnumerator &&other) = delete;
+  ~LocalStereoEnumerator() = default;
+
+  boost::shared_ptr<RDKit::ROMol> next() {
+    auto iso = dp_enumerator->next();
+    if (!iso) {
+      return boost::shared_ptr<RDKit::ROMol>();
+    }
+    return boost::shared_ptr<RDKit::ROMol>(iso.release());
+  }
+
+  unsigned int GetStereoisomerCount() {
+    return dp_enumerator->getStereoisomerCount();
+  }
+
+ private:
+  std::unique_ptr<RDKit::EnumerateStereoisomers::StereoisomerEnumerator>
+      dp_enumerator;
+};
+
+}  // namespace
+namespace RDKit {
+
+BOOST_PYTHON_MODULE(rdEnumerateStereoisomers) {
+  python::scope().attr("__doc__") =
+      "Module containing functions to enumerate stereoisomers of a molecule."
+      "  Chiral centers and double bonds will be enumerated if unassigned, or,"
+      " if the appropriate option is set, if assigned.  Atropisomers will only"
+      " be enumerated if assigned.  There is, as yet, no means of finding "
+      " unassigned atropisomers.";
+
+  std::string docString = "EnumerateSteroisomers options.";
+  python::class_<EnumerateStereoisomers::StereoEnumerationOptions,
+                 boost::noncopyable>("StereoEnumerationOptions",
+                                     docString.c_str())
+      .def_readwrite(
+          "tryEmbedding",
+          &EnumerateStereoisomers::StereoEnumerationOptions::tryEmbedding,
+          "If true, the process attempts to generate a standard RDKit distance geometry"
+          " conformation for the stereoisomer.  If this fails, we assume that the stereoisomer is"
+          " non-physical and don't return it.  NOTE that this is computationally expensive and is"
+          " just a heuristic that could result in stereoisomers being lost.  Default=False")
+      .def_readwrite(
+          "onlyUnassigned",
+          &EnumerateStereoisomers::StereoEnumerationOptions::onlyUnassigned,
+          "If true, stereocenters which have a specified stereochemistry will not be"
+          " perturbed unless they are part of a relative stereo group.  Default=True.")
+      .def_readwrite(
+          "onlyStereoGroups",
+          &EnumerateStereoisomers::StereoEnumerationOptions::onlyStereoGroups,
+          "If true, only find stereoisomers that differ at the StereoGroups associated with"
+          " the molecule.  Default=False.")
+      .def_readwrite(
+          "unique", &EnumerateStereoisomers::StereoEnumerationOptions::unique,
+          "If true, only stereoisomers that differ in canonical CXSmiles will be"
+          " returned.  Default=True.")
+      .def_readwrite(
+          "maxIsomers",
+          &EnumerateStereoisomers::StereoEnumerationOptions::maxIsomers,
+          "The maximum number of isomers to yield.  If the number of possible isomers"
+          " is greater than maxIsomers, a random subset will be yielded.  If 0, there"
+          " is no maximum.  Since every additional stereocenter doubles the number of"
+          " results (and execution time) it's important to keep an eye on this.")
+      .def_readwrite(
+          "randomSeed",
+          &EnumerateStereoisomers::StereoEnumerationOptions::randomSeed,
+          "Seed for random number generator.  Default=-1 means no seed.")
+      .def("__setattr__", &safeSetattr);
+
+  docString = "Stereoisomer enumerator.";
+  python::class_<LocalStereoEnumerator, boost::noncopyable>(
+      "StereoisomerEnumerator", docString.c_str(), python::no_init)
+      .def(python::init<python::object &, python::object &, bool>(
+          (python::arg("options") = python::object(),
+           python::arg("verbose") = true)))
+      .def("next", &LocalStereoEnumerator::next,
+           "Get next isomer in the sequence, or None if at the end.")
+      .def("GetStereoisomerCount", &LocalStereoEnumerator::GetStereoisomerCount,
+           "Get the number of stereoisomers.");
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/EnumerateStereoisomers/nbWrap/rdEnumerateStereoisomers.cpp
+++ b/Code/GraphMol/EnumerateStereoisomers/nbWrap/rdEnumerateStereoisomers.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) David Cosgrove 2025.
+// Copyright (C) 2025-2026 David Cosgrove and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,111 +8,70 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/python.h>
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/unique_ptr.h>
 
 #include <GraphMol/EnumerateStereoisomers/EnumerateStereoisomers.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace RDKit;
+using namespace RDKit::EnumerateStereoisomers;
 
-namespace {
-class LocalStereoEnumerator {
- public:
-  LocalStereoEnumerator() = delete;
-  LocalStereoEnumerator(python::object &py_mol, python::object &py_options,
-                        const bool verbose) {
-    RDKit::EnumerateStereoisomers::StereoEnumerationOptions opts;
-    if (!py_options.is_none()) {
-      opts = python::extract<
-          RDKit::EnumerateStereoisomers::StereoEnumerationOptions>(py_options);
-    }
-    RDKit::ROMol mol = python::extract<RDKit::ROMol>(py_mol);
-    dp_enumerator.reset(
-        new RDKit::EnumerateStereoisomers::StereoisomerEnumerator(mol, opts,
-                                                                  verbose));
-  }
-  LocalStereoEnumerator(const LocalStereoEnumerator &other) = delete;
-  LocalStereoEnumerator(LocalStereoEnumerator &&other) = delete;
-  LocalStereoEnumerator &operator=(const LocalStereoEnumerator &other) = delete;
-  LocalStereoEnumerator &operator=(LocalStereoEnumerator &&other) = delete;
-  ~LocalStereoEnumerator() = default;
+NB_MODULE(rdEnumerateStereoisomers, m) {
+  m.doc() =
+      R"DOC(Module containing functions to enumerate stereoisomers of a molecule.
+Chiral centers and double bonds will be enumerated if unassigned, or,
+if the appropriate option is set, if assigned.  Atropisomers will only
+be enumerated if assigned.  There is, as yet, no means of finding
+unassigned atropisomers.)DOC";
 
-  boost::shared_ptr<RDKit::ROMol> next() {
-    auto iso = dp_enumerator->next();
-    if (!iso) {
-      return boost::shared_ptr<RDKit::ROMol>();
-    }
-    return boost::shared_ptr<RDKit::ROMol>(iso.release());
-  }
+  nb::class_<StereoEnumerationOptions>(m, "StereoEnumerationOptions",
+                                       "EnumerateSteroisomers options.")
+      .def(nb::init<>())
+      .def_rw(
+          "tryEmbedding", &StereoEnumerationOptions::tryEmbedding,
+          R"DOC(If true, the process attempts to generate a standard RDKit distance geometry
+conformation for the stereoisomer.  If this fails, we assume that the stereoisomer is
+non-physical and don't return it.  NOTE that this is computationally expensive and is
+just a heuristic that could result in stereoisomers being lost.  Default=False)DOC")
+      .def_rw(
+          "onlyUnassigned", &StereoEnumerationOptions::onlyUnassigned,
+          R"DOC(If true, stereocenters which have a specified stereochemistry will not be
+perturbed unless they are part of a relative stereo group.  Default=True.)DOC")
+      .def_rw(
+          "onlyStereoGroups", &StereoEnumerationOptions::onlyStereoGroups,
+          R"DOC(If true, only find stereoisomers that differ at the StereoGroups associated with
+the molecule.  Default=False.)DOC")
+      .def_rw(
+          "unique", &StereoEnumerationOptions::unique,
+          R"DOC(If true, only stereoisomers that differ in canonical CXSmiles will be
+returned.  Default=True.)DOC")
+      .def_rw(
+          "maxIsomers", &StereoEnumerationOptions::maxIsomers,
+          R"DOC(The maximum number of isomers to yield.  If the number of possible isomers
+is greater than maxIsomers, a random subset will be yielded.  If 0, there
+is no maximum.  Since every additional stereocenter doubles the number of
+results (and execution time) it's important to keep an eye on this.)DOC")
+      .def_rw("randomSeed", &StereoEnumerationOptions::randomSeed,
+              "Seed for random number generator.  Default=-1 means no seed.");
 
-  unsigned int GetStereoisomerCount() {
-    return dp_enumerator->getStereoisomerCount();
-  }
-
- private:
-  std::unique_ptr<RDKit::EnumerateStereoisomers::StereoisomerEnumerator>
-      dp_enumerator;
-};
-
-}  // namespace
-namespace RDKit {
-
-BOOST_PYTHON_MODULE(rdEnumerateStereoisomers) {
-  python::scope().attr("__doc__") =
-      "Module containing functions to enumerate stereoisomers of a molecule."
-      "  Chiral centers and double bonds will be enumerated if unassigned, or,"
-      " if the appropriate option is set, if assigned.  Atropisomers will only"
-      " be enumerated if assigned.  There is, as yet, no means of finding "
-      " unassigned atropisomers.";
-
-  std::string docString = "EnumerateSteroisomers options.";
-  python::class_<EnumerateStereoisomers::StereoEnumerationOptions,
-                 boost::noncopyable>("StereoEnumerationOptions",
-                                     docString.c_str())
-      .def_readwrite(
-          "tryEmbedding",
-          &EnumerateStereoisomers::StereoEnumerationOptions::tryEmbedding,
-          "If true, the process attempts to generate a standard RDKit distance geometry"
-          " conformation for the stereoisomer.  If this fails, we assume that the stereoisomer is"
-          " non-physical and don't return it.  NOTE that this is computationally expensive and is"
-          " just a heuristic that could result in stereoisomers being lost.  Default=False")
-      .def_readwrite(
-          "onlyUnassigned",
-          &EnumerateStereoisomers::StereoEnumerationOptions::onlyUnassigned,
-          "If true, stereocenters which have a specified stereochemistry will not be"
-          " perturbed unless they are part of a relative stereo group.  Default=True.")
-      .def_readwrite(
-          "onlyStereoGroups",
-          &EnumerateStereoisomers::StereoEnumerationOptions::onlyStereoGroups,
-          "If true, only find stereoisomers that differ at the StereoGroups associated with"
-          " the molecule.  Default=False.")
-      .def_readwrite(
-          "unique", &EnumerateStereoisomers::StereoEnumerationOptions::unique,
-          "If true, only stereoisomers that differ in canonical CXSmiles will be"
-          " returned.  Default=True.")
-      .def_readwrite(
-          "maxIsomers",
-          &EnumerateStereoisomers::StereoEnumerationOptions::maxIsomers,
-          "The maximum number of isomers to yield.  If the number of possible isomers"
-          " is greater than maxIsomers, a random subset will be yielded.  If 0, there"
-          " is no maximum.  Since every additional stereocenter doubles the number of"
-          " results (and execution time) it's important to keep an eye on this.")
-      .def_readwrite(
-          "randomSeed",
-          &EnumerateStereoisomers::StereoEnumerationOptions::randomSeed,
-          "Seed for random number generator.  Default=-1 means no seed.")
-      .def("__setattr__", &safeSetattr);
-
-  docString = "Stereoisomer enumerator.";
-  python::class_<LocalStereoEnumerator, boost::noncopyable>(
-      "StereoisomerEnumerator", docString.c_str(), python::no_init)
-      .def(python::init<python::object &, python::object &, bool>(
-          (python::arg("options") = python::object(),
-           python::arg("verbose") = true)))
-      .def("next", &LocalStereoEnumerator::next,
+  nb::class_<StereoisomerEnumerator>(m, "StereoisomerEnumerator",
+                                     "Stereoisomer enumerator.")
+      .def("__init__",
+           [](StereoisomerEnumerator *self, const ROMol &mol, bool verbose) {
+             new (self)
+                 StereoisomerEnumerator(mol, StereoEnumerationOptions(), verbose);
+           },
+           "mol"_a, "verbose"_a = false)
+      .def("__init__",
+           [](StereoisomerEnumerator *self, const ROMol &mol,
+              const StereoEnumerationOptions &options, bool verbose) {
+             new (self) StereoisomerEnumerator(mol, options, verbose);
+           },
+           "mol"_a, "options"_a, "verbose"_a = false)
+      .def("next", &StereoisomerEnumerator::next,
            "Get next isomer in the sequence, or None if at the end.")
-      .def("GetStereoisomerCount", &LocalStereoEnumerator::GetStereoisomerCount,
+      .def("GetStereoisomerCount", &StereoisomerEnumerator::getStereoisomerCount,
            "Get the number of stereoisomers.");
 }
-
-}  // namespace RDKit


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to EnumerateStereoisomers.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.