### PR TITLE
pr/SHARED-12367: Implement nanobind for MMPA

### DIFF
--- a/Code/GraphMol/MMPA/CMakeLists.txt
+++ b/Code/GraphMol/MMPA/CMakeLists.txt
@@ -18,3 +18,7 @@ rdkit_test(testMMPA MMPA_UnitTest.cpp LINK_LIBRARIES
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/MMPA/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MMPA/nbWrap/CMakeLists.txt
@@ -1,0 +1,7 @@
+remove_definitions(-DRDKIT_MMPA_BUILD)
+rdkit_python_extension(rdMMPA
+                       rdMMPA.cpp
+                       DEST Chem
+                       LINK_LIBRARIES MMPA )
+
+add_pytest(pyMMPA ${CMAKE_CURRENT_SOURCE_DIR}/testMMPA.py)

--- a/Code/GraphMol/MMPA/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MMPA/nbWrap/CMakeLists.txt
@@ -1,7 +1,7 @@
 remove_definitions(-DRDKIT_MMPA_BUILD)
-rdkit_python_extension(rdMMPA
-                       rdMMPA.cpp
-                       DEST Chem
-                       LINK_LIBRARIES MMPA )
+rdkit_nanobind_extension(rdMMPA
+                         rdMMPA.cpp
+                         DEST Chem
+                         LINK_LIBRARIES MMPA SmilesParse)
 
-add_pytest(pyMMPA ${CMAKE_CURRENT_SOURCE_DIR}/testMMPA.py)
+add_pytest(pyMMPA ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testMMPA.py)

--- a/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
@@ -1,0 +1,139 @@
+//
+//  Copyright (C) 2015 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define PY_ARRAY_UNIQUE_SYMBOL rdmmpa_array_API
+#include <boost/python.hpp>
+#include <GraphMol/ROMol.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <RDBoost/Wrap.h>
+#include <GraphMol/MMPA/MMPA.h>
+
+namespace python = boost::python;
+
+namespace {
+python::tuple fragmentMolHelper(const RDKit::ROMol &mol, unsigned int maxCuts,
+                                unsigned int maxCutBonds,
+                                const std::string &pattern,
+                                bool resultsAsMols) {
+  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
+  bool ok = RDKit::MMPA::fragmentMol(mol, tres, maxCuts, maxCutBonds, pattern);
+  python::list pyres;
+  if (ok) {
+    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
+             const_iterator pr = tres.begin();
+         pr != tres.end(); ++pr) {
+      python::list lres;
+      if (resultsAsMols) {
+        lres.append(pr->first);
+        lres.append(pr->second);
+      } else {
+        if (pr->first) {
+          lres.append(RDKit::MolToSmiles(*(pr->first), true));
+        } else {
+          lres.append("");
+        }
+        lres.append(RDKit::MolToSmiles(*(pr->second), true));
+      }
+      pyres.append(python::tuple(lres));
+    }
+  }
+  return python::tuple(pyres);
+}
+
+python::tuple fragmentMolHelper2(const RDKit::ROMol &mol, unsigned int minCuts,
+                                 unsigned int maxCuts, unsigned int maxCutBonds,
+                                 const std::string &pattern,
+                                 bool resultsAsMols) {
+  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
+  bool ok = RDKit::MMPA::fragmentMol(mol, tres, minCuts, maxCuts, maxCutBonds,
+                                     pattern);
+  python::list pyres;
+  if (ok) {
+    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
+             const_iterator pr = tres.begin();
+         pr != tres.end(); ++pr) {
+      python::list lres;
+      if (resultsAsMols) {
+        lres.append(pr->first);
+        lres.append(pr->second);
+      } else {
+        if (pr->first) {
+          lres.append(RDKit::MolToSmiles(*(pr->first), true));
+        } else {
+          lres.append("");
+        }
+        lres.append(RDKit::MolToSmiles(*(pr->second), true));
+      }
+      pyres.append(python::tuple(lres));
+    }
+  }
+  return python::tuple(pyres);
+}
+
+python::tuple fragmentMolHelper3(const RDKit::ROMol &mol, python::object ob,
+                                 unsigned int minCuts, unsigned int maxCuts,
+                                 bool resultsAsMols) {
+  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
+  std::unique_ptr<std::vector<unsigned int>> v =
+      pythonObjectToVect<unsigned int>(ob);
+  if (!v) {
+    throw_value_error("bondsToCut must be non-empty");
+  }
+  bool ok = RDKit::MMPA::fragmentMol(mol, tres, *v, minCuts, maxCuts);
+  python::list pyres;
+  if (ok) {
+    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
+             const_iterator pr = tres.begin();
+         pr != tres.end(); ++pr) {
+      python::list lres;
+      if (resultsAsMols) {
+        lres.append(pr->first);
+        lres.append(pr->second);
+      } else {
+        if (pr->first) {
+          lres.append(RDKit::MolToSmiles(*(pr->first), true));
+        } else {
+          lres.append("");
+        }
+        lres.append(RDKit::MolToSmiles(*(pr->second), true));
+      }
+      pyres.append(python::tuple(lres));
+    }
+  }
+  return python::tuple(pyres);
+}
+
+}  // namespace
+
+BOOST_PYTHON_MODULE(rdMMPA) {
+  python::scope().attr("__doc__") =
+      "Module containing a C++ implementation of code for doing MMPA";
+
+  std::string docString =
+      "Does the fragmentation necessary for an MMPA analysis";
+  python::def("FragmentMol", fragmentMolHelper,
+              (python::arg("mol"), python::arg("maxCuts") = 3,
+               python::arg("maxCutBonds") = 20,
+               python::arg("pattern") = "[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
+               python::arg("resultsAsMols") = true),
+              docString.c_str());
+
+  python::def("FragmentMol", fragmentMolHelper2,
+              (python::arg("mol"), python::arg("minCuts"),
+               python::arg("maxCuts"), python::arg("maxCutBonds"),
+               python::arg("pattern") = "[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
+               python::arg("resultsAsMols") = true),
+              docString.c_str());
+
+  python::def("FragmentMol", fragmentMolHelper3,
+              (python::arg("mol"), python::arg("bondsToCut"),
+               python::arg("minCuts") = 1, python::arg("maxCuts") = 3,
+               python::arg("resultsAsMols") = true),
+              docString.c_str());
+}

--- a/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
@@ -52,7 +52,7 @@ nb::tuple fragmentMolHelper(const RDKit::ROMol &mol, unsigned int maxCuts,
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, maxCuts, maxCutBonds, pattern);
   if (!ok) {
-    return nb::tuple(nb::list());
+    return nb::tuple();
   }
   return buildFragmentResults(tres, resultsAsMols);
 }
@@ -64,7 +64,7 @@ nb::tuple fragmentMolHelper2(const RDKit::ROMol &mol, unsigned int minCuts,
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, minCuts, maxCuts, maxCutBonds,
                                      pattern);
   if (!ok) {
-    return nb::tuple(nb::list());
+    return nb::tuple();
   }
   return buildFragmentResults(tres, resultsAsMols);
 }
@@ -79,7 +79,7 @@ nb::tuple fragmentMolHelper3(const RDKit::ROMol &mol,
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, bondsToCut, minCuts, maxCuts);
   if (!ok) {
-    return nb::tuple(nb::list());
+    return nb::tuple();
   }
   return buildFragmentResults(tres, resultsAsMols);
 }

--- a/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
@@ -9,8 +9,8 @@
 //
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 #include <RDBoost/boost_shared_ptr.h>
-#include <RDBoost/Wrap_nb.h>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/MMPA/MMPA.h>
@@ -20,34 +20,41 @@ using namespace nb::literals;
 
 namespace {
 
+nb::tuple buildFragmentResults(
+    const std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> &tres,
+    bool resultsAsMols) {
+  nb::list pyres;
+  for (const auto &pr : tres) {
+    nb::list lres;
+    if (resultsAsMols) {
+      if (pr.first) {
+        lres.append(pr.first);
+      } else {
+        lres.append(nb::none());
+      }
+      lres.append(pr.second);
+    } else {
+      if (pr.first) {
+        lres.append(RDKit::MolToSmiles(*(pr.first), true));
+      } else {
+        lres.append(std::string(""));
+      }
+      lres.append(RDKit::MolToSmiles(*(pr.second), true));
+    }
+    pyres.append(nb::tuple(lres));
+  }
+  return nb::tuple(pyres);
+}
+
 nb::tuple fragmentMolHelper(const RDKit::ROMol &mol, unsigned int maxCuts,
                             unsigned int maxCutBonds,
                             const std::string &pattern, bool resultsAsMols) {
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, maxCuts, maxCutBonds, pattern);
-  nb::list pyres;
-  if (ok) {
-    for (const auto &pr : tres) {
-      nb::list lres;
-      if (resultsAsMols) {
-        if (pr.first) {
-          lres.append(pr.first);
-        } else {
-          lres.append(nb::none());
-        }
-        lres.append(pr.second);
-      } else {
-        if (pr.first) {
-          lres.append(RDKit::MolToSmiles(*(pr.first), true));
-        } else {
-          lres.append(std::string(""));
-        }
-        lres.append(RDKit::MolToSmiles(*(pr.second), true));
-      }
-      pyres.append(nb::tuple(lres));
-    }
+  if (!ok) {
+    return nb::tuple(nb::list());
   }
-  return nb::steal<nb::tuple>(PySequence_Tuple(pyres.ptr()));
+  return buildFragmentResults(tres, resultsAsMols);
 }
 
 nb::tuple fragmentMolHelper2(const RDKit::ROMol &mol, unsigned int minCuts,
@@ -56,64 +63,25 @@ nb::tuple fragmentMolHelper2(const RDKit::ROMol &mol, unsigned int minCuts,
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, minCuts, maxCuts, maxCutBonds,
                                      pattern);
-  nb::list pyres;
-  if (ok) {
-    for (const auto &pr : tres) {
-      nb::list lres;
-      if (resultsAsMols) {
-        if (pr.first) {
-          lres.append(pr.first);
-        } else {
-          lres.append(nb::none());
-        }
-        lres.append(pr.second);
-      } else {
-        if (pr.first) {
-          lres.append(RDKit::MolToSmiles(*(pr.first), true));
-        } else {
-          lres.append(std::string(""));
-        }
-        lres.append(RDKit::MolToSmiles(*(pr.second), true));
-      }
-      pyres.append(nb::tuple(lres));
-    }
+  if (!ok) {
+    return nb::tuple(nb::list());
   }
-  return nb::steal<nb::tuple>(PySequence_Tuple(pyres.ptr()));
+  return buildFragmentResults(tres, resultsAsMols);
 }
 
-nb::tuple fragmentMolHelper3(const RDKit::ROMol &mol, nb::object ob,
+nb::tuple fragmentMolHelper3(const RDKit::ROMol &mol,
+                             const std::vector<unsigned int> &bondsToCut,
                              unsigned int minCuts, unsigned int maxCuts,
                              bool resultsAsMols) {
-  std::unique_ptr<std::vector<unsigned int>> v =
-      pythonObjectToVect<unsigned int>(ob);
-  if (!v) {
+  if (bondsToCut.empty()) {
     throw nb::value_error("bondsToCut must be non-empty");
   }
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
-  bool ok = RDKit::MMPA::fragmentMol(mol, tres, *v, minCuts, maxCuts);
-  nb::list pyres;
-  if (ok) {
-    for (const auto &pr : tres) {
-      nb::list lres;
-      if (resultsAsMols) {
-        if (pr.first) {
-          lres.append(pr.first);
-        } else {
-          lres.append(nb::none());
-        }
-        lres.append(pr.second);
-      } else {
-        if (pr.first) {
-          lres.append(RDKit::MolToSmiles(*(pr.first), true));
-        } else {
-          lres.append(std::string(""));
-        }
-        lres.append(RDKit::MolToSmiles(*(pr.second), true));
-      }
-      pyres.append(nb::tuple(lres));
-    }
+  bool ok = RDKit::MMPA::fragmentMol(mol, tres, bondsToCut, minCuts, maxCuts);
+  if (!ok) {
+    return nb::tuple(nb::list());
   }
-  return nb::steal<nb::tuple>(PySequence_Tuple(pyres.ptr()));
+  return buildFragmentResults(tres, resultsAsMols);
 }
 
 }  // namespace

--- a/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
+++ b/Code/GraphMol/MMPA/nbWrap/rdMMPA.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2015 Greg Landrum
+//  Copyright (C) 2015-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,133 +7,134 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define PY_ARRAY_UNIQUE_SYMBOL rdmmpa_array_API
-#include <boost/python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <RDBoost/boost_shared_ptr.h>
+#include <RDBoost/Wrap_nb.h>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
-#include <RDBoost/Wrap.h>
 #include <GraphMol/MMPA/MMPA.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace {
-python::tuple fragmentMolHelper(const RDKit::ROMol &mol, unsigned int maxCuts,
-                                unsigned int maxCutBonds,
-                                const std::string &pattern,
-                                bool resultsAsMols) {
+
+nb::tuple fragmentMolHelper(const RDKit::ROMol &mol, unsigned int maxCuts,
+                            unsigned int maxCutBonds,
+                            const std::string &pattern, bool resultsAsMols) {
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, maxCuts, maxCutBonds, pattern);
-  python::list pyres;
+  nb::list pyres;
   if (ok) {
-    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
-             const_iterator pr = tres.begin();
-         pr != tres.end(); ++pr) {
-      python::list lres;
+    for (const auto &pr : tres) {
+      nb::list lres;
       if (resultsAsMols) {
-        lres.append(pr->first);
-        lres.append(pr->second);
-      } else {
-        if (pr->first) {
-          lres.append(RDKit::MolToSmiles(*(pr->first), true));
+        if (pr.first) {
+          lres.append(pr.first);
         } else {
-          lres.append("");
+          lres.append(nb::none());
         }
-        lres.append(RDKit::MolToSmiles(*(pr->second), true));
+        lres.append(pr.second);
+      } else {
+        if (pr.first) {
+          lres.append(RDKit::MolToSmiles(*(pr.first), true));
+        } else {
+          lres.append(std::string(""));
+        }
+        lres.append(RDKit::MolToSmiles(*(pr.second), true));
       }
-      pyres.append(python::tuple(lres));
+      pyres.append(nb::tuple(lres));
     }
   }
-  return python::tuple(pyres);
+  return nb::steal<nb::tuple>(PySequence_Tuple(pyres.ptr()));
 }
 
-python::tuple fragmentMolHelper2(const RDKit::ROMol &mol, unsigned int minCuts,
-                                 unsigned int maxCuts, unsigned int maxCutBonds,
-                                 const std::string &pattern,
-                                 bool resultsAsMols) {
+nb::tuple fragmentMolHelper2(const RDKit::ROMol &mol, unsigned int minCuts,
+                             unsigned int maxCuts, unsigned int maxCutBonds,
+                             const std::string &pattern, bool resultsAsMols) {
   std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, minCuts, maxCuts, maxCutBonds,
                                      pattern);
-  python::list pyres;
+  nb::list pyres;
   if (ok) {
-    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
-             const_iterator pr = tres.begin();
-         pr != tres.end(); ++pr) {
-      python::list lres;
+    for (const auto &pr : tres) {
+      nb::list lres;
       if (resultsAsMols) {
-        lres.append(pr->first);
-        lres.append(pr->second);
-      } else {
-        if (pr->first) {
-          lres.append(RDKit::MolToSmiles(*(pr->first), true));
+        if (pr.first) {
+          lres.append(pr.first);
         } else {
-          lres.append("");
+          lres.append(nb::none());
         }
-        lres.append(RDKit::MolToSmiles(*(pr->second), true));
+        lres.append(pr.second);
+      } else {
+        if (pr.first) {
+          lres.append(RDKit::MolToSmiles(*(pr.first), true));
+        } else {
+          lres.append(std::string(""));
+        }
+        lres.append(RDKit::MolToSmiles(*(pr.second), true));
       }
-      pyres.append(python::tuple(lres));
+      pyres.append(nb::tuple(lres));
     }
   }
-  return python::tuple(pyres);
+  return nb::steal<nb::tuple>(PySequence_Tuple(pyres.ptr()));
 }
 
-python::tuple fragmentMolHelper3(const RDKit::ROMol &mol, python::object ob,
-                                 unsigned int minCuts, unsigned int maxCuts,
-                                 bool resultsAsMols) {
-  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
+nb::tuple fragmentMolHelper3(const RDKit::ROMol &mol, nb::object ob,
+                             unsigned int minCuts, unsigned int maxCuts,
+                             bool resultsAsMols) {
   std::unique_ptr<std::vector<unsigned int>> v =
       pythonObjectToVect<unsigned int>(ob);
   if (!v) {
-    throw_value_error("bondsToCut must be non-empty");
+    throw nb::value_error("bondsToCut must be non-empty");
   }
+  std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>> tres;
   bool ok = RDKit::MMPA::fragmentMol(mol, tres, *v, minCuts, maxCuts);
-  python::list pyres;
+  nb::list pyres;
   if (ok) {
-    for (std::vector<std::pair<RDKit::ROMOL_SPTR, RDKit::ROMOL_SPTR>>::
-             const_iterator pr = tres.begin();
-         pr != tres.end(); ++pr) {
-      python::list lres;
+    for (const auto &pr : tres) {
+      nb::list lres;
       if (resultsAsMols) {
-        lres.append(pr->first);
-        lres.append(pr->second);
-      } else {
-        if (pr->first) {
-          lres.append(RDKit::MolToSmiles(*(pr->first), true));
+        if (pr.first) {
+          lres.append(pr.first);
         } else {
-          lres.append("");
+          lres.append(nb::none());
         }
-        lres.append(RDKit::MolToSmiles(*(pr->second), true));
+        lres.append(pr.second);
+      } else {
+        if (pr.first) {
+          lres.append(RDKit::MolToSmiles(*(pr.first), true));
+        } else {
+          lres.append(std::string(""));
+        }
+        lres.append(RDKit::MolToSmiles(*(pr.second), true));
       }
-      pyres.append(python::tuple(lres));
+      pyres.append(nb::tuple(lres));
     }
   }
-  return python::tuple(pyres);
+  return nb::steal<nb::tuple>(PySequence_Tuple(pyres.ptr()));
 }
 
 }  // namespace
 
-BOOST_PYTHON_MODULE(rdMMPA) {
-  python::scope().attr("__doc__") =
-      "Module containing a C++ implementation of code for doing MMPA";
+NB_MODULE(rdMMPA, m) {
+  m.doc() = "Module containing a C++ implementation of code for doing MMPA";
 
-  std::string docString =
-      "Does the fragmentation necessary for an MMPA analysis";
-  python::def("FragmentMol", fragmentMolHelper,
-              (python::arg("mol"), python::arg("maxCuts") = 3,
-               python::arg("maxCutBonds") = 20,
-               python::arg("pattern") = "[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
-               python::arg("resultsAsMols") = true),
-              docString.c_str());
+  m.def("FragmentMol", fragmentMolHelper,
+        "mol"_a, "maxCuts"_a = 3, "maxCutBonds"_a = 20,
+        "pattern"_a = "[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
+        "resultsAsMols"_a = true,
+        R"DOC(Does the fragmentation necessary for an MMPA analysis)DOC");
 
-  python::def("FragmentMol", fragmentMolHelper2,
-              (python::arg("mol"), python::arg("minCuts"),
-               python::arg("maxCuts"), python::arg("maxCutBonds"),
-               python::arg("pattern") = "[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
-               python::arg("resultsAsMols") = true),
-              docString.c_str());
+  m.def("FragmentMol", fragmentMolHelper2,
+        "mol"_a, "minCuts"_a, "maxCuts"_a, "maxCutBonds"_a,
+        "pattern"_a = "[#6+0;!$(*=,#[!#6])]!@!=!#[*]",
+        "resultsAsMols"_a = true,
+        R"DOC(Does the fragmentation necessary for an MMPA analysis)DOC");
 
-  python::def("FragmentMol", fragmentMolHelper3,
-              (python::arg("mol"), python::arg("bondsToCut"),
-               python::arg("minCuts") = 1, python::arg("maxCuts") = 3,
-               python::arg("resultsAsMols") = true),
-              docString.c_str());
+  m.def("FragmentMol", fragmentMolHelper3,
+        "mol"_a, "bondsToCut"_a, "minCuts"_a = 1, "maxCuts"_a = 3,
+        "resultsAsMols"_a = true,
+        R"DOC(Does the fragmentation necessary for an MMPA analysis)DOC");
 }


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to MMPA.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.