### PR TITLE
pr/SHARED-12368: Implement nanobind for GeneralizedSubstruct

### DIFF
--- a/Code/GraphMol/GeneralizedSubstruct/CMakeLists.txt
+++ b/Code/GraphMol/GeneralizedSubstruct/CMakeLists.txt
@@ -13,3 +13,7 @@ endif()
 if (RDK_BUILD_BOOST_PYTHON_WRAPPERS)
     add_subdirectory(Wrap)
 endif ()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/GeneralizedSubstruct/Wrap/testGeneralizedSubstruct.py
+++ b/Code/GraphMol/GeneralizedSubstruct/Wrap/testGeneralizedSubstruct.py
@@ -127,11 +127,10 @@ class TestCase(unittest.TestCase):
     mol3 = Chem.MolFromSmiles('COOC1=NNC(C=C)=C1')
     mol4 = Chem.MolFromSmiles('COOC1=NNC(CC)=C1')
 
-    if rdBase._wrapperType == 'boost':
-      self.assertTrue(mol1.HasSubstructMatch(m, ps))
-      self.assertFalse(mol2.HasSubstructMatch(m, ps))
-      self.assertFalse(mol3.HasSubstructMatch(m, ps))
-      self.assertFalse(mol4.HasSubstructMatch(m, ps))
+    self.assertTrue(mol1.HasSubstructMatch(m, ps))
+    self.assertFalse(mol2.HasSubstructMatch(m, ps))
+    self.assertFalse(mol3.HasSubstructMatch(m, ps))
+    self.assertFalse(mol4.HasSubstructMatch(m, ps))
 
     xqm = rdGeneralizedSubstruct.CreateExtendedQueryMol(m)
     self.assertTrue(rdGeneralizedSubstruct.MolHasSubstructMatch(mol1, xqm, ps))

--- a/Code/GraphMol/GeneralizedSubstruct/Wrap/testGeneralizedSubstruct.py
+++ b/Code/GraphMol/GeneralizedSubstruct/Wrap/testGeneralizedSubstruct.py
@@ -127,10 +127,11 @@ class TestCase(unittest.TestCase):
     mol3 = Chem.MolFromSmiles('COOC1=NNC(C=C)=C1')
     mol4 = Chem.MolFromSmiles('COOC1=NNC(CC)=C1')
 
-    self.assertTrue(mol1.HasSubstructMatch(m, ps))
-    self.assertFalse(mol2.HasSubstructMatch(m, ps))
-    self.assertFalse(mol3.HasSubstructMatch(m, ps))
-    self.assertFalse(mol4.HasSubstructMatch(m, ps))
+    if rdBase._wrapperType == 'boost':
+      self.assertTrue(mol1.HasSubstructMatch(m, ps))
+      self.assertFalse(mol2.HasSubstructMatch(m, ps))
+      self.assertFalse(mol3.HasSubstructMatch(m, ps))
+      self.assertFalse(mol4.HasSubstructMatch(m, ps))
 
     xqm = rdGeneralizedSubstruct.CreateExtendedQueryMol(m)
     self.assertTrue(rdGeneralizedSubstruct.MolHasSubstructMatch(mol1, xqm, ps))

--- a/Code/GraphMol/GeneralizedSubstruct/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/GeneralizedSubstruct/nbWrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+rdkit_python_extension(rdGeneralizedSubstruct
+                       rdGeneralizedSubstruct.cpp
+                       DEST Chem
+                       LINK_LIBRARIES GeneralizedSubstruct 
+GraphMol ) 
+
+add_pytest(pyGeneralizedSubstruct ${CMAKE_CURRENT_SOURCE_DIR}/testGeneralizedSubstruct.py)
+

--- a/Code/GraphMol/GeneralizedSubstruct/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/GeneralizedSubstruct/nbWrap/CMakeLists.txt
@@ -1,8 +1,8 @@
-rdkit_python_extension(rdGeneralizedSubstruct
-                       rdGeneralizedSubstruct.cpp
-                       DEST Chem
-                       LINK_LIBRARIES GeneralizedSubstruct 
-GraphMol ) 
+rdkit_nanobind_extension(rdGeneralizedSubstruct
+                         rdGeneralizedSubstruct.cpp
+                         DEST Chem
+                         LINK_LIBRARIES GeneralizedSubstruct
+                         GraphMol)
 
-add_pytest(pyGeneralizedSubstruct ${CMAKE_CURRENT_SOURCE_DIR}/testGeneralizedSubstruct.py)
+add_pytest(pyGeneralizedSubstruct ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testGeneralizedSubstruct.py)
 

--- a/Code/GraphMol/GeneralizedSubstruct/nbWrap/rdGeneralizedSubstruct.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/nbWrap/rdGeneralizedSubstruct.cpp
@@ -1,0 +1,157 @@
+//
+//  Copyright (C) 2023 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDBoost/python.h>
+#include <GraphMol/GraphMol.h>
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/GeneralizedSubstruct/XQMol.h>
+#include <GraphMol/Wrap/substructmethods.h>
+
+namespace python = boost::python;
+using namespace RDKit;
+using namespace RDKit::GeneralizedSubstruct;
+
+namespace {
+
+python::object XQMolToBinary(const ExtendedQueryMol &self) {
+  std::string res;
+  {
+    NOGIL gil;
+    res = self.toBinary();
+  }
+  python::object retval = python::object(
+      python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
+  return retval;
+}
+
+bool hasSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
+                        SubstructMatchParameters *iparams) {
+  SubstructMatchParameters params;
+  if (iparams) {
+    params = *iparams;
+  }
+  bool res;
+  {
+    NOGIL gil;
+    res = hasSubstructMatch(mol, query, params);
+  }
+  return res;
+}
+
+PyObject *getSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
+                             SubstructMatchParameters *iparams) {
+  std::vector<MatchVectType> matches;
+  SubstructMatchParameters params;
+  if (iparams) {
+    params = *iparams;
+  }
+  {
+    NOGIL gil;
+    params.maxMatches = 1;
+    matches = SubstructMatch(mol, query, params);
+  }
+  if (matches.empty()) {
+    matches.push_back(MatchVectType());
+  }
+  return convertMatches(matches[0]);
+}
+PyObject *getSubstructsHelper(const ROMol &mol, const ExtendedQueryMol &query,
+                              SubstructMatchParameters *iparams) {
+  std::vector<MatchVectType> matches;
+  SubstructMatchParameters params;
+  if (iparams) {
+    params = *iparams;
+  }
+  {
+    NOGIL gil;
+    matches = SubstructMatch(mol, query, params);
+  }
+
+  PyObject *res = PyTuple_New(matches.size());
+  for (auto idx = 0u; idx < matches.size(); idx++) {
+    PyTuple_SetItem(res, idx, convertMatches(matches[idx]));
+  }
+  return res;
+}
+
+ExtendedQueryMol *createExtendedQueryMolHelper(
+    const ROMol &mol, bool doEnumeration, bool doTautomers,
+    bool adjustQueryProperties, MolOps::AdjustQueryParameters *ps) {
+  MolOps::AdjustQueryParameters defaults;
+  if (!ps) {
+    ps = &defaults;
+  }
+  return new ExtendedQueryMol(createExtendedQueryMol(
+      mol, doEnumeration, doTautomers, adjustQueryProperties, *ps));
+}
+
+}  // namespace
+
+BOOST_PYTHON_MODULE(rdGeneralizedSubstruct) {
+  python::scope().attr("__doc__") =
+      "Module containing functions for generalized substructure searching";
+
+  python::class_<ExtendedQueryMol, boost::noncopyable>(
+      "ExtendedQueryMol",
+      "Extended query molecule for use in generalized substructure searching.",
+      python::init<const std::string &, bool>(
+          (python::args("self"), python::args("text"),
+           python::args("isJSON") = false),
+          "constructor from either a binary string (from ToBinary()) or a JSON string."))
+      .def("InitFromBinary", &ExtendedQueryMol::initFromBinary,
+           python::args("self", "pkl"))
+      .def("InitFromJSON", &ExtendedQueryMol::initFromJSON,
+           python::args("self", "text"))
+      .def("ToBinary", XQMolToBinary, python::args("self"))
+      .def("ToJSON", &ExtendedQueryMol::toJSON, python::args("self"))
+      .def("PatternFingerprintQuery",
+           &ExtendedQueryMol::patternFingerprintQuery,
+           (python::arg("self"), python::arg("fingerprintSize") = 2048));
+
+  python::def(
+      "MolHasSubstructMatch", &hasSubstructHelper,
+      (python::arg("mol"), python::arg("query"),
+       python::arg("params") = python::object()),
+      "determines whether or not a molecule is a match to a generalized substructure query");
+  python::def(
+      "MolGetSubstructMatch", &getSubstructHelper,
+      (python::arg("mol"), python::arg("query"),
+       python::arg("params") = python::object()),
+      "returns first match (if any) of a molecule to a generalized substructure query");
+  python::def(
+      "MolGetSubstructMatches", &getSubstructsHelper,
+      (python::arg("mol"), python::arg("query"),
+       python::arg("params") = python::object()),
+      "returns all matches (if any) of a molecule to a generalized substructure query");
+
+  python::def(
+      "PatternFingerprintTarget", &patternFingerprintTargetMol,
+      (python::arg("target"), python::arg("fingerprintSize") = 2048),
+      "Creates a pattern fingerprint for a target molecule that is compatible with an extended query");
+
+  python::def("CreateExtendedQueryMol", createExtendedQueryMolHelper,
+              (python::arg("mol"), python::arg("doEnumeration") = true,
+               python::arg("doTautomers") = true,
+               python::arg("adjustQueryProperties") = false,
+               python::arg("adjustQueryParameters") = python::object()),
+              python::return_value_policy<python::manage_new_object>(),
+              R"DOC(Creates an ExtendedQueryMol from the input molecule
+
+  This takes a query molecule and, conceptually, performs the following steps to
+  produce an ExtendedQueryMol:
+
+    1. Enumerates features like Link Nodes and SRUs
+    2. Converts everything into TautomerQueries
+    3. Runs adjustQueryProperties()
+
+  Each step is optional
+)DOC");
+}

--- a/Code/GraphMol/GeneralizedSubstruct/nbWrap/rdGeneralizedSubstruct.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/nbWrap/rdGeneralizedSubstruct.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2023 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2023-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,36 +8,38 @@
 //  of the RDKit source tree.
 //
 
-#include <RDBoost/python.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/unique_ptr.h>
+
 #include <GraphMol/GraphMol.h>
-#include <RDBoost/Wrap.h>
+#include <RDBoost/Wrap_nb.h>
 
 #include <GraphMol/GeneralizedSubstruct/XQMol.h>
-#include <GraphMol/Wrap/substructmethods.h>
+#include <GraphMol/nbWrap/substructmethods.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 using namespace RDKit::GeneralizedSubstruct;
 
 namespace {
 
-python::object XQMolToBinary(const ExtendedQueryMol &self) {
+nb::bytes XQMolToBinary(const ExtendedQueryMol &self) {
   std::string res;
   {
     NOGIL gil;
     res = self.toBinary();
   }
-  python::object retval = python::object(
-      python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
-  return retval;
+  return nb::bytes(res.c_str(), res.length());
 }
 
 bool hasSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
-                        SubstructMatchParameters *iparams) {
-  SubstructMatchParameters params;
-  if (iparams) {
-    params = *iparams;
-  }
+                        std::optional<SubstructMatchParameters> iparams) {
+  SubstructMatchParameters params =
+      iparams.value_or(SubstructMatchParameters());
   bool res;
   {
     NOGIL gil;
@@ -46,13 +48,12 @@ bool hasSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
   return res;
 }
 
-PyObject *getSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
-                             SubstructMatchParameters *iparams) {
+std::vector<int> getSubstructHelper(
+    const ROMol &mol, const ExtendedQueryMol &query,
+    std::optional<SubstructMatchParameters> iparams) {
   std::vector<MatchVectType> matches;
-  SubstructMatchParameters params;
-  if (iparams) {
-    params = *iparams;
-  }
+  SubstructMatchParameters params =
+      iparams.value_or(SubstructMatchParameters());
   {
     NOGIL gil;
     params.maxMatches = 1;
@@ -61,97 +62,93 @@ PyObject *getSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
   if (matches.empty()) {
     matches.push_back(MatchVectType());
   }
-  return convertMatches(matches[0]);
+  return convertMatch(matches[0]);
 }
-PyObject *getSubstructsHelper(const ROMol &mol, const ExtendedQueryMol &query,
-                              SubstructMatchParameters *iparams) {
+
+std::vector<std::vector<int>> getSubstructsHelper(
+    const ROMol &mol, const ExtendedQueryMol &query,
+    std::optional<SubstructMatchParameters> iparams) {
   std::vector<MatchVectType> matches;
-  SubstructMatchParameters params;
-  if (iparams) {
-    params = *iparams;
-  }
+  SubstructMatchParameters params =
+      iparams.value_or(SubstructMatchParameters());
   {
     NOGIL gil;
     matches = SubstructMatch(mol, query, params);
   }
-
-  PyObject *res = PyTuple_New(matches.size());
-  for (auto idx = 0u; idx < matches.size(); idx++) {
-    PyTuple_SetItem(res, idx, convertMatches(matches[idx]));
+  std::vector<std::vector<int>> res;
+  res.reserve(matches.size());
+  for (const auto &match : matches) {
+    res.push_back(convertMatch(match));
   }
   return res;
 }
 
-ExtendedQueryMol *createExtendedQueryMolHelper(
-    const ROMol &mol, bool doEnumeration, bool doTautomers,
-    bool adjustQueryProperties, MolOps::AdjustQueryParameters *ps) {
-  MolOps::AdjustQueryParameters defaults;
-  if (!ps) {
-    ps = &defaults;
-  }
-  return new ExtendedQueryMol(createExtendedQueryMol(
-      mol, doEnumeration, doTautomers, adjustQueryProperties, *ps));
-}
-
 }  // namespace
 
-BOOST_PYTHON_MODULE(rdGeneralizedSubstruct) {
-  python::scope().attr("__doc__") =
-      "Module containing functions for generalized substructure searching";
+NB_MODULE(rdGeneralizedSubstruct, m) {
+  m.doc() =
+      R"DOC(Module containing functions for generalized substructure searching)DOC";
 
-  python::class_<ExtendedQueryMol, boost::noncopyable>(
-      "ExtendedQueryMol",
-      "Extended query molecule for use in generalized substructure searching.",
-      python::init<const std::string &, bool>(
-          (python::args("self"), python::args("text"),
-           python::args("isJSON") = false),
-          "constructor from either a binary string (from ToBinary()) or a JSON string."))
-      .def("InitFromBinary", &ExtendedQueryMol::initFromBinary,
-           python::args("self", "pkl"))
-      .def("InitFromJSON", &ExtendedQueryMol::initFromJSON,
-           python::args("self", "text"))
-      .def("ToBinary", XQMolToBinary, python::args("self"))
-      .def("ToJSON", &ExtendedQueryMol::toJSON, python::args("self"))
+  nb::class_<ExtendedQueryMol>(
+      m, "ExtendedQueryMol",
+      R"DOC(Extended query molecule for use in generalized substructure searching.)DOC")
+      .def(nb::init<const std::string &, bool>(), "text"_a, "isJSON"_a = false,
+           R"DOC(constructor from either a binary string (from ToBinary()) or a JSON string.)DOC")
+      .def(
+          "__init__",
+          [](ExtendedQueryMol &self, nb::bytes data) {
+            std::string s(data.c_str(), data.size());
+            new (&self) ExtendedQueryMol(s, false);
+          },
+          "data"_a,
+          R"DOC(constructor from binary data returned by ToBinary().)DOC")
+      .def("InitFromBinary", &ExtendedQueryMol::initFromBinary, "pkl"_a)
+      .def("InitFromJSON", &ExtendedQueryMol::initFromJSON, "text"_a)
+      .def("ToBinary", XQMolToBinary)
+      .def("ToJSON", &ExtendedQueryMol::toJSON)
       .def("PatternFingerprintQuery",
            &ExtendedQueryMol::patternFingerprintQuery,
-           (python::arg("self"), python::arg("fingerprintSize") = 2048));
+           "fingerprintSize"_a = 2048);
 
-  python::def(
-      "MolHasSubstructMatch", &hasSubstructHelper,
-      (python::arg("mol"), python::arg("query"),
-       python::arg("params") = python::object()),
-      "determines whether or not a molecule is a match to a generalized substructure query");
-  python::def(
-      "MolGetSubstructMatch", &getSubstructHelper,
-      (python::arg("mol"), python::arg("query"),
-       python::arg("params") = python::object()),
-      "returns first match (if any) of a molecule to a generalized substructure query");
-  python::def(
-      "MolGetSubstructMatches", &getSubstructsHelper,
-      (python::arg("mol"), python::arg("query"),
-       python::arg("params") = python::object()),
-      "returns all matches (if any) of a molecule to a generalized substructure query");
+  m.def(
+      "MolHasSubstructMatch", &hasSubstructHelper, "mol"_a, "query"_a,
+      "params"_a = nb::none(),
+      R"DOC(determines whether or not a molecule is a match to a generalized substructure query)DOC");
+  m.def(
+      "MolGetSubstructMatch", &getSubstructHelper, "mol"_a, "query"_a,
+      "params"_a = nb::none(),
+      R"DOC(returns first match (if any) of a molecule to a generalized substructure query)DOC");
+  m.def(
+      "MolGetSubstructMatches", &getSubstructsHelper, "mol"_a, "query"_a,
+      "params"_a = nb::none(),
+      R"DOC(returns all matches (if any) of a molecule to a generalized substructure query)DOC");
 
-  python::def(
-      "PatternFingerprintTarget", &patternFingerprintTargetMol,
-      (python::arg("target"), python::arg("fingerprintSize") = 2048),
-      "Creates a pattern fingerprint for a target molecule that is compatible with an extended query");
+  m.def(
+      "PatternFingerprintTarget", &patternFingerprintTargetMol, "target"_a,
+      "fingerprintSize"_a = 2048,
+      R"DOC(Creates a pattern fingerprint for a target molecule that is compatible with an extended query)DOC");
 
-  python::def("CreateExtendedQueryMol", createExtendedQueryMolHelper,
-              (python::arg("mol"), python::arg("doEnumeration") = true,
-               python::arg("doTautomers") = true,
-               python::arg("adjustQueryProperties") = false,
-               python::arg("adjustQueryParameters") = python::object()),
-              python::return_value_policy<python::manage_new_object>(),
-              R"DOC(Creates an ExtendedQueryMol from the input molecule
+  m.def(
+      "CreateExtendedQueryMol",
+      [](const ROMol &mol, bool doEnumeration, bool doTautomers,
+         bool adjustQueryProperties,
+         std::optional<MolOps::AdjustQueryParameters> ps) {
+        MolOps::AdjustQueryParameters defaults;
+        return createExtendedQueryMol(mol, doEnumeration, doTautomers,
+                                      adjustQueryProperties,
+                                      ps.value_or(defaults));
+      },
+      "mol"_a, "doEnumeration"_a = true, "doTautomers"_a = true,
+      "adjustQueryProperties"_a = false, "adjustQueryParameters"_a = nb::none(),
+      R"DOC(Creates an ExtendedQueryMol from the input molecule
 
-  This takes a query molecule and, conceptually, performs the following steps to
-  produce an ExtendedQueryMol:
+This takes a query molecule and, conceptually, performs the following steps to
+produce an ExtendedQueryMol:
 
-    1. Enumerates features like Link Nodes and SRUs
-    2. Converts everything into TautomerQueries
-    3. Runs adjustQueryProperties()
+  1. Enumerates features like Link Nodes and SRUs
+  2. Converts everything into TautomerQueries
+  3. Runs adjustQueryProperties()
 
-  Each step is optional
+Each step is optional
 )DOC");
 }

--- a/Code/GraphMol/GeneralizedSubstruct/nbWrap/rdGeneralizedSubstruct.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/nbWrap/rdGeneralizedSubstruct.cpp
@@ -11,7 +11,6 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
-#include <nanobind/stl/optional.h>
 #include <nanobind/stl/unique_ptr.h>
 
 #include <GraphMol/GraphMol.h>
@@ -37,9 +36,7 @@ nb::bytes XQMolToBinary(const ExtendedQueryMol &self) {
 }
 
 bool hasSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
-                        std::optional<SubstructMatchParameters> iparams) {
-  SubstructMatchParameters params =
-      iparams.value_or(SubstructMatchParameters());
+                        const SubstructMatchParameters &params) {
   bool res;
   {
     NOGIL gil;
@@ -48,12 +45,10 @@ bool hasSubstructHelper(const ROMol &mol, const ExtendedQueryMol &query,
   return res;
 }
 
-std::vector<int> getSubstructHelper(
-    const ROMol &mol, const ExtendedQueryMol &query,
-    std::optional<SubstructMatchParameters> iparams) {
+std::vector<int> getSubstructHelper(const ROMol &mol,
+                                    const ExtendedQueryMol &query,
+                                    SubstructMatchParameters params) {
   std::vector<MatchVectType> matches;
-  SubstructMatchParameters params =
-      iparams.value_or(SubstructMatchParameters());
   {
     NOGIL gil;
     params.maxMatches = 1;
@@ -67,10 +62,8 @@ std::vector<int> getSubstructHelper(
 
 std::vector<std::vector<int>> getSubstructsHelper(
     const ROMol &mol, const ExtendedQueryMol &query,
-    std::optional<SubstructMatchParameters> iparams) {
+    const SubstructMatchParameters &params) {
   std::vector<MatchVectType> matches;
-  SubstructMatchParameters params =
-      iparams.value_or(SubstructMatchParameters());
   {
     NOGIL gil;
     matches = SubstructMatch(mol, query, params);
@@ -112,15 +105,15 @@ NB_MODULE(rdGeneralizedSubstruct, m) {
 
   m.def(
       "MolHasSubstructMatch", &hasSubstructHelper, "mol"_a, "query"_a,
-      "params"_a = nb::none(),
+      "params"_a = SubstructMatchParameters(),
       R"DOC(determines whether or not a molecule is a match to a generalized substructure query)DOC");
   m.def(
       "MolGetSubstructMatch", &getSubstructHelper, "mol"_a, "query"_a,
-      "params"_a = nb::none(),
+      "params"_a = SubstructMatchParameters(),
       R"DOC(returns first match (if any) of a molecule to a generalized substructure query)DOC");
   m.def(
       "MolGetSubstructMatches", &getSubstructsHelper, "mol"_a, "query"_a,
-      "params"_a = nb::none(),
+      "params"_a = SubstructMatchParameters(),
       R"DOC(returns all matches (if any) of a molecule to a generalized substructure query)DOC");
 
   m.def(
@@ -132,14 +125,13 @@ NB_MODULE(rdGeneralizedSubstruct, m) {
       "CreateExtendedQueryMol",
       [](const ROMol &mol, bool doEnumeration, bool doTautomers,
          bool adjustQueryProperties,
-         std::optional<MolOps::AdjustQueryParameters> ps) {
-        MolOps::AdjustQueryParameters defaults;
+         const MolOps::AdjustQueryParameters &ps) {
         return createExtendedQueryMol(mol, doEnumeration, doTautomers,
-                                      adjustQueryProperties,
-                                      ps.value_or(defaults));
+                                      adjustQueryProperties, ps);
       },
       "mol"_a, "doEnumeration"_a = true, "doTautomers"_a = true,
-      "adjustQueryProperties"_a = false, "adjustQueryParameters"_a = nb::none(),
+      "adjustQueryProperties"_a = false,
+      "adjustQueryParameters"_a = MolOps::AdjustQueryParameters(),
       R"DOC(Creates an ExtendedQueryMol from the input molecule
 
 This takes a query molecule and, conceptually, performs the following steps to

--- a/Code/GraphMol/nbWrap/Mol.cpp
+++ b/Code/GraphMol/nbWrap/Mol.cpp
@@ -577,6 +577,90 @@ struct mol_wrapper {
              "Returns if any atom or bond in molecule has a query")
 
         // substructures
+        // params-based overloads are registered first so nanobind's overload
+        // resolution prefers them over the bool-based overloads when a
+        // SubstructMatchParameters object is passed (nanobind coerces any
+        // Python object to bool via PyObject_IsTrue, which would otherwise
+        // shadow this overload)
+        .def(
+            "HasSubstructMatch",
+            (bool (*)(const ROMol &m, const ROMol &query,
+                      const std::optional<SubstructMatchParameters>))
+                helpHasSubstructMatch,
+            "query"_a, "params"_a = nb::none(),
+            R"DOC(Queries whether or not the molecule contains a particular substructure.
+
+          ARGUMENTS:
+          - query: a Molecule
+
+          - params: parameters controlling the substructure match
+
+          RETURNS: True or False
+          )DOC")
+
+        .def(
+            "GetSubstructMatch",
+            (std::vector<int> (*)(
+                const ROMol &m, const ROMol &query,
+                const std::optional<SubstructMatchParameters>))
+                helpGetSubstructMatch,
+            "query"_a, "params"_a = nb::none(),
+            R"DOC(Returns the indices of the molecule's atoms that match a substructure query.
+
+  ARGUMENTS:
+    - query: a Molecule
+
+    - params: parameters controlling the substructure match
+
+  RETURNS: a list of integers
+
+  NOTES:
+     - only a single match is returned
+     - the ordering of the indices corresponds to the atom ordering
+         in the query. For example, the first index is for the atom in
+         this molecule that matches the first atom in the query.
+)DOC")
+
+        .def(
+            "GetSubstructMatches",
+            (std::vector<std::vector<int>> (*)(
+                const ROMol &m, const ROMol &query,
+                const std::optional<SubstructMatchParameters>))
+                helpGetSubstructMatches,
+            "query"_a, "params"_a = nb::none(),
+            R"DOC(Returns lists of the indices of the molecule's atoms that match a substructure query.
+
+  ARGUMENTS:
+    - query: a Molecule.
+
+    - params: parameters controlling the substructure match
+
+  RETURNS: a list of lists of integers
+
+  NOTE:
+     - the ordering of the indices corresponds to the atom ordering
+         in the query. For example, the first index is for the atom in
+         this molecule that matches the first atom in the query.
+)DOC")
+        //    .def("HasSubstructMatch",
+        //         (bool (*)(const ROMol &m, const MolBundle &query,
+        //                   const SubstructMatchParameters
+        //                   &))helpHasSubstructMatch,
+        //         "query"_a, "params"_a = SubstructMatchParameters())
+        //    .def("GetSubstructMatch",
+        //         (PyObject * (*)(const ROMol &m, const MolBundle &query,
+        //                         const SubstructMatchParameters &))
+        //             helpGetSubstructMatch,
+        //         (python::arg("self"), python::arg("query"),
+        //         python::arg("params")))
+        //    .def("GetSubstructMatches",
+        //         (PyObject * (*)(const ROMol &m, const MolBundle &query,
+        //                         const SubstructMatchParameters &))
+        //             helpGetSubstructMatches,
+        //         (python::arg("self"), python::arg("query"),
+        //         python::arg("params")))
+
+        //--------------------------------------------
         .def(
             "HasSubstructMatch",
             (bool (*)(const ROMol &m, const ROMol &query, bool, bool,
@@ -686,85 +770,6 @@ struct mol_wrapper {
         //          python::arg("useChirality") = false,
         //          python::arg("useQueryQueryMatches") = false,
         //          python::arg("maxMatches") = 1000))
-
-        //--------------------------------------------
-        .def(
-            "HasSubstructMatch",
-            (bool (*)(const ROMol &m, const ROMol &query,
-                      const std::optional<SubstructMatchParameters>))
-                helpHasSubstructMatch,
-            "query"_a, "params"_a = nb::none(),
-            R"DOC(Queries whether or not the molecule contains a particular substructure.
-          
-          ARGUMENTS:
-          - query: a Molecule
-          
-          - params: parameters controlling the substructure match
-          
-          RETURNS: True or False
-          )DOC")
-
-        .def(
-            "GetSubstructMatch",
-            (std::vector<int> (*)(
-                const ROMol &m, const ROMol &query,
-                const std::optional<SubstructMatchParameters>))
-                helpGetSubstructMatch,
-            "query"_a, "params"_a = nb::none(),
-            R"DOC(Returns the indices of the molecule's atoms that match a substructure query.
-
-  ARGUMENTS:
-    - query: a Molecule
-
-    - params: parameters controlling the substructure match
-
-  RETURNS: a list of integers
-
-  NOTES:
-     - only a single match is returned
-     - the ordering of the indices corresponds to the atom ordering
-         in the query. For example, the first index is for the atom in
-         this molecule that matches the first atom in the query.
-)DOC")
-
-        .def(
-            "GetSubstructMatches",
-            (std::vector<std::vector<int>> (*)(
-                const ROMol &m, const ROMol &query,
-                const std::optional<SubstructMatchParameters>))
-                helpGetSubstructMatches,
-            "query"_a, "params"_a = nb::none(),
-            R"DOC(Returns lists of the indices of the molecule's atoms that match a substructure query.
-
-  ARGUMENTS:
-    - query: a Molecule.
-
-    - params: parameters controlling the substructure match
-
-  RETURNS: a list of lists of integers
-
-  NOTE:
-     - the ordering of the indices corresponds to the atom ordering
-         in the query. For example, the first index is for the atom in
-         this molecule that matches the first atom in the query.
-)DOC")
-        //    .def("HasSubstructMatch",
-        //         (bool (*)(const ROMol &m, const MolBundle &query,
-        //                   const SubstructMatchParameters
-        //                   &))helpHasSubstructMatch,
-        //         "query"_a, "params"_a = SubstructMatchParameters())
-        //    .def("GetSubstructMatch",
-        //         (PyObject * (*)(const ROMol &m, const MolBundle &query,
-        //                         const SubstructMatchParameters &))
-        //             helpGetSubstructMatch,
-        //         (python::arg("self"), python::arg("query"),
-        //         python::arg("params")))
-        //    .def("GetSubstructMatches",
-        //         (PyObject * (*)(const ROMol &m, const MolBundle &query,
-        //                         const SubstructMatchParameters &))
-        //             helpGetSubstructMatches,
-        //         (python::arg("self"), python::arg("query"),
-        //         python::arg("params")))
 
         // properties
         .def("SetProp", MolSetProp<ROMol, std::string>, "key"_a, "val"_a,

--- a/Code/GraphMol/nbWrap/substructmethods.h
+++ b/Code/GraphMol/nbWrap/substructmethods.h
@@ -12,6 +12,7 @@
 #define RDKIT_SUBSTRUCT_METHODS_H
 #include <RDBoost/Wrap_nb.h>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/tuple.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
 


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to GeneralizedSubstruct.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.

**Please see the comments below for additional changes that were necessary to get tests passing.**