### PR TITLE
pr/SHARED-12417: Implement nanobind for ShapeHelpers

### DIFF
--- a/Code/GraphMol/ShapeHelpers/CMakeLists.txt
+++ b/Code/GraphMol/ShapeHelpers/CMakeLists.txt
@@ -14,3 +14,7 @@ if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
 
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()
+

--- a/Code/GraphMol/ShapeHelpers/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/ShapeHelpers/nbWrap/CMakeLists.txt
@@ -1,0 +1,10 @@
+remove_definitions(-DRDKIT_SHAPEHELPERS_BUILD)
+rdkit_python_extension(rdShapeHelpers rdShapeHelpers.cpp
+                       DEST Chem
+		       LINK_LIBRARIES
+                       ShapeHelpers )
+
+add_pytest(pyShapeHelpers
+         ${CMAKE_CURRENT_SOURCE_DIR}/testShapeHelpers.py)
+
+

--- a/Code/GraphMol/ShapeHelpers/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/ShapeHelpers/nbWrap/CMakeLists.txt
@@ -1,10 +1,8 @@
 remove_definitions(-DRDKIT_SHAPEHELPERS_BUILD)
-rdkit_python_extension(rdShapeHelpers rdShapeHelpers.cpp
-                       DEST Chem
-		       LINK_LIBRARIES
-                       ShapeHelpers )
+rdkit_nanobind_extension(rdShapeHelpers rdShapeHelpers.cpp
+                         DEST Chem
+                         LINK_LIBRARIES
+                         ShapeHelpers)
 
-add_pytest(pyShapeHelpers
-         ${CMAKE_CURRENT_SOURCE_DIR}/testShapeHelpers.py)
-
+add_pytest(pyShapeHelpers ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testShapeHelpers.py)
 

--- a/Code/GraphMol/ShapeHelpers/nbWrap/rdShapeHelpers.cpp
+++ b/Code/GraphMol/ShapeHelpers/nbWrap/rdShapeHelpers.cpp
@@ -1,0 +1,294 @@
+//
+//   Copyright (C) 2005-2025 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define PY_ARRAY_UNIQUE_SYMBOL rdshapehelpers_array_API
+#include <RDBoost/python.h>
+#include <GraphMol/ROMol.h>
+#include <RDBoost/Wrap.h>
+#include <RDBoost/import_array.h>
+
+#include <Geometry/Transform3D.h>
+#include <Geometry/UniformGrid3D.h>
+
+#include <GraphMol/ShapeHelpers/ShapeEncoder.h>
+#include <GraphMol/ShapeHelpers/ShapeUtils.h>
+#include <DataStructs/DiscreteValueVect.h>
+#include <Geometry/point.h>
+
+namespace python = boost::python;
+
+namespace RDKit {
+void _copyTransform(const PyArrayObject *transMat, RDGeom::Transform3D &trans) {
+  unsigned int nrows = PyArray_DIM(transMat, 0);
+  unsigned int ncols = PyArray_DIM(transMat, 1);
+  if ((nrows != 4) || (ncols != 4)) {
+    throw_value_error("The transform has to be square matrix, of size 4x4");
+  }
+  if (PyArray_DESCR(const_cast<PyArrayObject *>(transMat))->type_num !=
+      NPY_DOUBLE) {
+    throw_value_error("Only double arrays allowed for transform object ");
+  }
+
+  unsigned int dSize = nrows * nrows;
+  const auto *inData = reinterpret_cast<const double *>(
+      PyArray_DATA(const_cast<PyArrayObject *>(transMat)));
+  double *tData = trans.getData();
+  memcpy(static_cast<void *>(tData), static_cast<const void *>(inData),
+         dSize * sizeof(double));
+}
+
+python::tuple getConformerDimsAndOffset(const Conformer &conf,
+                                        python::object trans = python::object(),
+                                        double padding = 2.5) {
+  RDGeom::Point3D dims, offSet;
+  PyObject *transObj = trans.ptr();
+  if (PyArray_Check(transObj)) {
+    auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
+    RDGeom::Transform3D ctrans;
+    _copyTransform(transMat, ctrans);
+    MolShapes::computeConfDimsAndOffset(conf, dims, offSet, &ctrans, padding);
+  } else {
+    MolShapes::computeConfDimsAndOffset(conf, dims, offSet, nullptr, padding);
+  }
+
+  python::tuple res = python::make_tuple(dims, offSet);
+  return res;
+}
+
+python::tuple getConfBox(const Conformer &conf,
+                         python::object trans = python::object(),
+                         double padding = 2.5) {
+  RDGeom::Point3D lowerCorner, upperCorner;
+  PyObject *transObj = trans.ptr();
+  if (PyArray_Check(transObj)) {
+    auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
+    RDGeom::Transform3D ctrans;
+    _copyTransform(transMat, ctrans);
+    MolShapes::computeConfBox(conf, lowerCorner, upperCorner, &ctrans, padding);
+  } else {
+    MolShapes::computeConfBox(conf, lowerCorner, upperCorner, nullptr, padding);
+  }
+  python::tuple res = python::make_tuple(lowerCorner, upperCorner);
+  return res;
+}
+
+python::tuple getUnionOfTwoBox(python::tuple box1, python::tuple box2) {
+  unsigned int len1 = python::len(box1);
+  unsigned int len2 = python::len(box2);
+  if ((len1 != 2) || (len2 != 2)) {
+    throw_value_error(
+        "In correct format for one of the box: expecting a tuple of two "
+        "Point3D");
+  }
+  RDGeom::Point3D lC1 = python::extract<RDGeom::Point3D>(box1[0]);
+  RDGeom::Point3D uC1 = python::extract<RDGeom::Point3D>(box1[1]);
+
+  RDGeom::Point3D lC2 = python::extract<RDGeom::Point3D>(box2[0]);
+  RDGeom::Point3D uC2 = python::extract<RDGeom::Point3D>(box2[1]);
+
+  RDGeom::Point3D lowerCorner, upperCorner;
+  MolShapes::computeUnionBox(lC1, uC1, lC2, uC2, lowerCorner, upperCorner);
+  python::tuple res = python::make_tuple(lowerCorner, upperCorner);
+  return res;
+}
+
+void EncodeMolShape(
+    const ROMol &mol, RDGeom::UniformGrid3D &grid, int confId = -1,
+    python::object trans = python::object(),  // PyObject *trans=0,
+    double vdwScale = 0.8, double stepSize = 0.25, int maxLayers = -1,
+    bool ignoreHs = true) {
+  PyObject *transObj = trans.ptr();
+
+  if (PyArray_Check(transObj)) {
+    auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
+    RDGeom::Transform3D ctrans;
+    _copyTransform(transMat, ctrans);
+    MolShapes::EncodeShape(mol, grid, confId, &ctrans, vdwScale, stepSize,
+                           maxLayers, ignoreHs);
+  } else {
+    MolShapes::EncodeShape(mol, grid, confId, nullptr, vdwScale, stepSize,
+                           maxLayers, ignoreHs);
+  }
+}
+double tverskyMolShapes(const ROMol &mol1, const ROMol &mol2, double alpha,
+                        double beta, int confId1 = -1, int confId2 = -1,
+                        double gridSpacing = 0.5,
+                        DiscreteValueVect::DiscreteValueType bitsPerPoint =
+                            DiscreteValueVect::TWOBITVALUE,
+                        double vdwScale = 0.8, double stepSize = 0.25,
+                        int maxLayers = -1, bool ignoreHs = true) {
+  return MolShapes::tverskyIndex(mol1, mol2, alpha, beta, confId1, confId2,
+                                 gridSpacing, bitsPerPoint, vdwScale, stepSize,
+                                 maxLayers, ignoreHs);
+}
+
+double tanimotoMolShapes(const ROMol &mol1, const ROMol &mol2, int confId1 = -1,
+                         int confId2 = -1, double gridSpacing = 0.5,
+                         DiscreteValueVect::DiscreteValueType bitsPerPoint =
+                             DiscreteValueVect::TWOBITVALUE,
+                         double vdwScale = 0.8, double stepSize = 0.25,
+                         int maxLayers = -1, bool ignoreHs = true) {
+  return MolShapes::tanimotoDistance(mol1, mol2, confId1, confId2, gridSpacing,
+                                     bitsPerPoint, vdwScale, stepSize,
+                                     maxLayers, ignoreHs);
+}
+double protrudeMolShapes(const ROMol &mol1, const ROMol &mol2, int confId1 = -1,
+                         int confId2 = -1, double gridSpacing = 0.5,
+                         DiscreteValueVect::DiscreteValueType bitsPerPoint =
+                             DiscreteValueVect::TWOBITVALUE,
+                         double vdwScale = 0.8, double stepSize = 0.25,
+                         int maxLayers = -1, bool ignoreHs = true,
+                         bool allowReordering = true) {
+  return MolShapes::protrudeDistance(mol1, mol2, confId1, confId2, gridSpacing,
+                                     bitsPerPoint, vdwScale, stepSize,
+                                     maxLayers, ignoreHs, allowReordering);
+}
+}  // namespace RDKit
+
+BOOST_PYTHON_MODULE(rdShapeHelpers) {
+  python::scope().attr("__doc__") =
+      "Module containing functions to encode and compare the shapes of "
+      "molecules";
+
+  rdkit_import_array();
+
+  std::string docString =
+      "Encode the shape of a molecule (one of its conformer) onto a grid\n\n\
+ \n\
+ ARGUMENTS:\n\n\
+    - mol : the molecule of interest\n\
+    - grid : grid onto which the encoding is written \n\
+    - confId : id of the conformation of interest on mol (defaults to the first one) \n\
+    - trans : any transformation that needs to be used to encode onto the grid (note the molecule remains unchanged) \n\
+    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
+                 used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
+    - setpSize : thickness of the layers outside the base radius, the occupancy value is decreased \n\
+                 from layer to layer from the maximum value \n\
+    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
+                  used per grid point - e.g. two bits per grid point will allow 3 layers\n\
+    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n";
+  python::def(
+      "EncodeShape", RDKit::EncodeMolShape,
+      (python::arg("mol"), python::arg("grid"), python::arg("confId") = -1,
+       python::arg("trans") = python::object(), python::arg("vdwScale") = 0.8,
+       python::arg("stepSize") = 0.25, python::arg("maxLayers") = -1,
+       python::arg("ignoreHs") = true),
+      docString.c_str());
+
+  docString =
+      "Compute the shape tversky index between two molecule based on a predefined alignment\n\
+  \n\
+  ARGUMENTS:\n\
+    - mol1 : The first molecule of interest \n\
+    - mol2 : The second molecule of interest \n\
+    - alpha : first parameter of the Tversky index\n\
+    - beta : second parameter of the Tversky index\n\
+    - confId1 : Conformer in the first molecule (defaults to first conformer) \n\
+    - confId2 : Conformer in the second molecule (defaults to first conformer) \n\
+    - gridSpacing : resolution of the grid used to encode the molecular shapes \n\
+    - bitsPerPoint : number of bits used to encode the occupancy at each grid point \n\
+                          defaults to two bits per grid point \n\
+    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
+                used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
+    - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased \n\
+                 from layer to layer from the maximum value \n\
+    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
+                  used per grid point - e.g. two bits per grid point will allow 3 layers \n\
+    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n";
+
+  python::def(
+      "ShapeTverskyIndex", RDKit::tverskyMolShapes,
+      (python::arg("mol1"), python::arg("mol2"), python::arg("alpha"),
+       python::arg("beta"), python::arg("confId1") = -1,
+       python::arg("confId2") = -1, python::arg("gridSpacing") = 0.5,
+       python::arg("bitsPerPoint") = RDKit::DiscreteValueVect::TWOBITVALUE,
+       python::arg("vdwScale") = 0.8, python::arg("stepSize") = 0.25,
+       python::arg("maxLayers") = -1, python::arg("ignoreHs") = true),
+      docString.c_str());
+
+  docString =
+      "Compute the shape tanimoto distance between two molecule based on a predefined alignment\n\
+  \n\
+  ARGUMENTS:\n\
+    - mol1 : The first molecule of interest \n\
+    - mol2 : The second molecule of interest \n\
+    - confId1 : Conformer in the first molecule (defaults to first conformer) \n\
+    - confId2 : Conformer in the second molecule (defaults to first conformer) \n\
+    - gridSpacing : resolution of the grid used to encode the molecular shapes \n\
+    - bitsPerPoint : number of bits used to encode the occupancy at each grid point \n\
+                          defaults to two bits per grid point \n\
+    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
+                used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
+    - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased \n\
+                 from layer to layer from the maximum value \n\
+    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
+                  used per grid point - e.g. two bits per grid point will allow 3 layers \n\
+    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n";
+
+  python::def(
+      "ShapeTanimotoDist", RDKit::tanimotoMolShapes,
+      (python::arg("mol1"), python::arg("mol2"), python::arg("confId1") = -1,
+       python::arg("confId2") = -1, python::arg("gridSpacing") = 0.5,
+       python::arg("bitsPerPoint") = RDKit::DiscreteValueVect::TWOBITVALUE,
+       python::arg("vdwScale") = 0.8, python::arg("stepSize") = 0.25,
+       python::arg("maxLayers") = -1, python::arg("ignoreHs") = true),
+      docString.c_str());
+
+  docString =
+      "Compute the shape protrude distance between two molecule based on a predefined alignment\n\
+  \n\
+  ARGUMENTS:\n\
+    - mol1 : The first molecule of interest \n\
+    - mol2 : The second molecule of interest \n\
+    - confId1 : Conformer in the first molecule (defaults to first conformer) \n\
+    - confId2 : Conformer in the second molecule (defaults to first conformer) \n\
+    - gridSpacing : resolution of the grid used to encode the molecular shapes \n\
+    - bitsPerPoint : number of bit used to encode the occupancy at each grid point \n\
+                          defaults to two bits per grid point \n\
+    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
+                used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
+    - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased \n\
+                 from layer to layer from the maximum value \n\
+    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
+                  used per grid point - e.g. two bits per grid point will allow 3 layers \n\
+    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n\
+    - allowReordering : when set, the order will be automatically updated so that the value calculated\n\
+                        is the protrusion of the smaller shape from the larger one.\n";
+  python::def(
+      "ShapeProtrudeDist", RDKit::protrudeMolShapes,
+      (python::arg("mol1"), python::arg("mol2"), python::arg("confId1") = -1,
+       python::arg("confId2") = -1, python::arg("gridSpacing") = 0.5,
+       python::arg("bitsPerPoint") = RDKit::DiscreteValueVect::TWOBITVALUE,
+       python::arg("vdwScale") = 0.8, python::arg("stepSize") = 0.25,
+       python::arg("maxLayers") = -1, python::arg("ignoreHs") = true,
+       python::arg("allowReordering") = true),
+      docString.c_str());
+
+  docString =
+      "Compute the size of the box that can fit the conformations, and offset \n\
+   of the box from the origin\n";
+  python::def("ComputeConfDimsAndOffset", RDKit::getConformerDimsAndOffset,
+              (python::arg("conf"), python::arg("trans") = python::object(),
+               python::arg("padding") = 2.0),
+              docString.c_str());
+
+  docString =
+      "Compute the lower and upper corners of a cuboid that will fit the "
+      "conformer";
+  python::def("ComputeConfBox", RDKit::getConfBox,
+              (python::arg("conf"), python::arg("trans") = python::object(),
+               python::arg("padding") = 2.0),
+              docString.c_str());
+
+  docString =
+      "Compute the union of two boxes, so that all the points in both boxes are \n\
+    contained in the new box";
+  python::def("ComputeUnionBox", RDKit::getUnionOfTwoBox, docString.c_str(),
+              python::args("box1", "box2"));
+}

--- a/Code/GraphMol/ShapeHelpers/nbWrap/rdShapeHelpers.cpp
+++ b/Code/GraphMol/ShapeHelpers/nbWrap/rdShapeHelpers.cpp
@@ -1,5 +1,5 @@
 //
-//   Copyright (C) 2005-2025 Greg Landrum and other RDKit contributors
+//   Copyright (C) 2005-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,11 +7,12 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define PY_ARRAY_UNIQUE_SYMBOL rdshapehelpers_array_API
-#include <RDBoost/python.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/tuple.h>
+
 #include <GraphMol/ROMol.h>
-#include <RDBoost/Wrap.h>
-#include <RDBoost/import_array.h>
+#include <GraphMol/Conformer.h>
 
 #include <Geometry/Transform3D.h>
 #include <Geometry/UniformGrid3D.h>
@@ -21,274 +22,224 @@
 #include <DataStructs/DiscreteValueVect.h>
 #include <Geometry/point.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace RDKit;
 
-namespace RDKit {
-void _copyTransform(const PyArrayObject *transMat, RDGeom::Transform3D &trans) {
-  unsigned int nrows = PyArray_DIM(transMat, 0);
-  unsigned int ncols = PyArray_DIM(transMat, 1);
+namespace {
+
+static void copyTransform(
+    const nb::ndarray<nb::numpy, const double, nb::ndim<2>, nb::c_contig>
+        &transMat,
+    RDGeom::Transform3D &trans) {
+  unsigned int nrows = transMat.shape(0);
+  unsigned int ncols = transMat.shape(1);
   if ((nrows != 4) || (ncols != 4)) {
-    throw_value_error("The transform has to be square matrix, of size 4x4");
-  }
-  if (PyArray_DESCR(const_cast<PyArrayObject *>(transMat))->type_num !=
-      NPY_DOUBLE) {
-    throw_value_error("Only double arrays allowed for transform object ");
+    throw nb::value_error("The transform has to be square matrix, of size 4x4");
   }
 
   unsigned int dSize = nrows * nrows;
-  const auto *inData = reinterpret_cast<const double *>(
-      PyArray_DATA(const_cast<PyArrayObject *>(transMat)));
+  const double *inData = transMat.data();
   double *tData = trans.getData();
   memcpy(static_cast<void *>(tData), static_cast<const void *>(inData),
          dSize * sizeof(double));
 }
 
-python::tuple getConformerDimsAndOffset(const Conformer &conf,
-                                        python::object trans = python::object(),
-                                        double padding = 2.5) {
-  RDGeom::Point3D dims, offSet;
-  PyObject *transObj = trans.ptr();
-  if (PyArray_Check(transObj)) {
-    auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
-    RDGeom::Transform3D ctrans;
-    _copyTransform(transMat, ctrans);
-    MolShapes::computeConfDimsAndOffset(conf, dims, offSet, &ctrans, padding);
-  } else {
-    MolShapes::computeConfDimsAndOffset(conf, dims, offSet, nullptr, padding);
-  }
+}  // namespace
 
-  python::tuple res = python::make_tuple(dims, offSet);
-  return res;
-}
+NB_MODULE(rdShapeHelpers, m) {
+  m.doc() = R"DOC(Module containing functions to encode and compare the shapes of molecules)DOC";
 
-python::tuple getConfBox(const Conformer &conf,
-                         python::object trans = python::object(),
-                         double padding = 2.5) {
-  RDGeom::Point3D lowerCorner, upperCorner;
-  PyObject *transObj = trans.ptr();
-  if (PyArray_Check(transObj)) {
-    auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
-    RDGeom::Transform3D ctrans;
-    _copyTransform(transMat, ctrans);
-    MolShapes::computeConfBox(conf, lowerCorner, upperCorner, &ctrans, padding);
-  } else {
-    MolShapes::computeConfBox(conf, lowerCorner, upperCorner, nullptr, padding);
-  }
-  python::tuple res = python::make_tuple(lowerCorner, upperCorner);
-  return res;
-}
-
-python::tuple getUnionOfTwoBox(python::tuple box1, python::tuple box2) {
-  unsigned int len1 = python::len(box1);
-  unsigned int len2 = python::len(box2);
-  if ((len1 != 2) || (len2 != 2)) {
-    throw_value_error(
-        "In correct format for one of the box: expecting a tuple of two "
-        "Point3D");
-  }
-  RDGeom::Point3D lC1 = python::extract<RDGeom::Point3D>(box1[0]);
-  RDGeom::Point3D uC1 = python::extract<RDGeom::Point3D>(box1[1]);
-
-  RDGeom::Point3D lC2 = python::extract<RDGeom::Point3D>(box2[0]);
-  RDGeom::Point3D uC2 = python::extract<RDGeom::Point3D>(box2[1]);
-
-  RDGeom::Point3D lowerCorner, upperCorner;
-  MolShapes::computeUnionBox(lC1, uC1, lC2, uC2, lowerCorner, upperCorner);
-  python::tuple res = python::make_tuple(lowerCorner, upperCorner);
-  return res;
-}
-
-void EncodeMolShape(
-    const ROMol &mol, RDGeom::UniformGrid3D &grid, int confId = -1,
-    python::object trans = python::object(),  // PyObject *trans=0,
-    double vdwScale = 0.8, double stepSize = 0.25, int maxLayers = -1,
-    bool ignoreHs = true) {
-  PyObject *transObj = trans.ptr();
-
-  if (PyArray_Check(transObj)) {
-    auto *transMat = reinterpret_cast<PyArrayObject *>(transObj);
-    RDGeom::Transform3D ctrans;
-    _copyTransform(transMat, ctrans);
-    MolShapes::EncodeShape(mol, grid, confId, &ctrans, vdwScale, stepSize,
-                           maxLayers, ignoreHs);
-  } else {
-    MolShapes::EncodeShape(mol, grid, confId, nullptr, vdwScale, stepSize,
-                           maxLayers, ignoreHs);
-  }
-}
-double tverskyMolShapes(const ROMol &mol1, const ROMol &mol2, double alpha,
-                        double beta, int confId1 = -1, int confId2 = -1,
-                        double gridSpacing = 0.5,
-                        DiscreteValueVect::DiscreteValueType bitsPerPoint =
-                            DiscreteValueVect::TWOBITVALUE,
-                        double vdwScale = 0.8, double stepSize = 0.25,
-                        int maxLayers = -1, bool ignoreHs = true) {
-  return MolShapes::tverskyIndex(mol1, mol2, alpha, beta, confId1, confId2,
-                                 gridSpacing, bitsPerPoint, vdwScale, stepSize,
+  m.def(
+      "EncodeShape",
+      [](const ROMol &mol, RDGeom::UniformGrid3D &grid, int confId,
+         nb::object trans, double vdwScale, double stepSize, int maxLayers,
+         bool ignoreHs) {
+        if (!trans.is_none()) {
+          auto transMat = nb::cast<
+              nb::ndarray<nb::numpy, const double, nb::ndim<2>, nb::c_contig>>(
+              trans);
+          RDGeom::Transform3D ctrans;
+          copyTransform(transMat, ctrans);
+          MolShapes::EncodeShape(mol, grid, confId, &ctrans, vdwScale, stepSize,
                                  maxLayers, ignoreHs);
-}
+        } else {
+          MolShapes::EncodeShape(mol, grid, confId, nullptr, vdwScale, stepSize,
+                                 maxLayers, ignoreHs);
+        }
+      },
+      "mol"_a, "grid"_a, "confId"_a = -1, "trans"_a = nb::none(),
+      "vdwScale"_a = 0.8, "stepSize"_a = 0.25, "maxLayers"_a = -1,
+      "ignoreHs"_a = true,
+      R"DOC(Encode the shape of a molecule (one of its conformer) onto a grid
 
-double tanimotoMolShapes(const ROMol &mol1, const ROMol &mol2, int confId1 = -1,
-                         int confId2 = -1, double gridSpacing = 0.5,
-                         DiscreteValueVect::DiscreteValueType bitsPerPoint =
-                             DiscreteValueVect::TWOBITVALUE,
-                         double vdwScale = 0.8, double stepSize = 0.25,
-                         int maxLayers = -1, bool ignoreHs = true) {
-  return MolShapes::tanimotoDistance(mol1, mol2, confId1, confId2, gridSpacing,
-                                     bitsPerPoint, vdwScale, stepSize,
-                                     maxLayers, ignoreHs);
-}
-double protrudeMolShapes(const ROMol &mol1, const ROMol &mol2, int confId1 = -1,
-                         int confId2 = -1, double gridSpacing = 0.5,
-                         DiscreteValueVect::DiscreteValueType bitsPerPoint =
-                             DiscreteValueVect::TWOBITVALUE,
-                         double vdwScale = 0.8, double stepSize = 0.25,
-                         int maxLayers = -1, bool ignoreHs = true,
-                         bool allowReordering = true) {
-  return MolShapes::protrudeDistance(mol1, mol2, confId1, confId2, gridSpacing,
-                                     bitsPerPoint, vdwScale, stepSize,
-                                     maxLayers, ignoreHs, allowReordering);
-}
-}  // namespace RDKit
+ARGUMENTS:
 
-BOOST_PYTHON_MODULE(rdShapeHelpers) {
-  python::scope().attr("__doc__") =
-      "Module containing functions to encode and compare the shapes of "
-      "molecules";
+   - mol : the molecule of interest
+   - grid : grid onto which the encoding is written
+   - confId : id of the conformation of interest on mol (defaults to the first one)
+   - trans : any transformation that needs to be used to encode onto the grid (note the molecule remains unchanged)
+   - vdwScale : Scaling factor for the radius of the atoms to determine the base radius
+                used in the encoding - grid points inside this sphere carry the maximum occupancy
+   - setpSize : thickness of the layers outside the base radius, the occupancy value is decreased
+                from layer to layer from the maximum value
+   - maxLayers : the maximum number of layers - defaults to the number of bits
+                 used per grid point - e.g. two bits per grid point will allow 3 layers
+   - ignoreHs : when set, the contribution of Hs to the shape will be ignored
+)DOC");
 
-  rdkit_import_array();
+  m.def(
+      "ShapeTverskyIndex",
+      nb::overload_cast<const ROMol &, const ROMol &, double, double, int, int,
+                        double, DiscreteValueVect::DiscreteValueType, double,
+                        double, int, bool>(&MolShapes::tverskyIndex),
+      "mol1"_a, "mol2"_a, "alpha"_a, "beta"_a, "confId1"_a = -1,
+      "confId2"_a = -1, "gridSpacing"_a = 0.5,
+      "bitsPerPoint"_a = DiscreteValueVect::TWOBITVALUE,
+      "vdwScale"_a = 0.8, "stepSize"_a = 0.25, "maxLayers"_a = -1,
+      "ignoreHs"_a = true,
+      R"DOC(Compute the shape tversky index between two molecule based on a predefined alignment
 
-  std::string docString =
-      "Encode the shape of a molecule (one of its conformer) onto a grid\n\n\
- \n\
- ARGUMENTS:\n\n\
-    - mol : the molecule of interest\n\
-    - grid : grid onto which the encoding is written \n\
-    - confId : id of the conformation of interest on mol (defaults to the first one) \n\
-    - trans : any transformation that needs to be used to encode onto the grid (note the molecule remains unchanged) \n\
-    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
-                 used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
-    - setpSize : thickness of the layers outside the base radius, the occupancy value is decreased \n\
-                 from layer to layer from the maximum value \n\
-    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
-                  used per grid point - e.g. two bits per grid point will allow 3 layers\n\
-    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n";
-  python::def(
-      "EncodeShape", RDKit::EncodeMolShape,
-      (python::arg("mol"), python::arg("grid"), python::arg("confId") = -1,
-       python::arg("trans") = python::object(), python::arg("vdwScale") = 0.8,
-       python::arg("stepSize") = 0.25, python::arg("maxLayers") = -1,
-       python::arg("ignoreHs") = true),
-      docString.c_str());
+ARGUMENTS:
+   - mol1 : The first molecule of interest
+   - mol2 : The second molecule of interest
+   - alpha : first parameter of the Tversky index
+   - beta : second parameter of the Tversky index
+   - confId1 : Conformer in the first molecule (defaults to first conformer)
+   - confId2 : Conformer in the second molecule (defaults to first conformer)
+   - gridSpacing : resolution of the grid used to encode the molecular shapes
+   - bitsPerPoint : number of bits used to encode the occupancy at each grid point
+                         defaults to two bits per grid point
+   - vdwScale : Scaling factor for the radius of the atoms to determine the base radius
+               used in the encoding - grid points inside this sphere carry the maximum occupancy
+   - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased
+                from layer to layer from the maximum value
+   - maxLayers : the maximum number of layers - defaults to the number of bits
+                 used per grid point - e.g. two bits per grid point will allow 3 layers
+   - ignoreHs : when set, the contribution of Hs to the shape will be ignored
+)DOC");
 
-  docString =
-      "Compute the shape tversky index between two molecule based on a predefined alignment\n\
-  \n\
-  ARGUMENTS:\n\
-    - mol1 : The first molecule of interest \n\
-    - mol2 : The second molecule of interest \n\
-    - alpha : first parameter of the Tversky index\n\
-    - beta : second parameter of the Tversky index\n\
-    - confId1 : Conformer in the first molecule (defaults to first conformer) \n\
-    - confId2 : Conformer in the second molecule (defaults to first conformer) \n\
-    - gridSpacing : resolution of the grid used to encode the molecular shapes \n\
-    - bitsPerPoint : number of bits used to encode the occupancy at each grid point \n\
-                          defaults to two bits per grid point \n\
-    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
-                used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
-    - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased \n\
-                 from layer to layer from the maximum value \n\
-    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
-                  used per grid point - e.g. two bits per grid point will allow 3 layers \n\
-    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n";
+  m.def(
+      "ShapeTanimotoDist",
+      nb::overload_cast<const ROMol &, const ROMol &, int, int, double,
+                        DiscreteValueVect::DiscreteValueType, double, double,
+                        int, bool>(&MolShapes::tanimotoDistance),
+      "mol1"_a, "mol2"_a, "confId1"_a = -1, "confId2"_a = -1,
+      "gridSpacing"_a = 0.5,
+      "bitsPerPoint"_a = DiscreteValueVect::TWOBITVALUE,
+      "vdwScale"_a = 0.8, "stepSize"_a = 0.25, "maxLayers"_a = -1,
+      "ignoreHs"_a = true,
+      R"DOC(Compute the shape tanimoto distance between two molecule based on a predefined alignment
 
-  python::def(
-      "ShapeTverskyIndex", RDKit::tverskyMolShapes,
-      (python::arg("mol1"), python::arg("mol2"), python::arg("alpha"),
-       python::arg("beta"), python::arg("confId1") = -1,
-       python::arg("confId2") = -1, python::arg("gridSpacing") = 0.5,
-       python::arg("bitsPerPoint") = RDKit::DiscreteValueVect::TWOBITVALUE,
-       python::arg("vdwScale") = 0.8, python::arg("stepSize") = 0.25,
-       python::arg("maxLayers") = -1, python::arg("ignoreHs") = true),
-      docString.c_str());
+ARGUMENTS:
+   - mol1 : The first molecule of interest
+   - mol2 : The second molecule of interest
+   - confId1 : Conformer in the first molecule (defaults to first conformer)
+   - confId2 : Conformer in the second molecule (defaults to first conformer)
+   - gridSpacing : resolution of the grid used to encode the molecular shapes
+   - bitsPerPoint : number of bits used to encode the occupancy at each grid point
+                         defaults to two bits per grid point
+   - vdwScale : Scaling factor for the radius of the atoms to determine the base radius
+               used in the encoding - grid points inside this sphere carry the maximum occupancy
+   - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased
+                from layer to layer from the maximum value
+   - maxLayers : the maximum number of layers - defaults to the number of bits
+                 used per grid point - e.g. two bits per grid point will allow 3 layers
+   - ignoreHs : when set, the contribution of Hs to the shape will be ignored
+)DOC");
 
-  docString =
-      "Compute the shape tanimoto distance between two molecule based on a predefined alignment\n\
-  \n\
-  ARGUMENTS:\n\
-    - mol1 : The first molecule of interest \n\
-    - mol2 : The second molecule of interest \n\
-    - confId1 : Conformer in the first molecule (defaults to first conformer) \n\
-    - confId2 : Conformer in the second molecule (defaults to first conformer) \n\
-    - gridSpacing : resolution of the grid used to encode the molecular shapes \n\
-    - bitsPerPoint : number of bits used to encode the occupancy at each grid point \n\
-                          defaults to two bits per grid point \n\
-    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
-                used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
-    - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased \n\
-                 from layer to layer from the maximum value \n\
-    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
-                  used per grid point - e.g. two bits per grid point will allow 3 layers \n\
-    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n";
+  m.def(
+      "ShapeProtrudeDist",
+      nb::overload_cast<const ROMol &, const ROMol &, int, int, double,
+                        DiscreteValueVect::DiscreteValueType, double, double,
+                        int, bool, bool>(&MolShapes::protrudeDistance),
+      "mol1"_a, "mol2"_a, "confId1"_a = -1, "confId2"_a = -1,
+      "gridSpacing"_a = 0.5,
+      "bitsPerPoint"_a = DiscreteValueVect::TWOBITVALUE,
+      "vdwScale"_a = 0.8, "stepSize"_a = 0.25, "maxLayers"_a = -1,
+      "ignoreHs"_a = true, "allowReordering"_a = true,
+      R"DOC(Compute the shape protrude distance between two molecule based on a predefined alignment
 
-  python::def(
-      "ShapeTanimotoDist", RDKit::tanimotoMolShapes,
-      (python::arg("mol1"), python::arg("mol2"), python::arg("confId1") = -1,
-       python::arg("confId2") = -1, python::arg("gridSpacing") = 0.5,
-       python::arg("bitsPerPoint") = RDKit::DiscreteValueVect::TWOBITVALUE,
-       python::arg("vdwScale") = 0.8, python::arg("stepSize") = 0.25,
-       python::arg("maxLayers") = -1, python::arg("ignoreHs") = true),
-      docString.c_str());
+ARGUMENTS:
+   - mol1 : The first molecule of interest
+   - mol2 : The second molecule of interest
+   - confId1 : Conformer in the first molecule (defaults to first conformer)
+   - confId2 : Conformer in the second molecule (defaults to first conformer)
+   - gridSpacing : resolution of the grid used to encode the molecular shapes
+   - bitsPerPoint : number of bit used to encode the occupancy at each grid point
+                         defaults to two bits per grid point
+   - vdwScale : Scaling factor for the radius of the atoms to determine the base radius
+               used in the encoding - grid points inside this sphere carry the maximum occupancy
+   - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased
+                from layer to layer from the maximum value
+   - maxLayers : the maximum number of layers - defaults to the number of bits
+                 used per grid point - e.g. two bits per grid point will allow 3 layers
+   - ignoreHs : when set, the contribution of Hs to the shape will be ignored
+   - allowReordering : when set, the order will be automatically updated so that the value calculated
+                       is the protrusion of the smaller shape from the larger one.
+)DOC");
 
-  docString =
-      "Compute the shape protrude distance between two molecule based on a predefined alignment\n\
-  \n\
-  ARGUMENTS:\n\
-    - mol1 : The first molecule of interest \n\
-    - mol2 : The second molecule of interest \n\
-    - confId1 : Conformer in the first molecule (defaults to first conformer) \n\
-    - confId2 : Conformer in the second molecule (defaults to first conformer) \n\
-    - gridSpacing : resolution of the grid used to encode the molecular shapes \n\
-    - bitsPerPoint : number of bit used to encode the occupancy at each grid point \n\
-                          defaults to two bits per grid point \n\
-    - vdwScale : Scaling factor for the radius of the atoms to determine the base radius \n\
-                used in the encoding - grid points inside this sphere carry the maximum occupancy \n\
-    - stepSize : thickness of the each layer outside the base radius, the occupancy value is decreased \n\
-                 from layer to layer from the maximum value \n\
-    - maxLayers : the maximum number of layers - defaults to the number of bits \n\
-                  used per grid point - e.g. two bits per grid point will allow 3 layers \n\
-    - ignoreHs : when set, the contribution of Hs to the shape will be ignored\n\
-    - allowReordering : when set, the order will be automatically updated so that the value calculated\n\
-                        is the protrusion of the smaller shape from the larger one.\n";
-  python::def(
-      "ShapeProtrudeDist", RDKit::protrudeMolShapes,
-      (python::arg("mol1"), python::arg("mol2"), python::arg("confId1") = -1,
-       python::arg("confId2") = -1, python::arg("gridSpacing") = 0.5,
-       python::arg("bitsPerPoint") = RDKit::DiscreteValueVect::TWOBITVALUE,
-       python::arg("vdwScale") = 0.8, python::arg("stepSize") = 0.25,
-       python::arg("maxLayers") = -1, python::arg("ignoreHs") = true,
-       python::arg("allowReordering") = true),
-      docString.c_str());
+  m.def(
+      "ComputeConfDimsAndOffset",
+      [](const Conformer &conf, nb::object trans, double padding) {
+        RDGeom::Point3D dims, offSet;
+        if (!trans.is_none()) {
+          auto transMat = nb::cast<
+              nb::ndarray<nb::numpy, const double, nb::ndim<2>, nb::c_contig>>(
+              trans);
+          RDGeom::Transform3D ctrans;
+          copyTransform(transMat, ctrans);
+          MolShapes::computeConfDimsAndOffset(conf, dims, offSet, &ctrans,
+                                              padding);
+        } else {
+          MolShapes::computeConfDimsAndOffset(conf, dims, offSet, nullptr,
+                                              padding);
+        }
+        return nb::make_tuple(dims, offSet);
+      },
+      "conf"_a, "trans"_a = nb::none(), "padding"_a = 2.0,
+      R"DOC(Compute the size of the box that can fit the conformations, and offset
+of the box from the origin)DOC");
 
-  docString =
-      "Compute the size of the box that can fit the conformations, and offset \n\
-   of the box from the origin\n";
-  python::def("ComputeConfDimsAndOffset", RDKit::getConformerDimsAndOffset,
-              (python::arg("conf"), python::arg("trans") = python::object(),
-               python::arg("padding") = 2.0),
-              docString.c_str());
+  m.def(
+      "ComputeConfBox",
+      [](const Conformer &conf, nb::object trans, double padding) {
+        RDGeom::Point3D lowerCorner, upperCorner;
+        if (!trans.is_none()) {
+          auto transMat = nb::cast<
+              nb::ndarray<nb::numpy, const double, nb::ndim<2>, nb::c_contig>>(
+              trans);
+          RDGeom::Transform3D ctrans;
+          copyTransform(transMat, ctrans);
+          MolShapes::computeConfBox(conf, lowerCorner, upperCorner, &ctrans,
+                                    padding);
+        } else {
+          MolShapes::computeConfBox(conf, lowerCorner, upperCorner, nullptr,
+                                    padding);
+        }
+        return nb::make_tuple(lowerCorner, upperCorner);
+      },
+      "conf"_a, "trans"_a = nb::none(), "padding"_a = 2.0,
+      "Compute the lower and upper corners of a cuboid that will fit the conformer");
 
-  docString =
-      "Compute the lower and upper corners of a cuboid that will fit the "
-      "conformer";
-  python::def("ComputeConfBox", RDKit::getConfBox,
-              (python::arg("conf"), python::arg("trans") = python::object(),
-               python::arg("padding") = 2.0),
-              docString.c_str());
-
-  docString =
-      "Compute the union of two boxes, so that all the points in both boxes are \n\
-    contained in the new box";
-  python::def("ComputeUnionBox", RDKit::getUnionOfTwoBox, docString.c_str(),
-              python::args("box1", "box2"));
+  m.def(
+      "ComputeUnionBox",
+      [](nb::tuple box1, nb::tuple box2) {
+        if (nb::len(box1) != 2 || nb::len(box2) != 2) {
+          throw nb::value_error(
+              "In correct format for one of the box: expecting a tuple of two "
+              "Point3D");
+        }
+        RDGeom::Point3D lC1 = nb::cast<RDGeom::Point3D>(box1[0]);
+        RDGeom::Point3D uC1 = nb::cast<RDGeom::Point3D>(box1[1]);
+        RDGeom::Point3D lC2 = nb::cast<RDGeom::Point3D>(box2[0]);
+        RDGeom::Point3D uC2 = nb::cast<RDGeom::Point3D>(box2[1]);
+        RDGeom::Point3D lowerCorner, upperCorner;
+        MolShapes::computeUnionBox(lC1, uC1, lC2, uC2, lowerCorner,
+                                   upperCorner);
+        return nb::make_tuple(lowerCorner, upperCorner);
+      },
+      "box1"_a, "box2"_a,
+      R"DOC(Compute the union of two boxes, so that all the points in both boxes are
+contained in the new box)DOC");
 }


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to ShapeHelpers.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.