### PR TITLE
pr/SHARED-12378: Implement nanobind for Alignment

### DIFF
--- a/Code/Numerics/Alignment/CMakeLists.txt
+++ b/Code/Numerics/Alignment/CMakeLists.txt
@@ -9,3 +9,7 @@ rdkit_catch_test(testAlignment testAlignment.cpp LINK_LIBRARIES Alignment )
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/Numerics/Alignment/Wrap/testAlignment.py
+++ b/Code/Numerics/Alignment/Wrap/testAlignment.py
@@ -180,6 +180,25 @@ class TestCase(unittest.TestCase):
     self.assertRaises(ValueError, lambda: rdAlg.GetAlignmentTransform(refPts, prbPts))
 
 
+  def test6NumpyInputs(self):
+    # numpy arrays are supported as points and weights via the sequence protocol
+    refPts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], float)
+    prbPts = np.array([[2.0, 2.0, 3.0], [3.0, 2.0, 3.0], [2.0, 3.0, 3.0], [2.0, 2.0, 4.0]], float)
+    wts = np.array([1.0, 1.0, 1.0, 1.0], float)
+
+    res = rdAlg.GetAlignmentTransform(refPts, prbPts, wts)
+    self.assertTrue(feq(res[0], 0.0))
+
+    # reflect accepts bool or int
+    res_bool = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=True)
+    res_int = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=1)
+    self.assertTrue(feq(res_bool[0], res_int[0]))
+
+    res_bool = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=False)
+    res_int = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=0)
+    self.assertTrue(feq(res_bool[0], res_int[0]))
+
+
 if __name__ == '__main__':
   print("Testing Alignment Wrapper code:")
   unittest.main()

--- a/Code/Numerics/Alignment/Wrap/testAlignment.py
+++ b/Code/Numerics/Alignment/Wrap/testAlignment.py
@@ -126,7 +126,7 @@ class TestCase(unittest.TestCase):
     res = rdAlg.GetAlignmentTransform(refPts, prbPts, wts)
     self.assertTrue(feq(res[0], 1.0))
 
-    res = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, 1)
+    res = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, True)
     self.assertTrue(feq(res[0], 0.0))
     cnt = 0
     refLst = list(refPts)
@@ -178,25 +178,6 @@ class TestCase(unittest.TestCase):
       (2.0, 2.0, 5.0),
     )
     self.assertRaises(ValueError, lambda: rdAlg.GetAlignmentTransform(refPts, prbPts))
-
-
-  def test6NumpyInputs(self):
-    # numpy arrays are supported as points and weights via the sequence protocol
-    refPts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], float)
-    prbPts = np.array([[2.0, 2.0, 3.0], [3.0, 2.0, 3.0], [2.0, 3.0, 3.0], [2.0, 2.0, 4.0]], float)
-    wts = np.array([1.0, 1.0, 1.0, 1.0], float)
-
-    res = rdAlg.GetAlignmentTransform(refPts, prbPts, wts)
-    self.assertTrue(feq(res[0], 0.0))
-
-    # reflect accepts bool or int
-    res_bool = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=True)
-    res_int = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=1)
-    self.assertTrue(feq(res_bool[0], res_int[0]))
-
-    res_bool = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=False)
-    res_int = rdAlg.GetAlignmentTransform(refPts, prbPts, wts, reflect=0)
-    self.assertTrue(feq(res_bool[0], res_int[0]))
 
 
 if __name__ == '__main__':

--- a/Code/Numerics/Alignment/nbWrap/CMakeLists.txt
+++ b/Code/Numerics/Alignment/nbWrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+remove_definitions(-DRDKIT_ALIGNMENT_BUILD)
+rdkit_python_extension(rdAlignment
+                       rdAlignment.cpp
+                       DEST Numerics 
+                       LINK_LIBRARIES Alignment)
+
+add_pytest(pyAlignment ${CMAKE_CURRENT_SOURCE_DIR}/testAlignment.py)
+

--- a/Code/Numerics/Alignment/nbWrap/CMakeLists.txt
+++ b/Code/Numerics/Alignment/nbWrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 remove_definitions(-DRDKIT_ALIGNMENT_BUILD)
-rdkit_python_extension(rdAlignment
-                       rdAlignment.cpp
-                       DEST Numerics 
-                       LINK_LIBRARIES Alignment)
+rdkit_nanobind_extension(rdAlignment
+                         rdAlignment.cpp
+                         DEST Numerics
+                         LINK_LIBRARIES Alignment)
 
-add_pytest(pyAlignment ${CMAKE_CURRENT_SOURCE_DIR}/testAlignment.py)
+add_pytest(pyAlignment ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testAlignment.py)
 

--- a/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
+++ b/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
@@ -1,0 +1,204 @@
+//
+//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define PY_ARRAY_UNIQUE_SYMBOL rdalignment_array_API
+#include <RDBoost/python.h>
+#include <RDBoost/boost_numpy.h>
+#include <RDBoost/import_array.h>
+
+#include <RDBoost/PySequenceHolder.h>
+#include <RDBoost/Wrap.h>
+#include <Geometry/point.h>
+
+#include <Numerics/Alignment/AlignPoints.h>
+
+namespace python = boost::python;
+
+namespace RDNumeric {
+namespace Alignments {
+
+class PointVectManager {
+ public:
+  PointVectManager() = default;
+  PointVectManager(const PointVectManager &rhs) = delete;
+  PointVectManager &operator=(const PointVectManager &rhs) = delete;
+  ~PointVectManager() {
+    for (auto &i : m_ptr) {
+      delete i;
+    }
+  }
+
+  RDGeom::Point3DConstPtrVect &getVect() { return m_ptr; }
+
+ private:
+  RDGeom::Point3DConstPtrVect m_ptr;
+};
+
+void GetPointsFromPythonSequence(python::object &points,
+                                 RDGeom::Point3DConstPtrVect &pts) {
+  PyObject *pyObj = points.ptr();
+  unsigned int nrows, ncols;
+  double *data;
+  if (PyArray_Check(pyObj)) {
+    // get the dimensions of the array
+    auto *ptsMat = reinterpret_cast<PyArrayObject *>(pyObj);
+    nrows = PyArray_DIM(ptsMat, 0);
+    ncols = PyArray_DIM(ptsMat, 1);
+
+    if (ncols != 3) {
+      throw_value_error("Wrong dimension for the points array");
+    }
+
+    data = reinterpret_cast<double *>(PyArray_DATA(ptsMat));
+
+    for (unsigned int i = 0; i < nrows; i++) {
+      auto *rpt =
+          new RDGeom::Point3D(data[i * 3], data[i * 3 + 1], data[i * 3 + 2]);
+      pts.push_back(rpt);
+    }
+  } else if (PySequence_Check(pyObj)) {
+    nrows = PySequence_Size(pyObj);
+    if (nrows <= 0) {
+      throw_value_error("Empty sequence passed in");
+    }
+    python::extract<RDGeom::Point3D> ptOk(points[0]);
+    if (!ptOk.check()) {
+      for (unsigned int i = 0; i < nrows; i++) {
+        PySequenceHolder<double> row(points[i]);
+        if (row.size() != 3) {
+          throw_value_error("Wrong number of entries in the list of lists");
+        }
+        auto *rpt = new RDGeom::Point3D(row[0], row[1], row[2]);
+        pts.push_back(rpt);
+      }
+    } else {
+      for (unsigned int i = 0; i < nrows; i++) {
+        python::extract<RDGeom::Point3D> pt(points[i]);
+        if (pt.check()) {
+          auto *rpt = new RDGeom::Point3D(pt);
+          pts.push_back(rpt);
+        } else {
+          throw_value_error("non-Point3D found in sequence of points");
+        }
+      }
+    }
+  } else {
+    throw_value_error("non-sequence argument provided");
+  }
+}
+
+PyObject *AlignPointPairs(python::object refPoints, python::object probePoints,
+                          python::object weights = python::list(),
+                          bool reflect = false,
+                          unsigned int maxIterations = 50) {
+  // The reference and probe points can be specified in two formats
+  // 1. A Numeric array of dimensions (N,3) where N is the number of points
+  // 2. A list (or tuple) or lists (or tuples)
+  //
+  // The similar thing applies to weights
+  // 1. Can be a numeric vector of size N
+  // 2. A list of doubles of size N
+
+  // first deal with situation where we have Numerics arrays
+  PointVectManager refPts, probePts;
+
+  GetPointsFromPythonSequence(refPoints, refPts.getVect());
+  GetPointsFromPythonSequence(probePoints, probePts.getVect());
+
+  unsigned int npt = refPts.getVect().size();
+  if (npt != probePts.getVect().size()) {
+    throw_value_error("Mis-match in number of points");
+  }
+
+  PyObject *weightsObj = weights.ptr();
+  std::unique_ptr<RDNumeric::DoubleVector> wtsVec;
+  double *data;
+  if (PyArray_Check(weightsObj)) {
+    auto *wtsMat = reinterpret_cast<PyArrayObject *>(weightsObj);
+    unsigned int nwts = PyArray_DIM(wtsMat, 0);
+    if (nwts != npt) {
+      throw_value_error(
+          "Number of weights supplied do not match the number of points");
+    }
+    wtsVec.reset(new RDNumeric::DoubleVector(nwts));
+    data = reinterpret_cast<double *>(PyArray_DATA(wtsMat));
+    for (unsigned int i = 0; i < nwts; i++) {
+      wtsVec->setVal(i, data[i]);
+    }
+  } else {
+    PySequenceHolder<double> wts(weights);
+    unsigned int nwts = wts.size();
+
+    if (nwts > 0) {
+      if (nwts != npt) {
+        throw_value_error(
+            "Number of weights supplied do not match the number of points");
+      }
+      wtsVec.reset(new RDNumeric::DoubleVector(nwts));
+      for (unsigned int i = 0; i < npt; i++) {
+        wtsVec->setVal(i, wts[i]);
+      }
+    }
+  }
+
+  RDGeom::Transform3D trans;
+  double ssd = AlignPoints(refPts.getVect(), probePts.getVect(), trans,
+                           wtsVec.get(), reflect, maxIterations);
+
+  npy_intp dims[2];
+  dims[0] = 4;
+  dims[1] = 4;
+  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
+  const double *tdata = trans.getData();
+  for (unsigned int i = 0; i < trans.numRows(); ++i) {
+    unsigned int itab = i * 4;
+    for (unsigned int j = 0; j < trans.numRows(); ++j) {
+      resData[itab + j] = tdata[itab + j];
+    }
+  }
+
+  PyObject *resTup = PyTuple_New(2);
+  PyObject *ssdItem = PyFloat_FromDouble(ssd);
+  PyTuple_SetItem(resTup, 0, ssdItem);
+  PyTuple_SetItem(resTup, 1, PyArray_Return(res));
+  return resTup;
+}
+}  // namespace Alignments
+}  // namespace RDNumeric
+
+BOOST_PYTHON_MODULE(rdAlignment) {
+  rdkit_import_array();
+  python::scope().attr("__doc__") =
+      "Module containing functions to align pairs of points in 3D";
+
+  std::string docString =
+      "Compute the optimal alignment (minimum RMSD) between two set of points using the quaternion algorithm \n\n\
+ \n\
+ ARGUMENTS:\n\n\
+    - refPoints : reference points specified as a N by 3 Numeric array or \n\
+                  sequence of 3-sequences or sequence of Point3Ds \n\
+    - probePoints : probe points to align to reference points - same format \n\
+                  restrictions as reference points apply here \n\
+    - weights : optional numeric vector or list of weights to associate to each pair of points\n\
+    - reflect : reflect the probe points before attempting alignment\n\
+    - maxIteration : maximum number of iterations for the eigen solver \n\
+                  \n\
+ RETURNS:\n\n\
+    a 2-tuple:\n\
+      - SSD value for the alignment\n\
+      - the 4x4 transform matrix, as a Numeric array\n\
+\n";
+  python::def(
+      "GetAlignmentTransform", RDNumeric::Alignments::AlignPointPairs,
+      (python::arg("refPoints"), python::arg("probePoints"),
+       python::arg("weights") = python::list(), python::arg("reflect") = false,
+       python::arg("maxIterations") = 50),
+      docString.c_str());
+}

--- a/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
+++ b/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
@@ -28,31 +28,27 @@ void fillPointVec(nb::object seq, std::vector<RDGeom::Point3D> &pts) {
     throw nb::value_error("expected a non-empty sequence of points");
   }
 
-  // Determine mode from the first element: Point3D objects (detected via
-  // duck-typing) vs. coordinate sequences (lists, tuples, numpy rows, etc.)
-  auto first = s[0];
-  bool point3dMode =
-      nb::hasattr(first, "x") && nb::hasattr(first, "y") && nb::hasattr(first, "z");
+  // Determine mode by trying to cast the first element to Point3D
+  RDGeom::Point3D testPt;
+  bool point3dMode = nb::try_cast<RDGeom::Point3D>(s[0], testPt);
 
   for (auto item : s) {
     if (point3dMode) {
-      if (!nb::hasattr(item, "x") || !nb::hasattr(item, "y") ||
-          !nb::hasattr(item, "z")) {
+      RDGeom::Point3D pt;
+      if (!nb::try_cast<RDGeom::Point3D>(item, pt)) {
         throw nb::value_error("non-Point3D found in sequence of points");
       }
-      pts.emplace_back(nb::cast<double>(item.attr("x")),
-                       nb::cast<double>(item.attr("y")),
-                       nb::cast<double>(item.attr("z")));
+      pts.push_back(pt);
     } else {
       if (!nb::isinstance<nb::sequence>(item)) {
         throw nb::value_error("non-sequence found in sequence of points");
       }
-      auto s = nb::cast<nb::sequence>(item);
-      if (nb::len(s) != 3) {
+      auto coords = nb::cast<nb::sequence>(item);
+      if (nb::len(coords) != 3) {
         throw nb::value_error("each point must have 3 coordinates");
       }
-      pts.emplace_back(nb::cast<double>(s[0]), nb::cast<double>(s[1]),
-                       nb::cast<double>(s[2]));
+      pts.emplace_back(nb::cast<double>(coords[0]), nb::cast<double>(coords[1]),
+                       nb::cast<double>(coords[2]));
     }
   }
 }

--- a/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
+++ b/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2004-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,198 +7,130 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define PY_ARRAY_UNIQUE_SYMBOL rdalignment_array_API
-#include <RDBoost/python.h>
-#include <RDBoost/boost_numpy.h>
-#include <RDBoost/import_array.h>
+#include <nanobind/nanobind.h>
 
-#include <RDBoost/PySequenceHolder.h>
-#include <RDBoost/Wrap.h>
 #include <Geometry/point.h>
-
+#include <Geometry/Transform3D.h>
+#include <Numerics/Vector.h>
 #include <Numerics/Alignment/AlignPoints.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
-namespace RDNumeric {
-namespace Alignments {
+namespace {
 
-class PointVectManager {
- public:
-  PointVectManager() = default;
-  PointVectManager(const PointVectManager &rhs) = delete;
-  PointVectManager &operator=(const PointVectManager &rhs) = delete;
-  ~PointVectManager() {
-    for (auto &i : m_ptr) {
-      delete i;
-    }
+void fillPointVec(nb::object seq, std::vector<RDGeom::Point3D> &pts) {
+  if (!nb::isinstance<nb::sequence>(seq)) {
+    throw nb::value_error("expected a non-empty sequence of points");
+  }
+  auto s = nb::cast<nb::sequence>(seq);
+  if (nb::len(s) == 0) {
+    throw nb::value_error("expected a non-empty sequence of points");
   }
 
-  RDGeom::Point3DConstPtrVect &getVect() { return m_ptr; }
+  // Determine mode from the first element: Point3D objects (detected via
+  // duck-typing) vs. coordinate sequences (lists, tuples, numpy rows, etc.)
+  auto first = s[0];
+  bool point3dMode =
+      nb::hasattr(first, "x") && nb::hasattr(first, "y") && nb::hasattr(first, "z");
 
- private:
-  RDGeom::Point3DConstPtrVect m_ptr;
-};
-
-void GetPointsFromPythonSequence(python::object &points,
-                                 RDGeom::Point3DConstPtrVect &pts) {
-  PyObject *pyObj = points.ptr();
-  unsigned int nrows, ncols;
-  double *data;
-  if (PyArray_Check(pyObj)) {
-    // get the dimensions of the array
-    auto *ptsMat = reinterpret_cast<PyArrayObject *>(pyObj);
-    nrows = PyArray_DIM(ptsMat, 0);
-    ncols = PyArray_DIM(ptsMat, 1);
-
-    if (ncols != 3) {
-      throw_value_error("Wrong dimension for the points array");
-    }
-
-    data = reinterpret_cast<double *>(PyArray_DATA(ptsMat));
-
-    for (unsigned int i = 0; i < nrows; i++) {
-      auto *rpt =
-          new RDGeom::Point3D(data[i * 3], data[i * 3 + 1], data[i * 3 + 2]);
-      pts.push_back(rpt);
-    }
-  } else if (PySequence_Check(pyObj)) {
-    nrows = PySequence_Size(pyObj);
-    if (nrows <= 0) {
-      throw_value_error("Empty sequence passed in");
-    }
-    python::extract<RDGeom::Point3D> ptOk(points[0]);
-    if (!ptOk.check()) {
-      for (unsigned int i = 0; i < nrows; i++) {
-        PySequenceHolder<double> row(points[i]);
-        if (row.size() != 3) {
-          throw_value_error("Wrong number of entries in the list of lists");
-        }
-        auto *rpt = new RDGeom::Point3D(row[0], row[1], row[2]);
-        pts.push_back(rpt);
+  for (auto item : s) {
+    if (point3dMode) {
+      if (!nb::hasattr(item, "x") || !nb::hasattr(item, "y") ||
+          !nb::hasattr(item, "z")) {
+        throw nb::value_error("non-Point3D found in sequence of points");
       }
+      pts.emplace_back(nb::cast<double>(item.attr("x")),
+                       nb::cast<double>(item.attr("y")),
+                       nb::cast<double>(item.attr("z")));
     } else {
-      for (unsigned int i = 0; i < nrows; i++) {
-        python::extract<RDGeom::Point3D> pt(points[i]);
-        if (pt.check()) {
-          auto *rpt = new RDGeom::Point3D(pt);
-          pts.push_back(rpt);
-        } else {
-          throw_value_error("non-Point3D found in sequence of points");
-        }
+      if (!nb::isinstance<nb::sequence>(item)) {
+        throw nb::value_error("non-sequence found in sequence of points");
       }
+      auto s = nb::cast<nb::sequence>(item);
+      if (nb::len(s) != 3) {
+        throw nb::value_error("each point must have 3 coordinates");
+      }
+      pts.emplace_back(nb::cast<double>(s[0]), nb::cast<double>(s[1]),
+                       nb::cast<double>(s[2]));
     }
-  } else {
-    throw_value_error("non-sequence argument provided");
   }
 }
 
-PyObject *AlignPointPairs(python::object refPoints, python::object probePoints,
-                          python::object weights = python::list(),
-                          bool reflect = false,
+nb::tuple AlignPointPairs(nb::object refPoints, nb::object probePoints,
+                          nb::object weights = nb::none(),
+                          int reflect = 0,
                           unsigned int maxIterations = 50) {
-  // The reference and probe points can be specified in two formats
-  // 1. A Numeric array of dimensions (N,3) where N is the number of points
-  // 2. A list (or tuple) or lists (or tuples)
-  //
-  // The similar thing applies to weights
-  // 1. Can be a numeric vector of size N
-  // 2. A list of doubles of size N
+  std::vector<RDGeom::Point3D> refOwned, probeOwned;
+  fillPointVec(refPoints, refOwned);
+  fillPointVec(probePoints, probeOwned);
 
-  // first deal with situation where we have Numerics arrays
-  PointVectManager refPts, probePts;
-
-  GetPointsFromPythonSequence(refPoints, refPts.getVect());
-  GetPointsFromPythonSequence(probePoints, probePts.getVect());
-
-  unsigned int npt = refPts.getVect().size();
-  if (npt != probePts.getVect().size()) {
-    throw_value_error("Mis-match in number of points");
+  if (refOwned.size() != probeOwned.size()) {
+    throw nb::value_error("Mis-match in number of points");
   }
 
-  PyObject *weightsObj = weights.ptr();
+  RDGeom::Point3DConstPtrVect refPts, probePts;
+  for (auto &p : refOwned) refPts.push_back(&p);
+  for (auto &p : probeOwned) probePts.push_back(&p);
+
   std::unique_ptr<RDNumeric::DoubleVector> wtsVec;
-  double *data;
-  if (PyArray_Check(weightsObj)) {
-    auto *wtsMat = reinterpret_cast<PyArrayObject *>(weightsObj);
-    unsigned int nwts = PyArray_DIM(wtsMat, 0);
-    if (nwts != npt) {
-      throw_value_error(
+  if (!weights.is_none()) {
+    auto wseq = nb::cast<nb::sequence>(weights);
+    auto nwts = nb::len(wseq);
+    if (nwts != refOwned.size()) {
+      throw nb::value_error(
           "Number of weights supplied do not match the number of points");
     }
-    wtsVec.reset(new RDNumeric::DoubleVector(nwts));
-    data = reinterpret_cast<double *>(PyArray_DATA(wtsMat));
-    for (unsigned int i = 0; i < nwts; i++) {
-      wtsVec->setVal(i, data[i]);
-    }
-  } else {
-    PySequenceHolder<double> wts(weights);
-    unsigned int nwts = wts.size();
-
-    if (nwts > 0) {
-      if (nwts != npt) {
-        throw_value_error(
-            "Number of weights supplied do not match the number of points");
-      }
-      wtsVec.reset(new RDNumeric::DoubleVector(nwts));
-      for (unsigned int i = 0; i < npt; i++) {
-        wtsVec->setVal(i, wts[i]);
-      }
+    wtsVec = std::make_unique<RDNumeric::DoubleVector>(nwts);
+    size_t i = 0;
+    for (auto w : wseq) {
+      wtsVec->setVal(i++, nb::cast<double>(w));
     }
   }
 
   RDGeom::Transform3D trans;
-  double ssd = AlignPoints(refPts.getVect(), probePts.getVect(), trans,
-                           wtsVec.get(), reflect, maxIterations);
+  double ssd = RDNumeric::Alignments::AlignPoints(refPts, probePts, trans,
+                                                   wtsVec.get(),
+                                                   static_cast<bool>(reflect),
+                                                   maxIterations);
 
-  npy_intp dims[2];
-  dims[0] = 4;
-  dims[1] = 4;
-  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
-  auto *resData = reinterpret_cast<double *>(PyArray_DATA(res));
   const double *tdata = trans.getData();
-  for (unsigned int i = 0; i < trans.numRows(); ++i) {
-    unsigned int itab = i * 4;
-    for (unsigned int j = 0; j < trans.numRows(); ++j) {
-      resData[itab + j] = tdata[itab + j];
+  nb::list mat;
+  for (int i = 0; i < 4; i++) {
+    nb::list row;
+    for (int j = 0; j < 4; j++) {
+      row.append(tdata[i * 4 + j]);
     }
+    mat.append(row);
   }
 
-  PyObject *resTup = PyTuple_New(2);
-  PyObject *ssdItem = PyFloat_FromDouble(ssd);
-  PyTuple_SetItem(resTup, 0, ssdItem);
-  PyTuple_SetItem(resTup, 1, PyArray_Return(res));
-  return resTup;
+  return nb::make_tuple(ssd, mat);
 }
-}  // namespace Alignments
-}  // namespace RDNumeric
 
-BOOST_PYTHON_MODULE(rdAlignment) {
-  rdkit_import_array();
-  python::scope().attr("__doc__") =
-      "Module containing functions to align pairs of points in 3D";
+}  // namespace
 
-  std::string docString =
-      "Compute the optimal alignment (minimum RMSD) between two set of points using the quaternion algorithm \n\n\
- \n\
- ARGUMENTS:\n\n\
-    - refPoints : reference points specified as a N by 3 Numeric array or \n\
-                  sequence of 3-sequences or sequence of Point3Ds \n\
-    - probePoints : probe points to align to reference points - same format \n\
-                  restrictions as reference points apply here \n\
-    - weights : optional numeric vector or list of weights to associate to each pair of points\n\
-    - reflect : reflect the probe points before attempting alignment\n\
-    - maxIteration : maximum number of iterations for the eigen solver \n\
-                  \n\
- RETURNS:\n\n\
-    a 2-tuple:\n\
-      - SSD value for the alignment\n\
-      - the 4x4 transform matrix, as a Numeric array\n\
-\n";
-  python::def(
-      "GetAlignmentTransform", RDNumeric::Alignments::AlignPointPairs,
-      (python::arg("refPoints"), python::arg("probePoints"),
-       python::arg("weights") = python::list(), python::arg("reflect") = false,
-       python::arg("maxIterations") = 50),
-      docString.c_str());
+NB_MODULE(rdAlignment, m) {
+  m.doc() = "Module containing functions to align pairs of points in 3D";
+
+  m.def(
+      "GetAlignmentTransform", &AlignPointPairs, "refPoints"_a,
+      "probePoints"_a, "weights"_a = nb::none(), "reflect"_a = 0,
+      "maxIterations"_a = 50,
+      R"DOC(Compute the optimal alignment (minimum RMSD) between two set of points using the quaternion algorithm
+
+ARGUMENTS:
+
+  - refPoints : reference points specified as a sequence of 3-sequences or sequence of Point3Ds
+  - probePoints : probe points to align to reference points - same format
+    restrictions as reference points apply here
+  - weights : optional sequence of weights to associate to each pair of points
+  - reflect : reflect the probe points before attempting alignment
+  - maxIterations : maximum number of iterations for the eigen solver
+
+RETURNS:
+
+  a 2-tuple:
+    - SSD value for the alignment
+    - the 4x4 transform matrix, as a list of lists
+)DOC");
 }

--- a/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
+++ b/Code/Numerics/Alignment/nbWrap/rdAlignment.cpp
@@ -59,7 +59,7 @@ void fillPointVec(nb::object seq, std::vector<RDGeom::Point3D> &pts) {
 
 nb::tuple AlignPointPairs(nb::object refPoints, nb::object probePoints,
                           nb::object weights = nb::none(),
-                          int reflect = 0,
+                          bool reflect = false,
                           unsigned int maxIterations = 50) {
   std::vector<RDGeom::Point3D> refOwned, probeOwned;
   fillPointVec(refPoints, refOwned);
@@ -90,8 +90,7 @@ nb::tuple AlignPointPairs(nb::object refPoints, nb::object probePoints,
 
   RDGeom::Transform3D trans;
   double ssd = RDNumeric::Alignments::AlignPoints(refPts, probePts, trans,
-                                                   wtsVec.get(),
-                                                   static_cast<bool>(reflect),
+                                                   wtsVec.get(), reflect,
                                                    maxIterations);
 
   const double *tdata = trans.getData();
@@ -114,7 +113,7 @@ NB_MODULE(rdAlignment, m) {
 
   m.def(
       "GetAlignmentTransform", &AlignPointPairs, "refPoints"_a,
-      "probePoints"_a, "weights"_a = nb::none(), "reflect"_a = 0,
+      "probePoints"_a, "weights"_a = nb::none(), "reflect"_a = false,
       "maxIterations"_a = 50,
       R"DOC(Compute the optimal alignment (minimum RMSD) between two set of points using the quaternion algorithm
 


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to Alignment.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.