### PR TITLE
pr/SHARED-12369: Implement nanobind for StructChecker

### DIFF
--- a/Code/GraphMol/StructChecker/CMakeLists.txt
+++ b/Code/GraphMol/StructChecker/CMakeLists.txt
@@ -13,5 +13,9 @@ if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
 
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()
+
 rdkit_test(testStructChecker  testStructChecker.cpp 
            LINK_LIBRARIES StructChecker SmilesParse )

--- a/Code/GraphMol/StructChecker/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/StructChecker/nbWrap/CMakeLists.txt
@@ -1,0 +1,6 @@
+remove_definitions(-DRDKIT_STRUCTCHECKER_BUILD)
+rdkit_python_extension(rdStructChecker
+        structchecker.cpp
+        DEST Chem
+        LINK_LIBRARIES StructChecker )
+add_pytest(pyStructChecker ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)

--- a/Code/GraphMol/StructChecker/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/StructChecker/nbWrap/CMakeLists.txt
@@ -1,6 +1,6 @@
 remove_definitions(-DRDKIT_STRUCTCHECKER_BUILD)
-rdkit_python_extension(rdStructChecker
+rdkit_nanobind_extension(rdStructChecker
         structchecker.cpp
         DEST Chem
         LINK_LIBRARIES StructChecker )
-add_pytest(pyStructChecker ${CMAKE_CURRENT_SOURCE_DIR}/rough_test.py)
+add_pytest(pyStructChecker ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/rough_test.py)

--- a/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
+++ b/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
@@ -1,0 +1,159 @@
+//  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <RDBoost/python.h>
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/StructChecker/StructChecker.h>
+#include <GraphMol/RDKitBase.h>
+
+namespace python = boost::python;
+
+namespace RDKit {
+namespace StructureCheck {
+unsigned int checkMolStructureHelper(const StructChecker &checker, ROMol &m) {
+  RWMol &fixer = static_cast<RWMol &>(m);
+  return checker.checkMolStructure(fixer);
+}
+}  // namespace StructureCheck
+}  // namespace RDKit
+
+struct struct_wrapper {
+  static void wrap() {
+    python::enum_<RDKit::StructureCheck::StructChecker::StructureFlags>(
+        "StructureFlags")
+        .value("NO_CHANGE", RDKit::StructureCheck::StructChecker::NO_CHANGE)
+        .value("BAD_MOLECULE",
+               RDKit::StructureCheck::StructChecker::BAD_MOLECULE)
+        .value("ALIAS_CONVERSION_FAILED",
+               RDKit::StructureCheck::StructChecker::ALIAS_CONVERSION_FAILED)
+        .value("STEREO_ERROR",
+               RDKit::StructureCheck::StructChecker::STEREO_ERROR)
+        .value("STEREO_FORCED_BAD",
+               RDKit::StructureCheck::StructChecker::STEREO_FORCED_BAD)
+        .value("ATOM_CLASH", RDKit::StructureCheck::StructChecker::ATOM_CLASH)
+        .value("ATOM_CHECK_FAILED",
+               RDKit::StructureCheck::StructChecker::ATOM_CHECK_FAILED)
+        .value("SIZE_CHECK_FAILED",
+               RDKit::StructureCheck::StructChecker::SIZE_CHECK_FAILED)
+        .value("TRANSFORMED", RDKit::StructureCheck::StructChecker::TRANSFORMED)
+        .value("FRAGMENTS_FOUND",
+               RDKit::StructureCheck::StructChecker::FRAGMENTS_FOUND)
+        .value("EITHER_WARNING",
+               RDKit::StructureCheck::StructChecker::EITHER_WARNING)
+        .value("DUBIOUS_STEREO_REMOVED",
+               RDKit::StructureCheck::StructChecker::DUBIOUS_STEREO_REMOVED)
+        .value("RECHARGED", RDKit::StructureCheck::StructChecker::RECHARGED)
+        .value("STEREO_TRANSFORMED",
+               RDKit::StructureCheck::StructChecker::STEREO_TRANSFORMED)
+        .value("TEMPLATE_TRANSFORMED",
+               RDKit::StructureCheck::StructChecker::TEMPLATE_TRANSFORMED)
+        .value("TAUTOMER_TRANSFORMED",
+               RDKit::StructureCheck::StructChecker::TAUTOMER_TRANSFORMED);
+
+    python::class_<RDKit::StructureCheck::StructCheckerOptions,
+                   RDKit::StructureCheck::StructCheckerOptions *>(
+        "StructCheckerOptions", python::init<>())
+        .def_readwrite(
+            "AcidityLimit",
+            &RDKit::StructureCheck::StructCheckerOptions::AcidityLimit)
+        .def_readwrite(
+            "RemoveMinorFragments",
+            &RDKit::StructureCheck::StructCheckerOptions::RemoveMinorFragments)
+        .def_readwrite(
+            "DesiredCharge",
+            &RDKit::StructureCheck::StructCheckerOptions::DesiredCharge)
+        .def_readwrite(
+            "CheckCollisions",
+            &RDKit::StructureCheck::StructCheckerOptions::CheckCollisions)
+        .def_readwrite(
+            "CollisionLimitPercent",
+            &RDKit::StructureCheck::StructCheckerOptions::CollisionLimitPercent)
+        .def_readwrite("MaxMolSize",
+                       &RDKit::StructureCheck::StructCheckerOptions::MaxMolSize)
+        .def_readwrite(
+            "ConvertSText",
+            &RDKit::StructureCheck::StructCheckerOptions::ConvertSText)
+        .def_readwrite("StripZeros",
+                       &RDKit::StructureCheck::StructCheckerOptions::StripZeros)
+        .def_readwrite(
+            "CheckStereo",
+            &RDKit::StructureCheck::StructCheckerOptions::CheckStereo)
+        .def_readwrite(
+            "ConvertAtomTexts",
+            &RDKit::StructureCheck::StructCheckerOptions::ConvertAtomTexts)
+        .def_readwrite(
+            "GroupsToSGroups",
+            &RDKit::StructureCheck::StructCheckerOptions::GroupsToSGroups)
+        .def_readwrite("Verbose",
+                       &RDKit::StructureCheck::StructCheckerOptions::Verbose)
+        .def(
+            "LoadGoodAugmentedAtoms",
+            &RDKit::StructureCheck::StructCheckerOptions::
+                loadGoodAugmentedAtoms,
+            (python::arg("path")),
+            "Load the set of good augmented atoms from the specified file path")
+        .def("LoadAcidicAugmentedAtoms",
+             &RDKit::StructureCheck::StructCheckerOptions::
+                 loadAcidicAugmentedAtoms,
+             (python::arg("path")),
+             "Load the set of acidic augmented atoms from the specified file "
+             "path")
+        .def("LoadAugmentedAtomTranslations",
+             &RDKit::StructureCheck::StructCheckerOptions::
+                 loadAugmentedAtomTranslations,
+             (python::arg("path")),
+             "Load the set of acidic augmented atoms from the specified file "
+             "path");
+
+    python::class_<RDKit::StructureCheck::StructChecker>("StructChecker",
+                                                         python::init<>())
+        .def(
+            python::init<const RDKit::StructureCheck::StructCheckerOptions &>())
+        .def("CheckMolStructure",
+             &RDKit::StructureCheck::checkMolStructureHelper,
+             (python::arg("mol")),
+             "Check the structure and return a set of structure flags")
+        .def("StructureFlagsToString",
+             &RDKit::StructureCheck::StructChecker::StructureFlagsToString,
+             (python::arg("flags")),
+             "Return the structure flags as a human readable string")
+        .staticmethod("StructureFlagsToString")
+        .def("StringToStructureFlags",
+             &RDKit::StructureCheck::StructChecker::StringToStructureFlags,
+             (python::arg("str")),
+             "Convert a comma separated string to the appropriate structure "
+             "flags")
+        .staticmethod("StringToStructureFlags");
+  }
+};
+
+BOOST_PYTHON_MODULE(rdStructChecker) { struct_wrapper::wrap(); }

--- a/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
+++ b/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
@@ -17,107 +17,69 @@
 
 namespace nb = nanobind;
 using namespace nb::literals;
+using namespace RDKit;
+using namespace RDKit::StructureCheck;
 
 NB_MODULE(rdStructChecker, m) {
-  nb::enum_<RDKit::StructureCheck::StructChecker::StructureFlags>(
-      m, "StructureFlags")
-      .value("NO_CHANGE", RDKit::StructureCheck::StructChecker::NO_CHANGE)
-      .value("BAD_MOLECULE",
-             RDKit::StructureCheck::StructChecker::BAD_MOLECULE)
-      .value("ALIAS_CONVERSION_FAILED",
-             RDKit::StructureCheck::StructChecker::ALIAS_CONVERSION_FAILED)
-      .value("STEREO_ERROR",
-             RDKit::StructureCheck::StructChecker::STEREO_ERROR)
-      .value("STEREO_FORCED_BAD",
-             RDKit::StructureCheck::StructChecker::STEREO_FORCED_BAD)
-      .value("ATOM_CLASH", RDKit::StructureCheck::StructChecker::ATOM_CLASH)
-      .value("ATOM_CHECK_FAILED",
-             RDKit::StructureCheck::StructChecker::ATOM_CHECK_FAILED)
-      .value("SIZE_CHECK_FAILED",
-             RDKit::StructureCheck::StructChecker::SIZE_CHECK_FAILED)
-      .value("TRANSFORMED", RDKit::StructureCheck::StructChecker::TRANSFORMED)
-      .value("FRAGMENTS_FOUND",
-             RDKit::StructureCheck::StructChecker::FRAGMENTS_FOUND)
-      .value("EITHER_WARNING",
-             RDKit::StructureCheck::StructChecker::EITHER_WARNING)
-      .value("DUBIOUS_STEREO_REMOVED",
-             RDKit::StructureCheck::StructChecker::DUBIOUS_STEREO_REMOVED)
-      .value("RECHARGED", RDKit::StructureCheck::StructChecker::RECHARGED)
-      .value("STEREO_TRANSFORMED",
-             RDKit::StructureCheck::StructChecker::STEREO_TRANSFORMED)
-      .value("TEMPLATE_TRANSFORMED",
-             RDKit::StructureCheck::StructChecker::TEMPLATE_TRANSFORMED)
-      .value("TAUTOMER_TRANSFORMED",
-             RDKit::StructureCheck::StructChecker::TAUTOMER_TRANSFORMED);
+  nb::enum_<StructChecker::StructureFlags>(m, "StructureFlags")
+      .value("NO_CHANGE", StructChecker::NO_CHANGE)
+      .value("BAD_MOLECULE", StructChecker::BAD_MOLECULE)
+      .value("ALIAS_CONVERSION_FAILED", StructChecker::ALIAS_CONVERSION_FAILED)
+      .value("STEREO_ERROR", StructChecker::STEREO_ERROR)
+      .value("STEREO_FORCED_BAD", StructChecker::STEREO_FORCED_BAD)
+      .value("ATOM_CLASH", StructChecker::ATOM_CLASH)
+      .value("ATOM_CHECK_FAILED", StructChecker::ATOM_CHECK_FAILED)
+      .value("SIZE_CHECK_FAILED", StructChecker::SIZE_CHECK_FAILED)
+      .value("TRANSFORMED", StructChecker::TRANSFORMED)
+      .value("FRAGMENTS_FOUND", StructChecker::FRAGMENTS_FOUND)
+      .value("EITHER_WARNING", StructChecker::EITHER_WARNING)
+      .value("DUBIOUS_STEREO_REMOVED", StructChecker::DUBIOUS_STEREO_REMOVED)
+      .value("RECHARGED", StructChecker::RECHARGED)
+      .value("STEREO_TRANSFORMED", StructChecker::STEREO_TRANSFORMED)
+      .value("TEMPLATE_TRANSFORMED", StructChecker::TEMPLATE_TRANSFORMED)
+      .value("TAUTOMER_TRANSFORMED", StructChecker::TAUTOMER_TRANSFORMED);
 
-  nb::class_<RDKit::StructureCheck::StructCheckerOptions>(
-      m, "StructCheckerOptions")
+  nb::class_<StructCheckerOptions>(m, "StructCheckerOptions")
       .def(nb::init<>())
-      .def_rw("AcidityLimit",
-              &RDKit::StructureCheck::StructCheckerOptions::AcidityLimit)
-      .def_rw("RemoveMinorFragments",
-              &RDKit::StructureCheck::StructCheckerOptions::RemoveMinorFragments)
-      .def_rw("DesiredCharge",
-              &RDKit::StructureCheck::StructCheckerOptions::DesiredCharge)
-      .def_rw("CheckCollisions",
-              &RDKit::StructureCheck::StructCheckerOptions::CheckCollisions)
-      .def_rw(
-          "CollisionLimitPercent",
-          &RDKit::StructureCheck::StructCheckerOptions::CollisionLimitPercent)
-      .def_rw("MaxMolSize",
-              &RDKit::StructureCheck::StructCheckerOptions::MaxMolSize)
-      .def_rw("ConvertSText",
-              &RDKit::StructureCheck::StructCheckerOptions::ConvertSText)
-      .def_rw("StripZeros",
-              &RDKit::StructureCheck::StructCheckerOptions::StripZeros)
-      .def_rw("CheckStereo",
-              &RDKit::StructureCheck::StructCheckerOptions::CheckStereo)
-      .def_rw("ConvertAtomTexts",
-              &RDKit::StructureCheck::StructCheckerOptions::ConvertAtomTexts)
-      .def_rw("GroupsToSGroups",
-              &RDKit::StructureCheck::StructCheckerOptions::GroupsToSGroups)
-      .def_rw("Verbose",
-              &RDKit::StructureCheck::StructCheckerOptions::Verbose)
-      .def(
-          "LoadGoodAugmentedAtoms",
-          &RDKit::StructureCheck::StructCheckerOptions::loadGoodAugmentedAtoms,
-          "path"_a,
-          "Load the set of good augmented atoms from the specified file path")
-      .def(
-          "LoadAcidicAugmentedAtoms",
-          &RDKit::StructureCheck::StructCheckerOptions::loadAcidicAugmentedAtoms,
-          "path"_a,
-          R"DOC(Load the set of acidic augmented atoms from the specified file
+      .def_rw("AcidityLimit", &StructCheckerOptions::AcidityLimit)
+      .def_rw("RemoveMinorFragments", &StructCheckerOptions::RemoveMinorFragments)
+      .def_rw("DesiredCharge", &StructCheckerOptions::DesiredCharge)
+      .def_rw("CheckCollisions", &StructCheckerOptions::CheckCollisions)
+      .def_rw("CollisionLimitPercent", &StructCheckerOptions::CollisionLimitPercent)
+      .def_rw("MaxMolSize", &StructCheckerOptions::MaxMolSize)
+      .def_rw("ConvertSText", &StructCheckerOptions::ConvertSText)
+      .def_rw("StripZeros", &StructCheckerOptions::StripZeros)
+      .def_rw("CheckStereo", &StructCheckerOptions::CheckStereo)
+      .def_rw("ConvertAtomTexts", &StructCheckerOptions::ConvertAtomTexts)
+      .def_rw("GroupsToSGroups", &StructCheckerOptions::GroupsToSGroups)
+      .def_rw("Verbose", &StructCheckerOptions::Verbose)
+      .def("LoadGoodAugmentedAtoms",
+           &StructCheckerOptions::loadGoodAugmentedAtoms, "path"_a,
+           "Load the set of good augmented atoms from the specified file path")
+      .def("LoadAcidicAugmentedAtoms",
+           &StructCheckerOptions::loadAcidicAugmentedAtoms, "path"_a,
+           R"DOC(Load the set of acidic augmented atoms from the specified file
 path)DOC")
-      .def(
-          "LoadAugmentedAtomTranslations",
-          &RDKit::StructureCheck::StructCheckerOptions::
-              loadAugmentedAtomTranslations,
-          "path"_a,
-          R"DOC(Load the set of acidic augmented atoms from the specified file
+      .def("LoadAugmentedAtomTranslations",
+           &StructCheckerOptions::loadAugmentedAtomTranslations, "path"_a,
+           R"DOC(Load the set of acidic augmented atoms from the specified file
 path)DOC");
 
-  nb::class_<RDKit::StructureCheck::StructChecker>(m, "StructChecker")
+  nb::class_<StructChecker>(m, "StructChecker")
       .def(nb::init<>())
-      .def(nb::init<const RDKit::StructureCheck::StructCheckerOptions &>())
+      .def(nb::init<const StructCheckerOptions &>())
       .def(
           "CheckMolStructure",
-          [](const RDKit::StructureCheck::StructChecker &checker,
-             RDKit::ROMol &mol) {
-            RDKit::RWMol &fixer = static_cast<RDKit::RWMol &>(mol);
-            return static_cast<RDKit::StructureCheck::StructChecker::StructureFlags>(
-                checker.checkMolStructure(fixer));
+          [](const StructChecker &checker, ROMol &mol) {
+            return static_cast<StructChecker::StructureFlags>(
+                checker.checkMolStructure(static_cast<RWMol &>(mol)));
           },
           "mol"_a, "Check the structure and return a set of structure flags")
-      .def_static(
-          "StructureFlagsToString",
-          &RDKit::StructureCheck::StructChecker::StructureFlagsToString,
-          "flags"_a,
-          "Return the structure flags as a human readable string")
-      .def_static(
-          "StringToStructureFlags",
-          &RDKit::StructureCheck::StructChecker::StringToStructureFlags,
-          "str"_a,
-          R"DOC(Convert a comma separated string to the appropriate structure
+      .def_static("StructureFlagsToString",
+                  &StructChecker::StructureFlagsToString, "flags"_a,
+                  "Return the structure flags as a human readable string")
+      .def_static("StringToStructureFlags",
+                  &StructChecker::StringToStructureFlags, "str"_a,
+                  R"DOC(Convert a comma separated string to the appropriate structure
 flags)DOC");
 }

--- a/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
+++ b/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
@@ -21,7 +21,8 @@ using namespace RDKit;
 using namespace RDKit::StructureCheck;
 
 NB_MODULE(rdStructChecker, m) {
-  nb::enum_<StructChecker::StructureFlags>(m, "StructureFlags")
+  nb::enum_<StructChecker::StructureFlags>(m, "StructureFlags",
+                                            nb::is_arithmetic())
       .value("NO_CHANGE", StructChecker::NO_CHANGE)
       .value("BAD_MOLECULE", StructChecker::BAD_MOLECULE)
       .value("ALIAS_CONVERSION_FAILED", StructChecker::ALIAS_CONVERSION_FAILED)
@@ -70,9 +71,8 @@ path)DOC");
       .def(nb::init<const StructCheckerOptions &>())
       .def(
           "CheckMolStructure",
-          [](const StructChecker &checker, ROMol &mol) {
-            return static_cast<StructChecker::StructureFlags>(
-                checker.checkMolStructure(static_cast<RWMol &>(mol)));
+          [](const StructChecker &checker, ROMol &mol) -> unsigned {
+            return checker.checkMolStructure(static_cast<RWMol &>(mol));
           },
           "mol"_a, "Check the structure and return a set of structure flags")
       .def_static("StructureFlagsToString",

--- a/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
+++ b/Code/GraphMol/StructChecker/nbWrap/structchecker.cpp
@@ -1,159 +1,123 @@
-//  Copyright (c) 2016, Novartis Institutes for BioMedical Research Inc.
-//  All rights reserved.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+//  Copyright (C) 2016-2026 Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
 //
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-//       copyright notice, this list of conditions and the following
-//       disclaimer in the documentation and/or other materials provided
-//       with the distribution.
-//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
-//       nor the names of its contributors may be used to endorse or promote
-//       products derived from this software without specific prior written
-//       permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
 //
 
-#include <RDBoost/python.h>
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 #include <GraphMol/StructChecker/StructChecker.h>
 #include <GraphMol/RDKitBase.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
-namespace RDKit {
-namespace StructureCheck {
-unsigned int checkMolStructureHelper(const StructChecker &checker, ROMol &m) {
-  RWMol &fixer = static_cast<RWMol &>(m);
-  return checker.checkMolStructure(fixer);
+NB_MODULE(rdStructChecker, m) {
+  nb::enum_<RDKit::StructureCheck::StructChecker::StructureFlags>(
+      m, "StructureFlags")
+      .value("NO_CHANGE", RDKit::StructureCheck::StructChecker::NO_CHANGE)
+      .value("BAD_MOLECULE",
+             RDKit::StructureCheck::StructChecker::BAD_MOLECULE)
+      .value("ALIAS_CONVERSION_FAILED",
+             RDKit::StructureCheck::StructChecker::ALIAS_CONVERSION_FAILED)
+      .value("STEREO_ERROR",
+             RDKit::StructureCheck::StructChecker::STEREO_ERROR)
+      .value("STEREO_FORCED_BAD",
+             RDKit::StructureCheck::StructChecker::STEREO_FORCED_BAD)
+      .value("ATOM_CLASH", RDKit::StructureCheck::StructChecker::ATOM_CLASH)
+      .value("ATOM_CHECK_FAILED",
+             RDKit::StructureCheck::StructChecker::ATOM_CHECK_FAILED)
+      .value("SIZE_CHECK_FAILED",
+             RDKit::StructureCheck::StructChecker::SIZE_CHECK_FAILED)
+      .value("TRANSFORMED", RDKit::StructureCheck::StructChecker::TRANSFORMED)
+      .value("FRAGMENTS_FOUND",
+             RDKit::StructureCheck::StructChecker::FRAGMENTS_FOUND)
+      .value("EITHER_WARNING",
+             RDKit::StructureCheck::StructChecker::EITHER_WARNING)
+      .value("DUBIOUS_STEREO_REMOVED",
+             RDKit::StructureCheck::StructChecker::DUBIOUS_STEREO_REMOVED)
+      .value("RECHARGED", RDKit::StructureCheck::StructChecker::RECHARGED)
+      .value("STEREO_TRANSFORMED",
+             RDKit::StructureCheck::StructChecker::STEREO_TRANSFORMED)
+      .value("TEMPLATE_TRANSFORMED",
+             RDKit::StructureCheck::StructChecker::TEMPLATE_TRANSFORMED)
+      .value("TAUTOMER_TRANSFORMED",
+             RDKit::StructureCheck::StructChecker::TAUTOMER_TRANSFORMED);
+
+  nb::class_<RDKit::StructureCheck::StructCheckerOptions>(
+      m, "StructCheckerOptions")
+      .def(nb::init<>())
+      .def_rw("AcidityLimit",
+              &RDKit::StructureCheck::StructCheckerOptions::AcidityLimit)
+      .def_rw("RemoveMinorFragments",
+              &RDKit::StructureCheck::StructCheckerOptions::RemoveMinorFragments)
+      .def_rw("DesiredCharge",
+              &RDKit::StructureCheck::StructCheckerOptions::DesiredCharge)
+      .def_rw("CheckCollisions",
+              &RDKit::StructureCheck::StructCheckerOptions::CheckCollisions)
+      .def_rw(
+          "CollisionLimitPercent",
+          &RDKit::StructureCheck::StructCheckerOptions::CollisionLimitPercent)
+      .def_rw("MaxMolSize",
+              &RDKit::StructureCheck::StructCheckerOptions::MaxMolSize)
+      .def_rw("ConvertSText",
+              &RDKit::StructureCheck::StructCheckerOptions::ConvertSText)
+      .def_rw("StripZeros",
+              &RDKit::StructureCheck::StructCheckerOptions::StripZeros)
+      .def_rw("CheckStereo",
+              &RDKit::StructureCheck::StructCheckerOptions::CheckStereo)
+      .def_rw("ConvertAtomTexts",
+              &RDKit::StructureCheck::StructCheckerOptions::ConvertAtomTexts)
+      .def_rw("GroupsToSGroups",
+              &RDKit::StructureCheck::StructCheckerOptions::GroupsToSGroups)
+      .def_rw("Verbose",
+              &RDKit::StructureCheck::StructCheckerOptions::Verbose)
+      .def(
+          "LoadGoodAugmentedAtoms",
+          &RDKit::StructureCheck::StructCheckerOptions::loadGoodAugmentedAtoms,
+          "path"_a,
+          "Load the set of good augmented atoms from the specified file path")
+      .def(
+          "LoadAcidicAugmentedAtoms",
+          &RDKit::StructureCheck::StructCheckerOptions::loadAcidicAugmentedAtoms,
+          "path"_a,
+          R"DOC(Load the set of acidic augmented atoms from the specified file
+path)DOC")
+      .def(
+          "LoadAugmentedAtomTranslations",
+          &RDKit::StructureCheck::StructCheckerOptions::
+              loadAugmentedAtomTranslations,
+          "path"_a,
+          R"DOC(Load the set of acidic augmented atoms from the specified file
+path)DOC");
+
+  nb::class_<RDKit::StructureCheck::StructChecker>(m, "StructChecker")
+      .def(nb::init<>())
+      .def(nb::init<const RDKit::StructureCheck::StructCheckerOptions &>())
+      .def(
+          "CheckMolStructure",
+          [](const RDKit::StructureCheck::StructChecker &checker,
+             RDKit::ROMol &mol) {
+            RDKit::RWMol &fixer = static_cast<RDKit::RWMol &>(mol);
+            return static_cast<RDKit::StructureCheck::StructChecker::StructureFlags>(
+                checker.checkMolStructure(fixer));
+          },
+          "mol"_a, "Check the structure and return a set of structure flags")
+      .def_static(
+          "StructureFlagsToString",
+          &RDKit::StructureCheck::StructChecker::StructureFlagsToString,
+          "flags"_a,
+          "Return the structure flags as a human readable string")
+      .def_static(
+          "StringToStructureFlags",
+          &RDKit::StructureCheck::StructChecker::StringToStructureFlags,
+          "str"_a,
+          R"DOC(Convert a comma separated string to the appropriate structure
+flags)DOC");
 }
-}  // namespace StructureCheck
-}  // namespace RDKit
-
-struct struct_wrapper {
-  static void wrap() {
-    python::enum_<RDKit::StructureCheck::StructChecker::StructureFlags>(
-        "StructureFlags")
-        .value("NO_CHANGE", RDKit::StructureCheck::StructChecker::NO_CHANGE)
-        .value("BAD_MOLECULE",
-               RDKit::StructureCheck::StructChecker::BAD_MOLECULE)
-        .value("ALIAS_CONVERSION_FAILED",
-               RDKit::StructureCheck::StructChecker::ALIAS_CONVERSION_FAILED)
-        .value("STEREO_ERROR",
-               RDKit::StructureCheck::StructChecker::STEREO_ERROR)
-        .value("STEREO_FORCED_BAD",
-               RDKit::StructureCheck::StructChecker::STEREO_FORCED_BAD)
-        .value("ATOM_CLASH", RDKit::StructureCheck::StructChecker::ATOM_CLASH)
-        .value("ATOM_CHECK_FAILED",
-               RDKit::StructureCheck::StructChecker::ATOM_CHECK_FAILED)
-        .value("SIZE_CHECK_FAILED",
-               RDKit::StructureCheck::StructChecker::SIZE_CHECK_FAILED)
-        .value("TRANSFORMED", RDKit::StructureCheck::StructChecker::TRANSFORMED)
-        .value("FRAGMENTS_FOUND",
-               RDKit::StructureCheck::StructChecker::FRAGMENTS_FOUND)
-        .value("EITHER_WARNING",
-               RDKit::StructureCheck::StructChecker::EITHER_WARNING)
-        .value("DUBIOUS_STEREO_REMOVED",
-               RDKit::StructureCheck::StructChecker::DUBIOUS_STEREO_REMOVED)
-        .value("RECHARGED", RDKit::StructureCheck::StructChecker::RECHARGED)
-        .value("STEREO_TRANSFORMED",
-               RDKit::StructureCheck::StructChecker::STEREO_TRANSFORMED)
-        .value("TEMPLATE_TRANSFORMED",
-               RDKit::StructureCheck::StructChecker::TEMPLATE_TRANSFORMED)
-        .value("TAUTOMER_TRANSFORMED",
-               RDKit::StructureCheck::StructChecker::TAUTOMER_TRANSFORMED);
-
-    python::class_<RDKit::StructureCheck::StructCheckerOptions,
-                   RDKit::StructureCheck::StructCheckerOptions *>(
-        "StructCheckerOptions", python::init<>())
-        .def_readwrite(
-            "AcidityLimit",
-            &RDKit::StructureCheck::StructCheckerOptions::AcidityLimit)
-        .def_readwrite(
-            "RemoveMinorFragments",
-            &RDKit::StructureCheck::StructCheckerOptions::RemoveMinorFragments)
-        .def_readwrite(
-            "DesiredCharge",
-            &RDKit::StructureCheck::StructCheckerOptions::DesiredCharge)
-        .def_readwrite(
-            "CheckCollisions",
-            &RDKit::StructureCheck::StructCheckerOptions::CheckCollisions)
-        .def_readwrite(
-            "CollisionLimitPercent",
-            &RDKit::StructureCheck::StructCheckerOptions::CollisionLimitPercent)
-        .def_readwrite("MaxMolSize",
-                       &RDKit::StructureCheck::StructCheckerOptions::MaxMolSize)
-        .def_readwrite(
-            "ConvertSText",
-            &RDKit::StructureCheck::StructCheckerOptions::ConvertSText)
-        .def_readwrite("StripZeros",
-                       &RDKit::StructureCheck::StructCheckerOptions::StripZeros)
-        .def_readwrite(
-            "CheckStereo",
-            &RDKit::StructureCheck::StructCheckerOptions::CheckStereo)
-        .def_readwrite(
-            "ConvertAtomTexts",
-            &RDKit::StructureCheck::StructCheckerOptions::ConvertAtomTexts)
-        .def_readwrite(
-            "GroupsToSGroups",
-            &RDKit::StructureCheck::StructCheckerOptions::GroupsToSGroups)
-        .def_readwrite("Verbose",
-                       &RDKit::StructureCheck::StructCheckerOptions::Verbose)
-        .def(
-            "LoadGoodAugmentedAtoms",
-            &RDKit::StructureCheck::StructCheckerOptions::
-                loadGoodAugmentedAtoms,
-            (python::arg("path")),
-            "Load the set of good augmented atoms from the specified file path")
-        .def("LoadAcidicAugmentedAtoms",
-             &RDKit::StructureCheck::StructCheckerOptions::
-                 loadAcidicAugmentedAtoms,
-             (python::arg("path")),
-             "Load the set of acidic augmented atoms from the specified file "
-             "path")
-        .def("LoadAugmentedAtomTranslations",
-             &RDKit::StructureCheck::StructCheckerOptions::
-                 loadAugmentedAtomTranslations,
-             (python::arg("path")),
-             "Load the set of acidic augmented atoms from the specified file "
-             "path");
-
-    python::class_<RDKit::StructureCheck::StructChecker>("StructChecker",
-                                                         python::init<>())
-        .def(
-            python::init<const RDKit::StructureCheck::StructCheckerOptions &>())
-        .def("CheckMolStructure",
-             &RDKit::StructureCheck::checkMolStructureHelper,
-             (python::arg("mol")),
-             "Check the structure and return a set of structure flags")
-        .def("StructureFlagsToString",
-             &RDKit::StructureCheck::StructChecker::StructureFlagsToString,
-             (python::arg("flags")),
-             "Return the structure flags as a human readable string")
-        .staticmethod("StructureFlagsToString")
-        .def("StringToStructureFlags",
-             &RDKit::StructureCheck::StructChecker::StringToStructureFlags,
-             (python::arg("str")),
-             "Convert a comma separated string to the appropriate structure "
-             "flags")
-        .staticmethod("StringToStructureFlags");
-  }
-};
-
-BOOST_PYTHON_MODULE(rdStructChecker) { struct_wrapper::wrap(); }


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to StructChecker.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.