### PR TITLE
ignore new member functions

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -98,6 +98,16 @@
 %ignore RDKit::ROMol::bonds();
 %ignore RDKit::ROMol::bonds() const;
 
+%ignore RDKit::ROMol::checkedAtomNeighbors(Atom const *at) const;
+%ignore RDKit::ROMol::checkedAtomNeighbors(Atom const *at);
+%ignore RDKit::ROMol::checkedAtoms() const;
+%ignore RDKit::ROMol::checkedAtoms();
+
+%ignore RDKit::ROMol::checkedAtomBonds(Atom const *at) const;
+%ignore RDKit::ROMol::checkedAtomBonds(Atom const *at);
+%ignore RDKit::ROMol::checkedBonds();
+%ignore RDKit::ROMol::checkedBonds() const;
+
 %ignore RDKit::ROMol::getVertices() ;
 %ignore RDKit::ROMol::getVertices() const ;
 %ignore RDKit::ROMol::getEdges() ;


### PR DESCRIPTION
I took the easy solution.

I noticed everything that returns a CXX Atom/Bond Iterator is already ignored, so I ignored the new functions too, so we don't need to wrap the CXX iterators and they get ignored by SWIG.

Not sure if this actually duplicates definitions in Java (see comment above the previous block) or if we are not the first ones that tried and failed to wrap the CXX iterators...

