### PR TITLE
pr/SHARED-12391: Implement nanobind for MolTransforms

### DIFF
--- a/Code/Geometry/nbWrap/Point.cpp
+++ b/Code/Geometry/nbWrap/Point.cpp
@@ -158,6 +158,14 @@ void wrap_point(nb::module_ &m) {
            "(between 0 and 2*PI)")
       .def("DirectionVector", &Point3D::directionVector,
            "return a normalized direction vector from this point to another")
+      .def(
+          "Distance",
+          [](const Point3D &self, const Point3D &other) {
+            Point3D tmp(self);
+            tmp -= other;
+            return tmp.length();
+          },
+          "pt2"_a, "Distance from this point to another point")
       .def("__getstate__",
            [](const Point3D &pt) { return std::make_tuple(pt.x, pt.y, pt.z); })
       .def("__setstate__",

--- a/Code/GraphMol/MolTransforms/CMakeLists.txt
+++ b/Code/GraphMol/MolTransforms/CMakeLists.txt
@@ -14,3 +14,7 @@ rdkit_catch_test(molTransformsTestCatch catch_tests.cpp LINK_LIBRARIES MolTransf
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
+++ b/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
@@ -28,7 +28,7 @@ class TestCase(unittest.TestCase):
     mol = Chem.MolFromSmiles("C")
     conf = Chem.Conformer(1)
     conf.SetAtomPosition(0, (4.0, 5.0, 6.0))
-    mol.AddConformer(conf, 1)
+    mol.AddConformer(conf, True)
 
     conf = mol.GetConformer()
     pt = rdmt.ComputeCentroid(conf)

--- a/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
+++ b/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 
-from rdkit import Chem, DataStructs, RDConfig
+from rdkit import Chem, DataStructs, RDConfig, rdBase
 from rdkit.Chem import rdMolTransforms as rdmt
 from rdkit.Geometry import rdGeometry as geom
 
@@ -237,6 +237,9 @@ M  END
       exceptionRaised = True
     self.assertTrue(exceptionRaised)
 
+  @unittest.skipIf(rdBase._wrapperType == 'nanobind',
+                   'nanobind does not handle clean exits from context managers'
+                   ' (NoneType args to __exit__)')
   def testEigen3CanonicalTransformAgainstNumpy(self):
 
     def canonicalize_conf_rdkit(mol, conf_id=-1):

--- a/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
+++ b/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 
-from rdkit import Chem, DataStructs, RDConfig, rdBase
+from rdkit import Chem, DataStructs, RDConfig
 from rdkit.Chem import rdMolTransforms as rdmt
 from rdkit.Geometry import rdGeometry as geom
 
@@ -237,9 +237,6 @@ M  END
       exceptionRaised = True
     self.assertTrue(exceptionRaised)
 
-  @unittest.skipIf(rdBase._wrapperType == 'nanobind',
-                   'nanobind does not handle clean exits from context managers'
-                   ' (NoneType args to __exit__)')
   def testEigen3CanonicalTransformAgainstNumpy(self):
 
     def canonicalize_conf_rdkit(mol, conf_id=-1):

--- a/Code/GraphMol/MolTransforms/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolTransforms/nbWrap/CMakeLists.txt
@@ -1,0 +1,7 @@
+remove_definitions(-DRDKIT_MOLTRANSFORMS_BUILD)
+rdkit_python_extension(rdMolTransforms 
+                       rdMolTransforms.cpp
+                       DEST Chem 
+                       LINK_LIBRARIES MolTransforms )
+
+add_pytest(pyMolTransforms ${CMAKE_CURRENT_SOURCE_DIR}/testMolTransforms.py)

--- a/Code/GraphMol/MolTransforms/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolTransforms/nbWrap/CMakeLists.txt
@@ -1,7 +1,7 @@
 remove_definitions(-DRDKIT_MOLTRANSFORMS_BUILD)
-rdkit_python_extension(rdMolTransforms 
-                       rdMolTransforms.cpp
-                       DEST Chem 
-                       LINK_LIBRARIES MolTransforms )
+rdkit_nanobind_extension(rdMolTransforms
+                         rdMolTransforms.cpp
+                         DEST Chem
+                         LINK_LIBRARIES MolTransforms)
 
-add_pytest(pyMolTransforms ${CMAKE_CURRENT_SOURCE_DIR}/testMolTransforms.py)
+add_pytest(pyMolTransforms ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testMolTransforms.py)

--- a/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
@@ -1,0 +1,269 @@
+// $Id$
+//
+//  Copyright (C) 2005-2008 Greg Landrum and Rational Discovery LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define PY_ARRAY_UNIQUE_SYMBOL rdmoltransforms_array_API
+#include <RDBoost/python.h>
+#include <RDBoost/import_array.h>
+#include "numpy/arrayobject.h"
+#include <GraphMol/ROMol.h>
+#include <RDBoost/Wrap.h>
+#include <GraphMol/Conformer.h>
+#include <GraphMol/MolTransforms/MolTransforms.h>
+#include <Geometry/Transform3D.h>
+#include <Geometry/point.h>
+
+namespace python = boost::python;
+
+namespace RDKit {
+PyObject *computeCanonTrans(const Conformer &conf,
+                            const RDGeom::Point3D *center = nullptr,
+                            bool normalizeCovar = false, bool ignoreHs = true) {
+  RDGeom::Transform3D *trans;
+  trans = MolTransforms::computeCanonicalTransform(conf, center, normalizeCovar,
+                                                   ignoreHs);
+  npy_intp dims[2];
+  dims[0] = 4;
+  dims[1] = 4;
+  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
+  const double *tdata = trans->getData();
+  memcpy(static_cast<void *>(resData), static_cast<const void *>(tdata),
+         4 * 4 * sizeof(double));
+  delete trans;
+  return PyArray_Return(res);
+}
+
+#ifdef RDK_HAS_EIGEN3
+PyObject *computePrincAxesMomentsHelper(
+    bool func(const Conformer &, Eigen::Matrix3d &, Eigen::Vector3d &, bool,
+              bool, const std::vector<double> *),
+    const Conformer &conf, bool ignoreHs, const python::object &weights) {
+  Eigen::Matrix3d axes;
+  Eigen::Vector3d moments;
+  std::vector<double> *weightsVecPtr = nullptr;
+  std::vector<double> weightsVec;
+  size_t i;
+  if (weights != python::object()) {
+    size_t numElements = python::len(weights);
+    if (numElements != conf.getNumAtoms()) {
+      throw ValueErrorException(
+          "The Python container must have length equal to conf.GetNumAtoms()");
+    }
+    weightsVec.resize(numElements);
+    for (i = 0; i < numElements; ++i) {
+      weightsVec[i] = python::extract<double>(weights[i]);
+    }
+    weightsVecPtr = &weightsVec;
+  }
+  PyObject *res = PyTuple_New(2);
+  bool success = func(conf, axes, moments, ignoreHs, true, weightsVecPtr);
+  if (success) {
+    npy_intp dims[2];
+    dims[0] = 3;
+    dims[1] = 3;
+    auto *axesNpy = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+    auto *axesNpyData = reinterpret_cast<double *>(PyArray_DATA(axesNpy));
+    i = 0;
+    for (size_t y = 0; y < 3; ++y) {
+      for (size_t x = 0; x < 3; ++x) {
+        axesNpyData[i++] = axes(y, x);
+      }
+    }
+    auto *momentsNpy = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+    auto *momentsNpyData = reinterpret_cast<double *>(PyArray_DATA(momentsNpy));
+    for (size_t y = 0; y < 3; ++y) {
+      momentsNpyData[y] = moments(y);
+    }
+    res = PyTuple_New(2);
+    PyTuple_SetItem(res, 0, (PyObject *)axesNpy);
+    PyTuple_SetItem(res, 1, (PyObject *)momentsNpy);
+  } else {
+    PyTuple_SetItem(res, 0, Py_None);
+    PyTuple_SetItem(res, 1, Py_None);
+  }
+  return res;
+}
+
+PyObject *computePrincAxesMoments(const Conformer &conf, bool ignoreHs,
+                                  const python::object &weights) {
+  return computePrincAxesMomentsHelper(
+      MolTransforms::computePrincipalAxesAndMoments, conf, ignoreHs, weights);
+}
+
+PyObject *computePrincAxesMomentsFromGyrationMatrix(
+    const Conformer &conf, bool ignoreHs, const python::object &weights) {
+  return computePrincAxesMomentsHelper(
+      MolTransforms::computePrincipalAxesAndMomentsFromGyrationMatrix, conf,
+      ignoreHs, weights);
+}
+#endif
+
+void transConformer(Conformer &conf, python::object trans) {
+  PyObject *transObj = trans.ptr();
+  if (!PyArray_Check(transObj)) {
+    throw_value_error("Expecting a numeric array for transformation");
+  }
+  auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
+  unsigned int nrows = PyArray_DIM(transMat, 0);
+  unsigned int dSize = nrows * nrows;
+  auto *inData = reinterpret_cast<double *>(PyArray_DATA(transMat));
+  RDGeom::Transform3D transform;
+  double *tData = transform.getData();
+  memcpy(static_cast<void *>(tData), static_cast<void *>(inData),
+         dSize * sizeof(double));
+  MolTransforms::transformConformer(conf, transform);
+}
+}  // namespace RDKit
+
+BOOST_PYTHON_MODULE(rdMolTransforms) {
+  python::scope().attr("__doc__") =
+      "Module containing functions to perform 3D operations like rotate and "
+      "translate conformations";
+
+  rdkit_import_array();
+
+  std::string docString =
+      "Compute the centroid of the conformation - hydrogens are ignored and no attention\n\
+                           is paid to the difference in sizes of the heavy atoms; however,\n\
+                           an optional vector of weights can be passed.\n";
+  python::def("ComputeCentroid", MolTransforms::computeCentroid,
+              (python::arg("conf"), python::arg("ignoreHs") = true,
+               python::arg("weights") =
+                   static_cast<const std::vector<double> *>(nullptr)),
+              docString.c_str());
+
+  docString =
+      "Compute the transformation required aligna conformer so that\n\
+               the principal axes align up with the x,y, z axes\n\
+               The conformer itself is left unchanged\n\
+  ARGUMENTS:\n\
+    - conf : the conformer of interest\n\
+    - center : optional center point to compute the principal axes around (defaults to the centroid)\n\
+    - normalizeCovar : optionally normalize the covariance matrix by the number of atoms\n";
+  python::def(
+      "ComputeCanonicalTransform", RDKit::computeCanonTrans,
+      (python::arg("conf"),
+       python::arg("center") = static_cast<RDGeom::Point3D *>(nullptr),
+       python::arg("normalizeCovar") = false, python::arg("ignoreHs") = true),
+      docString.c_str());
+
+#ifdef RDK_HAS_EIGEN3
+  docString =
+      "Compute principal axes and moments of inertia for a conformer\n\
+       These values are calculated from the inertia tensor:\n\
+       Iij = - sum_{s=1..N}(w_s * r_{si} * r_{sj}) i != j\n\
+       Iii = sum_{s=1..N} sum_{j!=i} (w_s * r_{sj} * r_{sj})\n\
+       where the coordinates are relative to the center of mass.\n\
+\n\
+  ARGUMENTS:\n\
+    - conf : the conformer of interest\n\
+    - ignoreHs : if True, ignore hydrogen atoms\n\
+    - weights : if present, used to weight the atomic coordinates\n\n\
+  Returns a (principal axes, principal moments) tuple\n";
+  python::def("ComputePrincipalAxesAndMoments", RDKit::computePrincAxesMoments,
+              (python::arg("conf"), python::arg("ignoreHs") = true,
+               python::arg("weights") = python::object()),
+              docString.c_str());
+
+  docString =
+      "Compute principal axes and moments from the gyration matrix of a conformer\n\
+       These values are calculated from the gyration matrix/tensor:\n\
+       Iij = sum_{s=1..N}(w_s * r_{si} * r_{sj}) i != j\n\
+       Iii = sum_{s=1..N} sum_{t!=s}(w_s * r_{si} * r_{ti})\n\
+       where the coordinates are relative to the center of mass.\n\
+\n\
+  ARGUMENTS:\n\
+    - conf : the conformer of interest\n\
+    - ignoreHs : if True, ignore hydrogen atoms\n\
+    - weights : if present, used to weight the atomic coordinates\n\n\
+  Returns a (principal axes, principal moments) tuple\n";
+  python::def("ComputePrincipalAxesAndMomentsFromGyrationMatrix",
+              RDKit::computePrincAxesMomentsFromGyrationMatrix,
+              (python::arg("conf"), python::arg("ignoreHs") = true,
+               python::arg("weights") = python::object()),
+              docString.c_str());
+#endif
+
+  python::def("TransformConformer", RDKit::transConformer,
+              python::args("conf", "trans"),
+              "Transform the coordinates of a conformer");
+
+  docString =
+      "Canonicalize the orientation of a conformer so that its principal axes\n\
+               around the specified center point coincide with the x, y, z axes\n\
+  \n\
+  ARGUMENTS:\n\
+    - conf : conformer of interest \n\
+    - center : optionally center point about which the principal axes are computed \n\
+                          if not specified the centroid of the conformer will be used\n\
+    - normalizeCovar : Optionally normalize the covariance matrix by the number of atoms\n";
+  python::def(
+      "CanonicalizeConformer", MolTransforms::canonicalizeConformer,
+      (python::arg("conf"), python::arg("center") = (RDGeom::Point3D *)nullptr,
+       python::arg("normalizeCovar") = false, python::arg("ignoreHs") = true),
+      docString.c_str());
+
+  python::def("CanonicalizeMol", MolTransforms::canonicalizeMol,
+              (python::arg("mol"), python::arg("normalizeCovar") = false,
+               python::arg("ignoreHs") = true),
+              "Loop over the conformers in a molecule and canonicalize their "
+              "orientation");
+
+  python::def(
+      "GetBondLength", &MolTransforms::getBondLength,
+      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId")),
+      "Returns the bond length in angstrom between atoms i, j\n");
+  python::def("SetBondLength", &MolTransforms::setBondLength,
+              (python::arg("conf"), python::arg("iAtomId"),
+               python::arg("jAtomId"), python::arg("value")),
+              "Sets the bond length in angstrom between atoms i, j; "
+              "all atoms bonded to atom j are moved\n");
+  python::def("GetAngleRad", &MolTransforms::getAngleRad,
+              (python::arg("conf"), python::arg("iAtomId"),
+               python::arg("jAtomId"), python::arg("kAtomId")),
+              "Returns the angle in radians between atoms i, j, k\n");
+  python::def("GetAngleDeg", &MolTransforms::getAngleDeg,
+              (python::arg("conf"), python::arg("iAtomId"),
+               python::arg("jAtomId"), python::arg("kAtomId")),
+              "Returns the angle in degrees between atoms i, j, k\n");
+  python::def(
+      "SetAngleRad", &MolTransforms::setAngleRad,
+      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
+       python::arg("kAtomId"), python::arg("value")),
+      "Sets the angle in radians between atoms i, j, k; "
+      "all atoms bonded to atom k are moved\n");
+  python::def(
+      "SetAngleDeg", &MolTransforms::setAngleDeg,
+      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
+       python::arg("kAtomId"), python::arg("value")),
+      "Sets the angle in degrees between atoms i, j, k; "
+      "all atoms bonded to atom k are moved\n");
+  python::def(
+      "GetDihedralRad", &MolTransforms::getDihedralRad,
+      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
+       python::arg("kAtomId"), python::arg("lAtomId")),
+      "Returns the dihedral angle in radians between atoms i, j, k, l\n");
+  python::def(
+      "GetDihedralDeg", &MolTransforms::getDihedralDeg,
+      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
+       python::arg("kAtomId"), python::arg("lAtomId")),
+      "Returns the dihedral angle in degrees between atoms i, j, k, l\n");
+  python::def(
+      "SetDihedralRad", &MolTransforms::setDihedralRad,
+      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
+       python::arg("kAtomId"), python::arg("lAtomId"), python::arg("value")),
+      "Sets the dihedral angle in radians between atoms i, j, k, l; "
+      "all atoms bonded to atom l are moved\n");
+  python::def(
+      "SetDihedralDeg", &MolTransforms::setDihedralDeg,
+      python::args("conf", "iAtomId", "jAtomId", "kAtomId", "lAtomId", "value"),
+      "Sets the dihedral angle in degrees between atoms i, j, k, l; "
+      "all atoms bonded to atom l are moved\n");
+}

--- a/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
@@ -10,7 +10,6 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/ndarray.h>
-#include <RDBoost/import_array.h>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/Conformer.h>
 #include <GraphMol/MolTransforms/MolTransforms.h>
@@ -127,8 +126,6 @@ void transConformer(Conformer &conf,
 }  // namespace RDKit
 
 NB_MODULE(rdMolTransforms, m) {
-  rdkit_import_array();
-
   m.doc() = R"DOC(Module containing functions to perform 3D operations like rotate and
 translate conformations)DOC";
 

--- a/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
@@ -18,8 +18,8 @@
 
 namespace nb = nanobind;
 using namespace nb::literals;
-
-namespace RDKit {
+using namespace RDKit;
+namespace {
 
 RDGeom::Point3D computeCentroidHelper(const Conformer &conf, bool ignoreHs,
                                       nb::object weights) {
@@ -139,21 +139,21 @@ void transConformer(Conformer &conf,
   MolTransforms::transformConformer(conf, transform);
 }
 
-}  // namespace RDKit
+}  // namespace
 
 NB_MODULE(rdMolTransforms, m) {
   m.doc() = R"DOC(Module containing functions to perform 3D operations like rotate and
 translate conformations)DOC";
 
   m.def(
-      "ComputeCentroid", RDKit::computeCentroidHelper, "conf"_a,
+      "ComputeCentroid", computeCentroidHelper, "conf"_a,
       "ignoreHs"_a = true, "weights"_a = nb::none(),
       R"DOC(Compute the centroid of the conformation - hydrogens are ignored and no attention
 is paid to the difference in sizes of the heavy atoms; however,
 an optional vector of weights can be passed.)DOC");
 
   m.def(
-      "ComputeCanonicalTransform", RDKit::computeCanonTrans, "conf"_a,
+      "ComputeCanonicalTransform", computeCanonTrans, "conf"_a,
       "center"_a = static_cast<RDGeom::Point3D *>(nullptr),
       "normalizeCovar"_a = false, "ignoreHs"_a = true,
       R"DOC(Compute the transformation required to align a conformer so that
@@ -166,7 +166,7 @@ ARGUMENTS:
 
 #ifdef RDK_HAS_EIGEN3
   m.def(
-      "ComputePrincipalAxesAndMoments", RDKit::computePrincAxesMoments,
+      "ComputePrincipalAxesAndMoments", computePrincAxesMoments,
       "conf"_a, "ignoreHs"_a = true, "weights"_a = nb::none(),
       R"DOC(Compute principal axes and moments of inertia for a conformer.
 These values are calculated from the inertia tensor:
@@ -183,7 +183,7 @@ Returns a (principal axes, principal moments) tuple)DOC");
 
   m.def(
       "ComputePrincipalAxesAndMomentsFromGyrationMatrix",
-      RDKit::computePrincAxesMomentsFromGyrationMatrix, "conf"_a,
+      computePrincAxesMomentsFromGyrationMatrix, "conf"_a,
       "ignoreHs"_a = true, "weights"_a = nb::none(),
       R"DOC(Compute principal axes and moments from the gyration matrix of a conformer.
 These values are calculated from the gyration matrix/tensor:
@@ -199,7 +199,7 @@ ARGUMENTS:
 Returns a (principal axes, principal moments) tuple)DOC");
 #endif
 
-  m.def("TransformConformer", RDKit::transConformer, "conf"_a, "trans"_a,
+  m.def("TransformConformer", transConformer, "conf"_a, "trans"_a,
         "Transform the coordinates of a conformer");
 
   m.def(

--- a/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-//  Copyright (C) 2005-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2005-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,262 +7,249 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define PY_ARRAY_UNIQUE_SYMBOL rdmoltransforms_array_API
-#include <RDBoost/python.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/ndarray.h>
 #include <RDBoost/import_array.h>
-#include "numpy/arrayobject.h"
 #include <GraphMol/ROMol.h>
-#include <RDBoost/Wrap.h>
 #include <GraphMol/Conformer.h>
 #include <GraphMol/MolTransforms/MolTransforms.h>
 #include <Geometry/Transform3D.h>
 #include <Geometry/point.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace RDKit {
-PyObject *computeCanonTrans(const Conformer &conf,
-                            const RDGeom::Point3D *center = nullptr,
-                            bool normalizeCovar = false, bool ignoreHs = true) {
-  RDGeom::Transform3D *trans;
-  trans = MolTransforms::computeCanonicalTransform(conf, center, normalizeCovar,
-                                                   ignoreHs);
-  npy_intp dims[2];
-  dims[0] = 4;
-  dims[1] = 4;
-  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
-  auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
+
+auto computeCanonTrans(const Conformer &conf,
+                       const RDGeom::Point3D *center = nullptr,
+                       bool normalizeCovar = false, bool ignoreHs = true) {
+  RDGeom::Transform3D *trans =
+      MolTransforms::computeCanonicalTransform(conf, center, normalizeCovar,
+                                               ignoreHs);
+  double *resData = new double[4 * 4];
   const double *tdata = trans->getData();
   memcpy(static_cast<void *>(resData), static_cast<const void *>(tdata),
          4 * 4 * sizeof(double));
   delete trans;
-  return PyArray_Return(res);
+
+  nb::capsule owner(resData, [](void *f) noexcept {
+    double *data = reinterpret_cast<double *>(f);
+    delete[] data;
+  });
+  return nb::ndarray<nb::numpy, double, nb::ndim<2>>(resData, {4, 4}, owner);
 }
 
 #ifdef RDK_HAS_EIGEN3
-PyObject *computePrincAxesMomentsHelper(
+nb::object computePrincAxesMomentsHelper(
     bool func(const Conformer &, Eigen::Matrix3d &, Eigen::Vector3d &, bool,
               bool, const std::vector<double> *),
-    const Conformer &conf, bool ignoreHs, const python::object &weights) {
+    const Conformer &conf, bool ignoreHs, nb::object weights) {
   Eigen::Matrix3d axes;
   Eigen::Vector3d moments;
   std::vector<double> *weightsVecPtr = nullptr;
   std::vector<double> weightsVec;
-  size_t i;
-  if (weights != python::object()) {
-    size_t numElements = python::len(weights);
+  if (!weights.is_none()) {
+    size_t numElements = nb::len(weights);
     if (numElements != conf.getNumAtoms()) {
       throw ValueErrorException(
           "The Python container must have length equal to conf.GetNumAtoms()");
     }
     weightsVec.resize(numElements);
-    for (i = 0; i < numElements; ++i) {
-      weightsVec[i] = python::extract<double>(weights[i]);
+    size_t i = 0;
+    for (nb::handle h : weights) {
+      weightsVec[i++] = nb::cast<double>(h);
     }
     weightsVecPtr = &weightsVec;
   }
-  PyObject *res = PyTuple_New(2);
   bool success = func(conf, axes, moments, ignoreHs, true, weightsVecPtr);
   if (success) {
-    npy_intp dims[2];
-    dims[0] = 3;
-    dims[1] = 3;
-    auto *axesNpy = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
-    auto *axesNpyData = reinterpret_cast<double *>(PyArray_DATA(axesNpy));
-    i = 0;
+    double *axesData = new double[3 * 3];
+    size_t i = 0;
     for (size_t y = 0; y < 3; ++y) {
       for (size_t x = 0; x < 3; ++x) {
-        axesNpyData[i++] = axes(y, x);
+        axesData[i++] = axes(y, x);
       }
     }
-    auto *momentsNpy = (PyArrayObject *)PyArray_SimpleNew(1, dims, NPY_DOUBLE);
-    auto *momentsNpyData = reinterpret_cast<double *>(PyArray_DATA(momentsNpy));
+    nb::capsule axesOwner(axesData, [](void *f) noexcept {
+      double *data = reinterpret_cast<double *>(f);
+      delete[] data;
+    });
+    auto axesNb =
+        nb::ndarray<nb::numpy, double, nb::ndim<2>>(axesData, {3, 3}, axesOwner);
+
+    double *momentsData = new double[3];
     for (size_t y = 0; y < 3; ++y) {
-      momentsNpyData[y] = moments(y);
+      momentsData[y] = moments(y);
     }
-    res = PyTuple_New(2);
-    PyTuple_SetItem(res, 0, (PyObject *)axesNpy);
-    PyTuple_SetItem(res, 1, (PyObject *)momentsNpy);
+    nb::capsule momentsOwner(momentsData, [](void *f) noexcept {
+      double *data = reinterpret_cast<double *>(f);
+      delete[] data;
+    });
+    auto momentsNb = nb::ndarray<nb::numpy, double, nb::ndim<1>>(
+        momentsData, {3}, momentsOwner);
+
+    return nb::make_tuple(axesNb, momentsNb);
   } else {
-    PyTuple_SetItem(res, 0, Py_None);
-    PyTuple_SetItem(res, 1, Py_None);
+    return nb::make_tuple(nb::none(), nb::none());
   }
-  return res;
 }
 
-PyObject *computePrincAxesMoments(const Conformer &conf, bool ignoreHs,
-                                  const python::object &weights) {
+nb::object computePrincAxesMoments(const Conformer &conf, bool ignoreHs,
+                                   nb::object weights) {
   return computePrincAxesMomentsHelper(
       MolTransforms::computePrincipalAxesAndMoments, conf, ignoreHs, weights);
 }
 
-PyObject *computePrincAxesMomentsFromGyrationMatrix(
-    const Conformer &conf, bool ignoreHs, const python::object &weights) {
+nb::object computePrincAxesMomentsFromGyrationMatrix(const Conformer &conf,
+                                                     bool ignoreHs,
+                                                     nb::object weights) {
   return computePrincAxesMomentsHelper(
       MolTransforms::computePrincipalAxesAndMomentsFromGyrationMatrix, conf,
       ignoreHs, weights);
 }
 #endif
 
-void transConformer(Conformer &conf, python::object trans) {
-  PyObject *transObj = trans.ptr();
-  if (!PyArray_Check(transObj)) {
-    throw_value_error("Expecting a numeric array for transformation");
-  }
-  auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
-  unsigned int nrows = PyArray_DIM(transMat, 0);
+void transConformer(Conformer &conf,
+                    const nb::ndarray<nb::numpy, const double,
+                                      nb::shape<-1, -1>, nb::c_contig> &trans) {
+  unsigned int nrows = trans.shape(0);
   unsigned int dSize = nrows * nrows;
-  auto *inData = reinterpret_cast<double *>(PyArray_DATA(transMat));
+  const double *inData = trans.data();
   RDGeom::Transform3D transform;
   double *tData = transform.getData();
-  memcpy(static_cast<void *>(tData), static_cast<void *>(inData),
+  memcpy(static_cast<void *>(tData), static_cast<const void *>(inData),
          dSize * sizeof(double));
   MolTransforms::transformConformer(conf, transform);
 }
+
 }  // namespace RDKit
 
-BOOST_PYTHON_MODULE(rdMolTransforms) {
-  python::scope().attr("__doc__") =
-      "Module containing functions to perform 3D operations like rotate and "
-      "translate conformations";
-
+NB_MODULE(rdMolTransforms, m) {
   rdkit_import_array();
 
-  std::string docString =
-      "Compute the centroid of the conformation - hydrogens are ignored and no attention\n\
-                           is paid to the difference in sizes of the heavy atoms; however,\n\
-                           an optional vector of weights can be passed.\n";
-  python::def("ComputeCentroid", MolTransforms::computeCentroid,
-              (python::arg("conf"), python::arg("ignoreHs") = true,
-               python::arg("weights") =
-                   static_cast<const std::vector<double> *>(nullptr)),
-              docString.c_str());
+  m.doc() = R"DOC(Module containing functions to perform 3D operations like rotate and
+translate conformations)DOC";
 
-  docString =
-      "Compute the transformation required aligna conformer so that\n\
-               the principal axes align up with the x,y, z axes\n\
-               The conformer itself is left unchanged\n\
-  ARGUMENTS:\n\
-    - conf : the conformer of interest\n\
-    - center : optional center point to compute the principal axes around (defaults to the centroid)\n\
-    - normalizeCovar : optionally normalize the covariance matrix by the number of atoms\n";
-  python::def(
-      "ComputeCanonicalTransform", RDKit::computeCanonTrans,
-      (python::arg("conf"),
-       python::arg("center") = static_cast<RDGeom::Point3D *>(nullptr),
-       python::arg("normalizeCovar") = false, python::arg("ignoreHs") = true),
-      docString.c_str());
+  m.def(
+      "ComputeCentroid", MolTransforms::computeCentroid, "conf"_a,
+      "ignoreHs"_a = true,
+      "weights"_a = static_cast<const std::vector<double> *>(nullptr),
+      R"DOC(Compute the centroid of the conformation - hydrogens are ignored and no attention
+is paid to the difference in sizes of the heavy atoms; however,
+an optional vector of weights can be passed.)DOC");
+
+  m.def(
+      "ComputeCanonicalTransform", RDKit::computeCanonTrans, "conf"_a,
+      "center"_a = static_cast<RDGeom::Point3D *>(nullptr),
+      "normalizeCovar"_a = false, "ignoreHs"_a = true,
+      R"DOC(Compute the transformation required to align a conformer so that
+the principal axes align up with the x,y,z axes.
+The conformer itself is left unchanged.
+ARGUMENTS:
+  - conf : the conformer of interest
+  - center : optional center point to compute the principal axes around (defaults to the centroid)
+  - normalizeCovar : optionally normalize the covariance matrix by the number of atoms)DOC");
 
 #ifdef RDK_HAS_EIGEN3
-  docString =
-      "Compute principal axes and moments of inertia for a conformer\n\
-       These values are calculated from the inertia tensor:\n\
-       Iij = - sum_{s=1..N}(w_s * r_{si} * r_{sj}) i != j\n\
-       Iii = sum_{s=1..N} sum_{j!=i} (w_s * r_{sj} * r_{sj})\n\
-       where the coordinates are relative to the center of mass.\n\
-\n\
-  ARGUMENTS:\n\
-    - conf : the conformer of interest\n\
-    - ignoreHs : if True, ignore hydrogen atoms\n\
-    - weights : if present, used to weight the atomic coordinates\n\n\
-  Returns a (principal axes, principal moments) tuple\n";
-  python::def("ComputePrincipalAxesAndMoments", RDKit::computePrincAxesMoments,
-              (python::arg("conf"), python::arg("ignoreHs") = true,
-               python::arg("weights") = python::object()),
-              docString.c_str());
+  m.def(
+      "ComputePrincipalAxesAndMoments", RDKit::computePrincAxesMoments,
+      "conf"_a, "ignoreHs"_a = true, "weights"_a = nb::none(),
+      R"DOC(Compute principal axes and moments of inertia for a conformer.
+These values are calculated from the inertia tensor:
+  Iij = - sum_{s=1..N}(w_s * r_{si} * r_{sj}) i != j
+  Iii = sum_{s=1..N} sum_{j!=i} (w_s * r_{sj} * r_{sj})
+where the coordinates are relative to the center of mass.
 
-  docString =
-      "Compute principal axes and moments from the gyration matrix of a conformer\n\
-       These values are calculated from the gyration matrix/tensor:\n\
-       Iij = sum_{s=1..N}(w_s * r_{si} * r_{sj}) i != j\n\
-       Iii = sum_{s=1..N} sum_{t!=s}(w_s * r_{si} * r_{ti})\n\
-       where the coordinates are relative to the center of mass.\n\
-\n\
-  ARGUMENTS:\n\
-    - conf : the conformer of interest\n\
-    - ignoreHs : if True, ignore hydrogen atoms\n\
-    - weights : if present, used to weight the atomic coordinates\n\n\
-  Returns a (principal axes, principal moments) tuple\n";
-  python::def("ComputePrincipalAxesAndMomentsFromGyrationMatrix",
-              RDKit::computePrincAxesMomentsFromGyrationMatrix,
-              (python::arg("conf"), python::arg("ignoreHs") = true,
-               python::arg("weights") = python::object()),
-              docString.c_str());
+ARGUMENTS:
+  - conf : the conformer of interest
+  - ignoreHs : if True, ignore hydrogen atoms
+  - weights : if present, used to weight the atomic coordinates
+
+Returns a (principal axes, principal moments) tuple)DOC");
+
+  m.def(
+      "ComputePrincipalAxesAndMomentsFromGyrationMatrix",
+      RDKit::computePrincAxesMomentsFromGyrationMatrix, "conf"_a,
+      "ignoreHs"_a = true, "weights"_a = nb::none(),
+      R"DOC(Compute principal axes and moments from the gyration matrix of a conformer.
+These values are calculated from the gyration matrix/tensor:
+  Iij = sum_{s=1..N}(w_s * r_{si} * r_{sj}) i != j
+  Iii = sum_{s=1..N} sum_{t!=s}(w_s * r_{si} * r_{ti})
+where the coordinates are relative to the center of mass.
+
+ARGUMENTS:
+  - conf : the conformer of interest
+  - ignoreHs : if True, ignore hydrogen atoms
+  - weights : if present, used to weight the atomic coordinates
+
+Returns a (principal axes, principal moments) tuple)DOC");
 #endif
 
-  python::def("TransformConformer", RDKit::transConformer,
-              python::args("conf", "trans"),
-              "Transform the coordinates of a conformer");
+  m.def("TransformConformer", RDKit::transConformer, "conf"_a, "trans"_a,
+        "Transform the coordinates of a conformer");
 
-  docString =
-      "Canonicalize the orientation of a conformer so that its principal axes\n\
-               around the specified center point coincide with the x, y, z axes\n\
-  \n\
-  ARGUMENTS:\n\
-    - conf : conformer of interest \n\
-    - center : optionally center point about which the principal axes are computed \n\
-                          if not specified the centroid of the conformer will be used\n\
-    - normalizeCovar : Optionally normalize the covariance matrix by the number of atoms\n";
-  python::def(
-      "CanonicalizeConformer", MolTransforms::canonicalizeConformer,
-      (python::arg("conf"), python::arg("center") = (RDGeom::Point3D *)nullptr,
-       python::arg("normalizeCovar") = false, python::arg("ignoreHs") = true),
-      docString.c_str());
+  m.def(
+      "CanonicalizeConformer", MolTransforms::canonicalizeConformer, "conf"_a,
+      "center"_a = static_cast<RDGeom::Point3D *>(nullptr),
+      "normalizeCovar"_a = false, "ignoreHs"_a = true,
+      R"DOC(Canonicalize the orientation of a conformer so that its principal axes
+around the specified center point coincide with the x, y, z axes.
 
-  python::def("CanonicalizeMol", MolTransforms::canonicalizeMol,
-              (python::arg("mol"), python::arg("normalizeCovar") = false,
-               python::arg("ignoreHs") = true),
-              "Loop over the conformers in a molecule and canonicalize their "
-              "orientation");
+ARGUMENTS:
+  - conf : conformer of interest
+  - center : optionally center point about which the principal axes are computed;
+if not specified the centroid of the conformer will be used
+  - normalizeCovar : Optionally normalize the covariance matrix by the number of atoms)DOC");
 
-  python::def(
-      "GetBondLength", &MolTransforms::getBondLength,
-      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId")),
-      "Returns the bond length in angstrom between atoms i, j\n");
-  python::def("SetBondLength", &MolTransforms::setBondLength,
-              (python::arg("conf"), python::arg("iAtomId"),
-               python::arg("jAtomId"), python::arg("value")),
-              "Sets the bond length in angstrom between atoms i, j; "
-              "all atoms bonded to atom j are moved\n");
-  python::def("GetAngleRad", &MolTransforms::getAngleRad,
-              (python::arg("conf"), python::arg("iAtomId"),
-               python::arg("jAtomId"), python::arg("kAtomId")),
-              "Returns the angle in radians between atoms i, j, k\n");
-  python::def("GetAngleDeg", &MolTransforms::getAngleDeg,
-              (python::arg("conf"), python::arg("iAtomId"),
-               python::arg("jAtomId"), python::arg("kAtomId")),
-              "Returns the angle in degrees between atoms i, j, k\n");
-  python::def(
-      "SetAngleRad", &MolTransforms::setAngleRad,
-      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
-       python::arg("kAtomId"), python::arg("value")),
-      "Sets the angle in radians between atoms i, j, k; "
-      "all atoms bonded to atom k are moved\n");
-  python::def(
-      "SetAngleDeg", &MolTransforms::setAngleDeg,
-      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
-       python::arg("kAtomId"), python::arg("value")),
-      "Sets the angle in degrees between atoms i, j, k; "
-      "all atoms bonded to atom k are moved\n");
-  python::def(
-      "GetDihedralRad", &MolTransforms::getDihedralRad,
-      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
-       python::arg("kAtomId"), python::arg("lAtomId")),
-      "Returns the dihedral angle in radians between atoms i, j, k, l\n");
-  python::def(
-      "GetDihedralDeg", &MolTransforms::getDihedralDeg,
-      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
-       python::arg("kAtomId"), python::arg("lAtomId")),
-      "Returns the dihedral angle in degrees between atoms i, j, k, l\n");
-  python::def(
-      "SetDihedralRad", &MolTransforms::setDihedralRad,
-      (python::arg("conf"), python::arg("iAtomId"), python::arg("jAtomId"),
-       python::arg("kAtomId"), python::arg("lAtomId"), python::arg("value")),
-      "Sets the dihedral angle in radians between atoms i, j, k, l; "
-      "all atoms bonded to atom l are moved\n");
-  python::def(
-      "SetDihedralDeg", &MolTransforms::setDihedralDeg,
-      python::args("conf", "iAtomId", "jAtomId", "kAtomId", "lAtomId", "value"),
-      "Sets the dihedral angle in degrees between atoms i, j, k, l; "
-      "all atoms bonded to atom l are moved\n");
+  m.def("CanonicalizeMol", MolTransforms::canonicalizeMol, "mol"_a,
+        "normalizeCovar"_a = false, "ignoreHs"_a = true,
+        "Loop over the conformers in a molecule and canonicalize their "
+        "orientation");
+
+  m.def("GetBondLength", &MolTransforms::getBondLength, "conf"_a, "iAtomId"_a,
+        "jAtomId"_a,
+        "Returns the bond length in angstrom between atoms i, j\n");
+
+  m.def("SetBondLength", &MolTransforms::setBondLength, "conf"_a, "iAtomId"_a,
+        "jAtomId"_a, "value"_a,
+        "Sets the bond length in angstrom between atoms i, j; "
+        "all atoms bonded to atom j are moved\n");
+
+  m.def("GetAngleRad", &MolTransforms::getAngleRad, "conf"_a, "iAtomId"_a,
+        "jAtomId"_a, "kAtomId"_a,
+        "Returns the angle in radians between atoms i, j, k\n");
+
+  m.def("GetAngleDeg", &MolTransforms::getAngleDeg, "conf"_a, "iAtomId"_a,
+        "jAtomId"_a, "kAtomId"_a,
+        "Returns the angle in degrees between atoms i, j, k\n");
+
+  m.def("SetAngleRad", &MolTransforms::setAngleRad, "conf"_a, "iAtomId"_a,
+        "jAtomId"_a, "kAtomId"_a, "value"_a,
+        "Sets the angle in radians between atoms i, j, k; "
+        "all atoms bonded to atom k are moved\n");
+
+  m.def("SetAngleDeg", &MolTransforms::setAngleDeg, "conf"_a, "iAtomId"_a,
+        "jAtomId"_a, "kAtomId"_a, "value"_a,
+        "Sets the angle in degrees between atoms i, j, k; "
+        "all atoms bonded to atom k are moved\n");
+
+  m.def("GetDihedralRad", &MolTransforms::getDihedralRad, "conf"_a,
+        "iAtomId"_a, "jAtomId"_a, "kAtomId"_a, "lAtomId"_a,
+        "Returns the dihedral angle in radians between atoms i, j, k, l\n");
+
+  m.def("GetDihedralDeg", &MolTransforms::getDihedralDeg, "conf"_a,
+        "iAtomId"_a, "jAtomId"_a, "kAtomId"_a, "lAtomId"_a,
+        "Returns the dihedral angle in degrees between atoms i, j, k, l\n");
+
+  m.def("SetDihedralRad", &MolTransforms::setDihedralRad, "conf"_a,
+        "iAtomId"_a, "jAtomId"_a, "kAtomId"_a, "lAtomId"_a, "value"_a,
+        "Sets the dihedral angle in radians between atoms i, j, k, l; "
+        "all atoms bonded to atom l are moved\n");
+
+  m.def("SetDihedralDeg", &MolTransforms::setDihedralDeg, "conf"_a,
+        "iAtomId"_a, "jAtomId"_a, "kAtomId"_a, "lAtomId"_a, "value"_a,
+        "Sets the dihedral angle in degrees between atoms i, j, k, l; "
+        "all atoms bonded to atom l are moved\n");
 }

--- a/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/nbWrap/rdMolTransforms.cpp
@@ -21,6 +21,22 @@ using namespace nb::literals;
 
 namespace RDKit {
 
+RDGeom::Point3D computeCentroidHelper(const Conformer &conf, bool ignoreHs,
+                                      nb::object weights) {
+  std::vector<double> *weightsVecPtr = nullptr;
+  std::vector<double> weightsVec;
+  if (!weights.is_none()) {
+    size_t numElements = nb::len(weights);
+    weightsVec.resize(numElements);
+    size_t i = 0;
+    for (nb::handle h : weights) {
+      weightsVec[i++] = nb::cast<double>(h);
+    }
+    weightsVecPtr = &weightsVec;
+  }
+  return MolTransforms::computeCentroid(conf, ignoreHs, weightsVecPtr);
+}
+
 auto computeCanonTrans(const Conformer &conf,
                        const RDGeom::Point3D *center = nullptr,
                        bool normalizeCovar = false, bool ignoreHs = true) {
@@ -130,9 +146,8 @@ NB_MODULE(rdMolTransforms, m) {
 translate conformations)DOC";
 
   m.def(
-      "ComputeCentroid", MolTransforms::computeCentroid, "conf"_a,
-      "ignoreHs"_a = true,
-      "weights"_a = static_cast<const std::vector<double> *>(nullptr),
+      "ComputeCentroid", RDKit::computeCentroidHelper, "conf"_a,
+      "ignoreHs"_a = true, "weights"_a = nb::none(),
       R"DOC(Compute the centroid of the conformation - hydrogens are ignored and no attention
 is paid to the difference in sizes of the heavy atoms; however,
 an optional vector of weights can be passed.)DOC");


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to MolTransforms.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.