### PR TITLE
pr/SHARED-12407: Implement nanobind for MolChemicalFeatures

### DIFF
--- a/Code/GraphMol/MolChemicalFeatures/CMakeLists.txt
+++ b/Code/GraphMol/MolChemicalFeatures/CMakeLists.txt
@@ -17,3 +17,7 @@ if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
 
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()
+

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/testChemicalFeatures.py
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/testChemicalFeatures.py
@@ -1,8 +1,14 @@
 import os
 import unittest
 
-from rdkit import Chem, DataStructs, Geometry, RDConfig
-from rdkit.Chem import AllChem, ChemicalFeatures, rdDistGeom
+from rdkit import Chem, RDConfig
+from rdkit.Chem import ChemicalFeatures, rdDistGeom
+
+try:
+  from rdkit.Chem import AllChem
+  haveAllChem = True
+except ImportError:
+  haveAllChem = False
 
 
 def lstFeq(l1, l2, tol=1.e-4):
@@ -194,6 +200,7 @@ EndFeature
     cfac = None
     self.assertEqual(feats[0].GetFamily(), 'Donor')
 
+  @unittest.skipIf(not haveAllChem, "AllChem not available in nanobind yet")
   def testGithub2530(self):
     cfac = ChemicalFeatures.BuildFeatureFactory(
       os.path.join(RDConfig.RDDataDir, "BaseFeatures.fdef"))

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/CMakeLists.txt
@@ -1,0 +1,13 @@
+remove_definitions(-DRDKIT_MOLCHEMICALFEATURES_BUILD)
+rdkit_python_extension(rdMolChemicalFeatures
+                       rdMolChemicalFeatures.cpp MolChemicalFeature.cpp 
+                       MolChemicalFeatureFactory.cpp ChemicalFeatureUtils.cpp
+		       DEST Chem
+		       LINK_LIBRARIES MolChemicalFeatures )
+
+add_pytest(pyChemicalFeatures
+         ${CMAKE_CURRENT_SOURCE_DIR}/testChemicalFeatures.py)
+
+
+
+

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/CMakeLists.txt
@@ -1,13 +1,9 @@
 remove_definitions(-DRDKIT_MOLCHEMICALFEATURES_BUILD)
-rdkit_python_extension(rdMolChemicalFeatures
-                       rdMolChemicalFeatures.cpp MolChemicalFeature.cpp 
-                       MolChemicalFeatureFactory.cpp ChemicalFeatureUtils.cpp
-		       DEST Chem
-		       LINK_LIBRARIES MolChemicalFeatures )
+rdkit_nanobind_extension(rdMolChemicalFeatures
+                         rdMolChemicalFeatures.cpp MolChemicalFeature.cpp
+                         MolChemicalFeatureFactory.cpp ChemicalFeatureUtils.cpp
+                         DEST Chem
+                         LINK_LIBRARIES MolChemicalFeatures)
 
 add_pytest(pyChemicalFeatures
-         ${CMAKE_CURRENT_SOURCE_DIR}/testChemicalFeatures.py)
-
-
-
-
+           ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testChemicalFeatures.py)

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2006 Rational Discovery LLC
+//  Copyright (C) 2006-2026 Rational Discovery LLC and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,32 +7,31 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-#include <RDBoost/python.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+
 #include <boost/dynamic_bitset.hpp>
 #include <GraphMol/RDKitBase.h>
-#include <RDGeneral/types.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
-#include <ChemicalFeatures/FreeChemicalFeature.h>
 
-namespace python = boost::python;
-namespace RDKit {
-python::object GetAtomMatch(python::object featMatch, int maxAts = 1024) {
-  python::list res;
-  unsigned int nEntries = python::len(featMatch);
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace RDKit;
+
+namespace {
+nb::object GetAtomMatch(nb::object featMatch, int maxAts = 1024) {
+  nb::list res;
+  auto nEntries = nb::len(featMatch);
 
   boost::dynamic_bitset<> indices(maxAts);
-  for (unsigned int i = 0; i < nEntries; ++i) {
-    MolChemicalFeature *feat =
-        python::extract<MolChemicalFeature *>(featMatch[i]);
-    const MolChemicalFeature::AtomPtrContainer &atoms = feat->getAtoms();
-    MolChemicalFeature::AtomPtrContainer_CI aci;
-    python::list local;
-    for (aci = atoms.begin(); aci != atoms.end(); ++aci) {
-      unsigned int idx = (*aci)->getIdx();
+  for (size_t i = 0; i < static_cast<size_t>(nEntries); ++i) {
+    auto feat = nb::cast<MolChemicalFeature *>(featMatch[i]);
+    nb::list local;
+    for (const auto *atom : feat->getAtoms()) {
+      unsigned int idx = atom->getIdx();
       if (indices[idx]) {
-        return python::list();
+        return nb::list();
       } else {
         indices[idx] = 1;
       }
@@ -42,18 +41,11 @@ python::object GetAtomMatch(python::object featMatch, int maxAts = 1024) {
   }
   return res;
 }
+}  // namespace
 
-struct ChemicalFeatureUtils_wrapper {
-  static void wrap() {
-    python::def(
-        "GetAtomMatch", GetAtomMatch,
-        (python::arg("featMatch"), python::arg("maxAts") = 1024),
-        "Returns an empty list if any of the features passed in share an atom.\n\
- Otherwise a list of lists of atom indices is returned.\n");
-  }
-};
-}  // end of namespace RDKit
-
-void wrap_ChemicalFeatureUtils() {
-  RDKit::ChemicalFeatureUtils_wrapper::wrap();
+void wrap_ChemicalFeatureUtils(nb::module_ &m) {
+  m.def("GetAtomMatch", GetAtomMatch, "featMatch"_a, "maxAts"_a = 1024,
+        R"DOC(Returns an empty list if any of the features passed in share an atom.
+Otherwise a list of lists of atom indices is returned.
+)DOC");
 }

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
@@ -1,0 +1,59 @@
+//
+//  Copyright (C) 2006 Rational Discovery LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+#include <RDBoost/python.h>
+#include <boost/dynamic_bitset.hpp>
+#include <GraphMol/RDKitBase.h>
+#include <RDGeneral/types.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
+#include <ChemicalFeatures/FreeChemicalFeature.h>
+
+namespace python = boost::python;
+namespace RDKit {
+python::object GetAtomMatch(python::object featMatch, int maxAts = 1024) {
+  python::list res;
+  unsigned int nEntries = python::len(featMatch);
+
+  boost::dynamic_bitset<> indices(maxAts);
+  for (unsigned int i = 0; i < nEntries; ++i) {
+    MolChemicalFeature *feat =
+        python::extract<MolChemicalFeature *>(featMatch[i]);
+    const MolChemicalFeature::AtomPtrContainer &atoms = feat->getAtoms();
+    MolChemicalFeature::AtomPtrContainer_CI aci;
+    python::list local;
+    for (aci = atoms.begin(); aci != atoms.end(); ++aci) {
+      unsigned int idx = (*aci)->getIdx();
+      if (indices[idx]) {
+        return python::list();
+      } else {
+        indices[idx] = 1;
+      }
+      local.append(idx);
+    }
+    res.append(local);
+  }
+  return res;
+}
+
+struct ChemicalFeatureUtils_wrapper {
+  static void wrap() {
+    python::def(
+        "GetAtomMatch", GetAtomMatch,
+        (python::arg("featMatch"), python::arg("maxAts") = 1024),
+        "Returns an empty list if any of the features passed in share an atom.\n\
+ Otherwise a list of lists of atom indices is returned.\n");
+  }
+};
+}  // end of namespace RDKit
+
+void wrap_ChemicalFeatureUtils() {
+  RDKit::ChemicalFeatureUtils_wrapper::wrap();
+}

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
@@ -10,7 +10,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/shared_ptr.h>
 
-#include <boost/dynamic_bitset.hpp>
+#include <vector>
+
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
@@ -24,7 +25,7 @@ nb::object GetAtomMatch(nb::object featMatch, int maxAts = 1024) {
   nb::list res;
   auto nEntries = nb::len(featMatch);
 
-  boost::dynamic_bitset<> indices(maxAts);
+  std::vector<bool> indices(maxAts, false);
   for (size_t i = 0; i < static_cast<size_t>(nEntries); ++i) {
     auto feat = nb::cast<MolChemicalFeature *>(featMatch[i]);
     nb::list local;
@@ -33,7 +34,7 @@ nb::object GetAtomMatch(nb::object featMatch, int maxAts = 1024) {
       if (indices[idx]) {
         return nb::list();
       } else {
-        indices[idx] = 1;
+        indices[idx] = true;
       }
       local.append(idx);
     }

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/ChemicalFeatureUtils.cpp
@@ -21,7 +21,7 @@ using namespace nb::literals;
 using namespace RDKit;
 
 namespace {
-nb::object GetAtomMatch(nb::object featMatch, int maxAts = 1024) {
+nb::list GetAtomMatch(nb::object featMatch, int maxAts = 1024) {
   nb::list res;
   auto nEntries = nb::len(featMatch);
 

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
@@ -52,10 +52,10 @@ and location.
            "Get the IDs of the atoms that participate in the feature")
       .def("GetMol", &MolChemicalFeature::getMol,
            "Get the molecule used to derive the features",
-           nb::rv_policy::reference)
+           nb::rv_policy::reference_internal)
       .def("GetFactory", &MolChemicalFeature::getFactory,
            "Get the factory used to generate this feature",
-           nb::rv_policy::reference)
+           nb::rv_policy::reference_internal)
       .def("ClearCache", &MolChemicalFeature::clearCache,
            "Clears the cache used to store position information.")
       .def("SetActiveConformer", &MolChemicalFeature::setActiveConformer,

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2004-2026 Rational Discovery LLC and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,81 +7,61 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-#include <RDBoost/python.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
 
-#include <RDGeneral/types.h>
-#include <RDBoost/pyint_api.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace RDKit;
 
-namespace RDKit {
-PyObject *getFeatAtomIds(const MolChemicalFeature &feat) {
-  const MolChemicalFeature::AtomPtrContainer &atoms = feat.getAtoms();
-  PyObject *res = PyTuple_New(atoms.size());
-  MolChemicalFeature::AtomPtrContainer_CI aci;
-  int idx = 0;
-  for (aci = atoms.begin(); aci != atoms.end(); ++aci) {
-    PyTuple_SetItem(res, idx, PyInt_FromLong((*aci)->getIdx()));
-    idx++;
+namespace {
+nb::tuple getFeatAtomIds(const MolChemicalFeature &feat) {
+  nb::list res;
+  for (const auto *atom : feat.getAtoms()) {
+    res.append(atom->getIdx());
   }
-  return res;
+  return nb::tuple(res);
 }
+}  // namespace
 
-std::string featClassDoc =
-    "Class to represent a chemical feature.\n\
-    These chemical features may or may not have been derived from molecule object;\n\
-    i.e. it is possible to have a chemical feature that was created just from its type\n\
-    and location.\n";
-struct feat_wrapper {
-  static void wrap() {
-    python::class_<MolChemicalFeature, FeatSPtr>(
-        "MolChemicalFeature", featClassDoc.c_str(), python::no_init)
-
-        .def("GetId", &MolChemicalFeature::getId, python::args("self"),
-             "Returns the identifier of the feature\n")
-        .def("GetFamily", &MolChemicalFeature::getFamily,
-             "Get the family to which the feature belongs; donor, acceptor, "
-             "etc.",
-             python::return_value_policy<python::copy_const_reference>(),
-             python::args("self"))
-        .def("GetType", &MolChemicalFeature::getType,
-             "Get the specific type for the feature",
-             python::return_value_policy<python::copy_const_reference>(),
-             python::args("self"))
-        .def("GetPos",
-             (RDGeom::Point3D(MolChemicalFeature::*)(int) const) &
-                 MolChemicalFeature::getPos,
-             (python::arg("self"), python::arg("confId")),
-             "Get the location of the chemical feature")
-        .def(
-            "GetPos",
-            (RDGeom::Point3D(MolChemicalFeature::*)() const) &
-                MolChemicalFeature::getPos,
-            python::arg("self"),
-            "Get the location of the default chemical feature (first position)")
-        .def("GetAtomIds", getFeatAtomIds, python::args("self"),
-             "Get the IDs of the atoms that participate in the feature")
-        .def("GetMol", &MolChemicalFeature::getMol,
-             "Get the molecule used to derive the features",
-             python::return_value_policy<python::reference_existing_object>(),
-             python::args("self"))
-        .def("GetFactory", &MolChemicalFeature::getFactory,
-             "Get the factory used to generate this feature",
-             python::return_value_policy<python::reference_existing_object>(),
-             python::args("self"))
-        .def("ClearCache", &MolChemicalFeature::clearCache,
-             python::args("self"),
-             "Clears the cache used to store position information.")
-        .def("SetActiveConformer", &MolChemicalFeature::setActiveConformer,
-             python::args("self", "confId"),
-             "Sets the conformer to use (must be associated with a molecule).")
-        .def("GetActiveConformer", &MolChemicalFeature::getActiveConformer,
-             python::args("self"), "Gets the conformer to use.");
-  };
-};
-}  // namespace RDKit
-void wrap_MolChemicalFeat() { RDKit::feat_wrapper::wrap(); }
+void wrap_MolChemicalFeat(nb::module_ &m) {
+  nb::class_<MolChemicalFeature, std::shared_ptr<MolChemicalFeature>>(
+      m, "MolChemicalFeature",
+      R"DOC(Class to represent a chemical feature.
+These chemical features may or may not have been derived from molecule object;
+i.e. it is possible to have a chemical feature that was created just from its type
+and location.
+)DOC")
+      .def("GetId", &MolChemicalFeature::getId,
+           "Returns the identifier of the feature")
+      .def("GetFamily", &MolChemicalFeature::getFamily,
+           "Get the family to which the feature belongs; donor, acceptor, etc.")
+      .def("GetType", &MolChemicalFeature::getType,
+           "Get the specific type for the feature")
+      .def("GetPos",
+           nb::overload_cast<int>(&MolChemicalFeature::getPos, nb::const_),
+           "confId"_a, "Get the location of the chemical feature")
+      .def("GetPos",
+           nb::overload_cast<>(&MolChemicalFeature::getPos, nb::const_),
+           "Get the location of the default chemical feature (first position)")
+      .def("GetAtomIds", getFeatAtomIds,
+           "Get the IDs of the atoms that participate in the feature")
+      .def("GetMol", &MolChemicalFeature::getMol,
+           "Get the molecule used to derive the features",
+           nb::rv_policy::reference)
+      .def("GetFactory", &MolChemicalFeature::getFactory,
+           "Get the factory used to generate this feature",
+           nb::rv_policy::reference)
+      .def("ClearCache", &MolChemicalFeature::clearCache,
+           "Clears the cache used to store position information.")
+      .def("SetActiveConformer", &MolChemicalFeature::setActiveConformer,
+           "confId"_a,
+           "Sets the conformer to use (must be associated with a molecule).")
+      .def("GetActiveConformer", &MolChemicalFeature::getActiveConformer,
+           "Gets the conformer to use.");
+}

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
@@ -30,8 +30,7 @@ nb::tuple getFeatAtomIds(const MolChemicalFeature &feat) {
 }  // namespace
 
 void wrap_MolChemicalFeat(nb::module_ &m) {
-  nb::class_<MolChemicalFeature, std::shared_ptr<MolChemicalFeature>>(
-      m, "MolChemicalFeature",
+  nb::class_<MolChemicalFeature>(m, "MolChemicalFeature",
       R"DOC(Class to represent a chemical feature.
 These chemical features may or may not have been derived from molecule object;
 i.e. it is possible to have a chemical feature that was created just from its type

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeature.cpp
@@ -1,0 +1,87 @@
+//
+//  Copyright (C) 2004-2006 Rational Discovery LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+#include <RDBoost/python.h>
+
+#include <RDGeneral/types.h>
+#include <RDBoost/pyint_api.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
+
+namespace python = boost::python;
+
+namespace RDKit {
+PyObject *getFeatAtomIds(const MolChemicalFeature &feat) {
+  const MolChemicalFeature::AtomPtrContainer &atoms = feat.getAtoms();
+  PyObject *res = PyTuple_New(atoms.size());
+  MolChemicalFeature::AtomPtrContainer_CI aci;
+  int idx = 0;
+  for (aci = atoms.begin(); aci != atoms.end(); ++aci) {
+    PyTuple_SetItem(res, idx, PyInt_FromLong((*aci)->getIdx()));
+    idx++;
+  }
+  return res;
+}
+
+std::string featClassDoc =
+    "Class to represent a chemical feature.\n\
+    These chemical features may or may not have been derived from molecule object;\n\
+    i.e. it is possible to have a chemical feature that was created just from its type\n\
+    and location.\n";
+struct feat_wrapper {
+  static void wrap() {
+    python::class_<MolChemicalFeature, FeatSPtr>(
+        "MolChemicalFeature", featClassDoc.c_str(), python::no_init)
+
+        .def("GetId", &MolChemicalFeature::getId, python::args("self"),
+             "Returns the identifier of the feature\n")
+        .def("GetFamily", &MolChemicalFeature::getFamily,
+             "Get the family to which the feature belongs; donor, acceptor, "
+             "etc.",
+             python::return_value_policy<python::copy_const_reference>(),
+             python::args("self"))
+        .def("GetType", &MolChemicalFeature::getType,
+             "Get the specific type for the feature",
+             python::return_value_policy<python::copy_const_reference>(),
+             python::args("self"))
+        .def("GetPos",
+             (RDGeom::Point3D(MolChemicalFeature::*)(int) const) &
+                 MolChemicalFeature::getPos,
+             (python::arg("self"), python::arg("confId")),
+             "Get the location of the chemical feature")
+        .def(
+            "GetPos",
+            (RDGeom::Point3D(MolChemicalFeature::*)() const) &
+                MolChemicalFeature::getPos,
+            python::arg("self"),
+            "Get the location of the default chemical feature (first position)")
+        .def("GetAtomIds", getFeatAtomIds, python::args("self"),
+             "Get the IDs of the atoms that participate in the feature")
+        .def("GetMol", &MolChemicalFeature::getMol,
+             "Get the molecule used to derive the features",
+             python::return_value_policy<python::reference_existing_object>(),
+             python::args("self"))
+        .def("GetFactory", &MolChemicalFeature::getFactory,
+             "Get the factory used to generate this feature",
+             python::return_value_policy<python::reference_existing_object>(),
+             python::args("self"))
+        .def("ClearCache", &MolChemicalFeature::clearCache,
+             python::args("self"),
+             "Clears the cache used to store position information.")
+        .def("SetActiveConformer", &MolChemicalFeature::setActiveConformer,
+             python::args("self", "confId"),
+             "Sets the conformer to use (must be associated with a molecule).")
+        .def("GetActiveConformer", &MolChemicalFeature::getActiveConformer,
+             python::args("self"), "Gets the conformer to use.");
+  };
+};
+}  // namespace RDKit
+void wrap_MolChemicalFeat() { RDKit::feat_wrapper::wrap(); }

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeatureFactory.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeatureFactory.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2004-2026 Rational Discovery LLC and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,44 +7,32 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-#include <RDBoost/python.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+
+#include <algorithm>
 
 #include <GraphMol/RDKitBase.h>
-#include <RDGeneral/types.h>
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
-#include <boost/python/converter/shared_ptr_to_python.hpp>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace RDKit;
 
-namespace RDKit {
-// ----------------------------------------------------------------------------
-// NOTE: the reason we don't provide an interface to get all the
-// features from a molecule at the same time directly from C++ is a
-// potential problem with the lifetime of molecules and features:
-// Each Feature carries around a pointer to its owning molecule,
-//  and that pointer must remain valid. So we need to use the BPL's
-//  with_custodian_and_ward() functionality to tie the lifetime
-//  of the molecule to that of the feature. This is not currently
-//  possible in BPL v1.32 if we return a tuple of objects; so if
-//  we return a set of features, there's no way to use
-//  with_custodian_and_ward() to ensure that the molecule doesn't vanish
-//  underneath them.  Access to all of a molecule's features is provided
-//  from within python (looping over getMolFeature() and gaining efficiency
-//  by not recomputing after the first call).
-// ----------------------------------------------------------------------------
-
+namespace {
 int getNumMolFeatures(const MolChemicalFeatureFactory &factory,
-                      const ROMol &mol, std::string includeOnly = "") {
+                      const ROMol &mol,
+                      const std::string &includeOnly = "") {
   FeatSPtrList feats = factory.getFeaturesForMol(mol, includeOnly.c_str());
   return feats.size();
 }
 
-FeatSPtr getMolFeature(const MolChemicalFeatureFactory &factory,
-                       const ROMol &mol, int idx, std::string includeOnly,
-                       bool recompute, int confId) {
+std::shared_ptr<MolChemicalFeature> getMolFeature(
+    const MolChemicalFeatureFactory &factory, const ROMol &mol, int idx,
+    const std::string &includeOnly, bool recompute, int confId) {
   static FeatSPtrList feats;
   if (recompute) {
     feats = factory.getFeaturesForMol(mol, includeOnly.c_str(), confId);
@@ -52,64 +40,58 @@ FeatSPtr getMolFeature(const MolChemicalFeatureFactory &factory,
   if (idx < 0 || idx >= static_cast<int>(feats.size())) {
     throw IndexErrorException(idx);
   }
-
   auto fi = feats.begin();
   for (int i = 0; i < idx; ++i) {
     ++fi;
   }
-  return (*fi);
+  // Aliasing constructor: wraps the boost::shared_ptr in a std::shared_ptr
+  // so nanobind can manage the feature's lifetime correctly.
+  auto holder = std::make_shared<FeatSPtr>(*fi);
+  return std::shared_ptr<MolChemicalFeature>(holder, holder->get());
 }
 
-python::tuple getFeatureFamilies(const MolChemicalFeatureFactory &factory) {
-  python::list res;
-
-  MolChemicalFeatureDef::CollectionType::const_iterator iter;
-  for (iter = factory.beginFeatureDefs(); iter != factory.endFeatureDefs();
-       ++iter) {
+nb::tuple getFeatureFamilies(const MolChemicalFeatureFactory &factory) {
+  std::vector<std::string> fams;
+  for (auto iter = factory.beginFeatureDefs();
+       iter != factory.endFeatureDefs(); ++iter) {
     std::string fam = (*iter)->getFamily();
-    if (res.count(fam) == 0) {
-      res.append(fam);
+    if (std::find(fams.begin(), fams.end(), fam) == fams.end()) {
+      fams.push_back(fam);
     }
   }
-  return python::tuple(res);
+  nb::list res;
+  for (const auto &f : fams) {
+    res.append(f);
+  }
+  return nb::tuple(res);
 }
 
-python::dict getFeatureDefs(const MolChemicalFeatureFactory &factory) {
-  python::dict res;
-  MolChemicalFeatureDef::CollectionType::const_iterator iter;
-  for (iter = factory.beginFeatureDefs(); iter != factory.endFeatureDefs();
-       ++iter) {
+nb::dict getFeatureDefs(const MolChemicalFeatureFactory &factory) {
+  nb::dict res;
+  for (auto iter = factory.beginFeatureDefs();
+       iter != factory.endFeatureDefs(); ++iter) {
     std::string key = (*iter)->getFamily() + "." + (*iter)->getType();
-    res[key] = (*iter)->getSmarts();
+    res[key.c_str()] = (*iter)->getSmarts();
   }
   return res;
 }
+}  // namespace
 
-struct featfactory_wrapper {
-  static void wrap() {
-    std::string factoryClassDoc = "Class to featurize a molecule\n";
-    // no direct constructor - use buildFactory function
-    python::class_<MolChemicalFeatureFactory>(
-        "MolChemicalFeatureFactory", factoryClassDoc.c_str(), python::no_init)
-        .def("GetNumFeatureDefs", &MolChemicalFeatureFactory::getNumFeatureDefs,
-             python::args("self"), "Get the number of feature definitions")
-        .def("GetFeatureFamilies", getFeatureFamilies, python::args("self"),
-             "Get a tuple of feature types")
-        .def("GetFeatureDefs", getFeatureDefs, python::args("self"),
-             "Get a dictionary with SMARTS definitions for each feature type")
-        .def("GetNumMolFeatures", getNumMolFeatures,
-             ((python::arg("self"), python::arg("mol")),
-              python::arg("includeOnly") = std::string("")),
-             "Get the number of features the molecule has")
-        .def("GetMolFeature", getMolFeature,
-             ((python::arg("self"), python::arg("mol")), python::arg("idx"),
-              python::arg("includeOnly") = std::string(""),
-              python::arg("recompute") = true, python::arg("confId") = -1),
-             python::with_custodian_and_ward_postcall<
-                 0, 2, python::with_custodian_and_ward_postcall<0, 1>>(),
-             "returns a particular feature (by index)");
-  };
-};
-}  // namespace RDKit
-
-void wrap_factory() { RDKit::featfactory_wrapper::wrap(); }
+void wrap_factory(nb::module_ &m) {
+  nb::class_<MolChemicalFeatureFactory>(m, "MolChemicalFeatureFactory",
+                                        "Class to featurize a molecule")
+      .def("GetNumFeatureDefs",
+           &MolChemicalFeatureFactory::getNumFeatureDefs,
+           "Get the number of feature definitions")
+      .def("GetFeatureFamilies", getFeatureFamilies,
+           "Get a tuple of feature types")
+      .def("GetFeatureDefs", getFeatureDefs,
+           "Get a dictionary with SMARTS definitions for each feature type")
+      .def("GetNumMolFeatures", getNumMolFeatures, "mol"_a,
+           "includeOnly"_a = std::string(""),
+           "Get the number of features the molecule has")
+      .def("GetMolFeature", getMolFeature, "mol"_a, "idx"_a,
+           "includeOnly"_a = std::string(""), "recompute"_a = true,
+           "confId"_a = -1, nb::keep_alive<0, 1>(), nb::keep_alive<0, 2>(),
+           "returns a particular feature (by index)");
+}

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeatureFactory.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/MolChemicalFeatureFactory.cpp
@@ -1,0 +1,115 @@
+//
+//  Copyright (C) 2004-2006 Rational Discovery LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+#include <RDBoost/python.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <RDGeneral/types.h>
+#include <RDGeneral/Exceptions.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
+#include <boost/python/converter/shared_ptr_to_python.hpp>
+
+namespace python = boost::python;
+
+namespace RDKit {
+// ----------------------------------------------------------------------------
+// NOTE: the reason we don't provide an interface to get all the
+// features from a molecule at the same time directly from C++ is a
+// potential problem with the lifetime of molecules and features:
+// Each Feature carries around a pointer to its owning molecule,
+//  and that pointer must remain valid. So we need to use the BPL's
+//  with_custodian_and_ward() functionality to tie the lifetime
+//  of the molecule to that of the feature. This is not currently
+//  possible in BPL v1.32 if we return a tuple of objects; so if
+//  we return a set of features, there's no way to use
+//  with_custodian_and_ward() to ensure that the molecule doesn't vanish
+//  underneath them.  Access to all of a molecule's features is provided
+//  from within python (looping over getMolFeature() and gaining efficiency
+//  by not recomputing after the first call).
+// ----------------------------------------------------------------------------
+
+int getNumMolFeatures(const MolChemicalFeatureFactory &factory,
+                      const ROMol &mol, std::string includeOnly = "") {
+  FeatSPtrList feats = factory.getFeaturesForMol(mol, includeOnly.c_str());
+  return feats.size();
+}
+
+FeatSPtr getMolFeature(const MolChemicalFeatureFactory &factory,
+                       const ROMol &mol, int idx, std::string includeOnly,
+                       bool recompute, int confId) {
+  static FeatSPtrList feats;
+  if (recompute) {
+    feats = factory.getFeaturesForMol(mol, includeOnly.c_str(), confId);
+  }
+  if (idx < 0 || idx >= static_cast<int>(feats.size())) {
+    throw IndexErrorException(idx);
+  }
+
+  auto fi = feats.begin();
+  for (int i = 0; i < idx; ++i) {
+    ++fi;
+  }
+  return (*fi);
+}
+
+python::tuple getFeatureFamilies(const MolChemicalFeatureFactory &factory) {
+  python::list res;
+
+  MolChemicalFeatureDef::CollectionType::const_iterator iter;
+  for (iter = factory.beginFeatureDefs(); iter != factory.endFeatureDefs();
+       ++iter) {
+    std::string fam = (*iter)->getFamily();
+    if (res.count(fam) == 0) {
+      res.append(fam);
+    }
+  }
+  return python::tuple(res);
+}
+
+python::dict getFeatureDefs(const MolChemicalFeatureFactory &factory) {
+  python::dict res;
+  MolChemicalFeatureDef::CollectionType::const_iterator iter;
+  for (iter = factory.beginFeatureDefs(); iter != factory.endFeatureDefs();
+       ++iter) {
+    std::string key = (*iter)->getFamily() + "." + (*iter)->getType();
+    res[key] = (*iter)->getSmarts();
+  }
+  return res;
+}
+
+struct featfactory_wrapper {
+  static void wrap() {
+    std::string factoryClassDoc = "Class to featurize a molecule\n";
+    // no direct constructor - use buildFactory function
+    python::class_<MolChemicalFeatureFactory>(
+        "MolChemicalFeatureFactory", factoryClassDoc.c_str(), python::no_init)
+        .def("GetNumFeatureDefs", &MolChemicalFeatureFactory::getNumFeatureDefs,
+             python::args("self"), "Get the number of feature definitions")
+        .def("GetFeatureFamilies", getFeatureFamilies, python::args("self"),
+             "Get a tuple of feature types")
+        .def("GetFeatureDefs", getFeatureDefs, python::args("self"),
+             "Get a dictionary with SMARTS definitions for each feature type")
+        .def("GetNumMolFeatures", getNumMolFeatures,
+             ((python::arg("self"), python::arg("mol")),
+              python::arg("includeOnly") = std::string("")),
+             "Get the number of features the molecule has")
+        .def("GetMolFeature", getMolFeature,
+             ((python::arg("self"), python::arg("mol")), python::arg("idx"),
+              python::arg("includeOnly") = std::string(""),
+              python::arg("recompute") = true, python::arg("confId") = -1),
+             python::with_custodian_and_ward_postcall<
+                 0, 2, python::with_custodian_and_ward_postcall<0, 1>>(),
+             "returns a particular feature (by index)");
+  };
+};
+}  // namespace RDKit
+
+void wrap_factory() { RDKit::featfactory_wrapper::wrap(); }

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/rdMolChemicalFeatures.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/rdMolChemicalFeatures.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2006 Rational Discovery LLC
+//  Copyright (C) 2003-2026 Rational Discovery LLC and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,66 +7,59 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
-#include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
-#include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+
 #include <fstream>
 #include <sstream>
+
 #include <GraphMol/MolChemicalFeatures/FeatureParser.h>
-namespace python = boost::python;
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 
-void wrap_MolChemicalFeat();
-void wrap_factory();
-void wrap_ChemicalFeatureUtils();
+void wrap_MolChemicalFeat(nb::module_ &m);
+void wrap_factory(nb::module_ &m);
+void wrap_ChemicalFeatureUtils(nb::module_ &m);
 
-namespace RDKit {
-MolChemicalFeatureFactory *buildFeatFactory(std::string fileName) {
-  std::ifstream inStream(fileName.c_str());
+namespace {
+MolChemicalFeatureFactory *buildFeatFactory(const std::string &fileName) {
+  std::ifstream inStream(fileName);
   if (!inStream.is_open()) {
-    std::string errorstring = "File: " + fileName + " could not be opened.";
-    PyErr_SetString(PyExc_IOError, errorstring.c_str());
-    python::throw_error_already_set();
+    PyErr_SetString(PyExc_IOError,
+                    ("File: " + fileName + " could not be opened.").c_str());
+    throw nb::python_error();
   }
-  auto &instrm = static_cast<std::istream &>(inStream);
-  return buildFeatureFactory(instrm);
+  return buildFeatureFactory(static_cast<std::istream &>(inStream));
 }
 
-MolChemicalFeatureFactory *buildFeatFactoryFromString(std::string fdefString) {
+MolChemicalFeatureFactory *buildFeatFactoryFromString(
+    const std::string &fdefString) {
   std::istringstream inStream(fdefString);
-  auto &instrm = static_cast<std::istream &>(inStream);
-  return buildFeatureFactory(instrm);
+  return buildFeatureFactory(static_cast<std::istream &>(inStream));
 }
-}  // namespace RDKit
+}  // namespace
 
-void translate_FeatureFileParse_error(
-    RDKit::FeatureFileParseException const &e) {
-  std::stringstream err;
-  err << "Error parsing feature file at line " << e.lineNo() << ":"
-      << std::endl;
-  err << e.what() << std::endl;
-  PyErr_SetString(PyExc_ValueError, err.str().c_str());
-  python::throw_error_already_set();
-}
+NB_MODULE(rdMolChemicalFeatures, m) {
+  m.doc() =
+      R"DOC(Module containing from chemical feature and functions to generate the)DOC";
 
-BOOST_PYTHON_MODULE(rdMolChemicalFeatures) {
-  python::scope().attr("__doc__") =
-      "Module containing from chemical feature and functions to generate the";
-  python::register_exception_translator<RDKit::FeatureFileParseException>(
-      &translate_FeatureFileParse_error);
+  nb::exception<FeatureFileParseException>(m, "FeatureFileParseException",
+                                           PyExc_ValueError);
 
-  python::def(
-      "BuildFeatureFactory", RDKit::buildFeatFactory,
-      "Construct a feature factory given a feature definition in a file",
-      python::return_value_policy<python::manage_new_object>(),
-      python::args("fileName"));
-  python::def("BuildFeatureFactoryFromString",
-              RDKit::buildFeatFactoryFromString,
-              "Construct a feature factory given a feature definition block",
-              python::return_value_policy<python::manage_new_object>(),
-              python::args("fdefString"));
+  m.def("BuildFeatureFactory", buildFeatFactory, "fileName"_a,
+        "Construct a feature factory given a feature definition in a file",
+        nb::rv_policy::take_ownership);
+  m.def("BuildFeatureFactoryFromString", buildFeatFactoryFromString,
+        "fdefString"_a,
+        "Construct a feature factory given a feature definition block",
+        nb::rv_policy::take_ownership);
 
-  wrap_MolChemicalFeat();
-  wrap_factory();
-  wrap_ChemicalFeatureUtils();
+  wrap_MolChemicalFeat(m);
+  wrap_factory(m);
+  wrap_ChemicalFeatureUtils(m);
 }

--- a/Code/GraphMol/MolChemicalFeatures/nbWrap/rdMolChemicalFeatures.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/nbWrap/rdMolChemicalFeatures.cpp
@@ -1,0 +1,72 @@
+//
+//  Copyright (C) 2003-2006 Rational Discovery LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeature.h>
+#include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
+#include <fstream>
+#include <sstream>
+#include <GraphMol/MolChemicalFeatures/FeatureParser.h>
+namespace python = boost::python;
+using namespace RDKit;
+
+void wrap_MolChemicalFeat();
+void wrap_factory();
+void wrap_ChemicalFeatureUtils();
+
+namespace RDKit {
+MolChemicalFeatureFactory *buildFeatFactory(std::string fileName) {
+  std::ifstream inStream(fileName.c_str());
+  if (!inStream.is_open()) {
+    std::string errorstring = "File: " + fileName + " could not be opened.";
+    PyErr_SetString(PyExc_IOError, errorstring.c_str());
+    python::throw_error_already_set();
+  }
+  auto &instrm = static_cast<std::istream &>(inStream);
+  return buildFeatureFactory(instrm);
+}
+
+MolChemicalFeatureFactory *buildFeatFactoryFromString(std::string fdefString) {
+  std::istringstream inStream(fdefString);
+  auto &instrm = static_cast<std::istream &>(inStream);
+  return buildFeatureFactory(instrm);
+}
+}  // namespace RDKit
+
+void translate_FeatureFileParse_error(
+    RDKit::FeatureFileParseException const &e) {
+  std::stringstream err;
+  err << "Error parsing feature file at line " << e.lineNo() << ":"
+      << std::endl;
+  err << e.what() << std::endl;
+  PyErr_SetString(PyExc_ValueError, err.str().c_str());
+  python::throw_error_already_set();
+}
+
+BOOST_PYTHON_MODULE(rdMolChemicalFeatures) {
+  python::scope().attr("__doc__") =
+      "Module containing from chemical feature and functions to generate the";
+  python::register_exception_translator<RDKit::FeatureFileParseException>(
+      &translate_FeatureFileParse_error);
+
+  python::def(
+      "BuildFeatureFactory", RDKit::buildFeatFactory,
+      "Construct a feature factory given a feature definition in a file",
+      python::return_value_policy<python::manage_new_object>(),
+      python::args("fileName"));
+  python::def("BuildFeatureFactoryFromString",
+              RDKit::buildFeatFactoryFromString,
+              "Construct a feature factory given a feature definition block",
+              python::return_value_policy<python::manage_new_object>(),
+              python::args("fdefString"));
+
+  wrap_MolChemicalFeat();
+  wrap_factory();
+  wrap_ChemicalFeatureUtils();
+}


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to MolChemicalFeatures.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.

DistGeomHelpers depends on this module.