### PR TITLE
pr/SHARED-12386: Implement nanobind for InfoTheory

### DIFF
--- a/Code/ML/InfoTheory/CMakeLists.txt
+++ b/Code/ML/InfoTheory/CMakeLists.txt
@@ -5,3 +5,7 @@ target_compile_definitions(InfoTheory PRIVATE RDKIT_INFOTHEORY_BUILD)
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/ML/InfoTheory/nbWrap/BitCorrMatGenerator.cpp
+++ b/Code/ML/InfoTheory/nbWrap/BitCorrMatGenerator.cpp
@@ -1,0 +1,95 @@
+// $Id$
+//
+//  Copyright (C) 2003-2008 Greg Landrum and  Rational Discovery LLC
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+#include <RDBoost/python.h>
+#define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+#include <RDBoost/Wrap.h>
+#include <RDBoost/PySequenceHolder.h>
+#include <ML/InfoTheory/CorrMatGenerator.h>
+#include <RDGeneral/types.h>
+
+namespace python = boost::python;
+
+namespace RDInfoTheory {
+
+PyObject *getCorrMatrix(BitCorrMatGenerator *cmGen) {
+  double *dres = cmGen->getCorrMat();
+  unsigned int nb = cmGen->getCorrBitList().size();
+  npy_intp dim = nb * (nb - 1) / 2;
+  auto *res = (PyArrayObject *)PyArray_SimpleNew(1, &dim, NPY_DOUBLE);
+  memcpy(static_cast<void *>(PyArray_DATA(res)), static_cast<void *>(dres),
+         dim * sizeof(double));
+  return PyArray_Return(res);
+}
+
+void setBitList(BitCorrMatGenerator *cmGen, python::object bitList) {
+  PySequenceHolder<int> blist(bitList);
+  unsigned int nb = blist.size();
+  RDKit::INT_VECT res;
+  res.reserve(nb);
+  for (unsigned int i = 0; i < nb; i++) {
+    res.push_back(blist[i]);
+  }
+  cmGen->setBitIdList(res);
+}
+
+void CollectVotes(BitCorrMatGenerator *cmGen, python::object bitVect) {
+  python::extract<ExplicitBitVect> ebvWorks(bitVect);
+  python::extract<SparseBitVect> sbvWorks(bitVect);
+  if (ebvWorks.check()) {
+    ExplicitBitVect ev = python::extract<ExplicitBitVect>(bitVect);
+    cmGen->collectVotes(ev);
+  } else if (sbvWorks.check()) {
+    SparseBitVect sv = python::extract<SparseBitVect>(bitVect);
+    cmGen->collectVotes(sv);
+  } else {
+    throw_value_error(
+        "CollectVote can only take ExplicitBitVects or SparseBitVects");
+  }
+}
+
+struct corrmat_wrap {
+  static void wrap() {
+    std::string docString =
+        "A class to generate a pairwise correlation matrix between a list of "
+        "bits\n"
+        "The mode of operation for this class is something like this\n\n"
+        "   >>> cmg = BitCorrMatGenerator() \n"
+        "   >>> cmg.SetBitList(blist) \n"
+        "   >>> for fp in fpList:  \n"
+        "   >>>    cmg.CollectVotes(fp)  \n"
+        "   >>> corrMat = cmg.GetCorrMatrix() \n"
+        "    \n"
+        "   The resulting correlation matrix is a one dimensional nummeric "
+        "array containing the \n"
+        "   lower triangle elements\n";
+    python::class_<BitCorrMatGenerator>("BitCorrMatGenerator",
+                                        docString.c_str())
+        .def("SetBitList", setBitList, python::args("self", "bitList"),
+             "Set the list of bits that need to be correllated\n\n"
+             " This may for example be their top ranking ensemble bits\n\n"
+             "ARGUMENTS:\n\n"
+             "  - bitList : an integer list of bit IDs\n")
+        .def("CollectVotes", CollectVotes, python::args("self", "bitVect"),
+             "For each pair of on bits (bi, bj) in fp increase the correlation "
+             "count for the pair by 1\n\n"
+             "ARGUMENTS:\n\n"
+             "  - fp : a bit vector to collect the fingerprints from\n")
+        .def("GetCorrMatrix", getCorrMatrix, python::args("self"),
+             "Get the correlation matrix following the collection of votes "
+             "from a bunch of fingerprints\n");
+  };
+};
+}  // namespace RDInfoTheory
+
+void wrap_corrmatgen() { RDInfoTheory::corrmat_wrap::wrap(); }

--- a/Code/ML/InfoTheory/nbWrap/BitCorrMatGenerator.cpp
+++ b/Code/ML/InfoTheory/nbWrap/BitCorrMatGenerator.cpp
@@ -1,6 +1,6 @@
-// $Id$
 //
-//  Copyright (C) 2003-2008 Greg Landrum and  Rational Discovery LLC
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
+//
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -8,88 +8,82 @@
 //  of the RDKit source tree.
 //
 #define NO_IMPORT_ARRAY
-#include <RDBoost/python.h>
 #define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
-#include <RDBoost/Wrap.h>
-#include <RDBoost/PySequenceHolder.h>
+#include <nanobind/nanobind.h>
 #include <ML/InfoTheory/CorrMatGenerator.h>
 #include <RDGeneral/types.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace RDInfoTheory {
 
-PyObject *getCorrMatrix(BitCorrMatGenerator *cmGen) {
+nb::object getCorrMatrix(BitCorrMatGenerator *cmGen) {
   double *dres = cmGen->getCorrMat();
-  unsigned int nb = cmGen->getCorrBitList().size();
-  npy_intp dim = nb * (nb - 1) / 2;
+  unsigned int nb_size = cmGen->getCorrBitList().size();
+  npy_intp dim = nb_size * (nb_size - 1) / 2;
   auto *res = (PyArrayObject *)PyArray_SimpleNew(1, &dim, NPY_DOUBLE);
   memcpy(static_cast<void *>(PyArray_DATA(res)), static_cast<void *>(dres),
          dim * sizeof(double));
-  return PyArray_Return(res);
+  return nb::steal<nb::object>(PyArray_Return(res));
 }
 
-void setBitList(BitCorrMatGenerator *cmGen, python::object bitList) {
-  PySequenceHolder<int> blist(bitList);
-  unsigned int nb = blist.size();
+void setBitList(BitCorrMatGenerator *cmGen, nb::iterable bitList) {
   RDKit::INT_VECT res;
-  res.reserve(nb);
-  for (unsigned int i = 0; i < nb; i++) {
-    res.push_back(blist[i]);
+  for (auto item : bitList) {
+    res.push_back(nb::cast<int>(item));
   }
   cmGen->setBitIdList(res);
 }
 
-void CollectVotes(BitCorrMatGenerator *cmGen, python::object bitVect) {
-  python::extract<ExplicitBitVect> ebvWorks(bitVect);
-  python::extract<SparseBitVect> sbvWorks(bitVect);
-  if (ebvWorks.check()) {
-    ExplicitBitVect ev = python::extract<ExplicitBitVect>(bitVect);
-    cmGen->collectVotes(ev);
-  } else if (sbvWorks.check()) {
-    SparseBitVect sv = python::extract<SparseBitVect>(bitVect);
-    cmGen->collectVotes(sv);
+void CollectVotes(BitCorrMatGenerator *cmGen, nb::object bitVect) {
+  if (nb::isinstance<ExplicitBitVect>(bitVect)) {
+    cmGen->collectVotes(nb::cast<ExplicitBitVect &>(bitVect));
+  } else if (nb::isinstance<SparseBitVect>(bitVect)) {
+    cmGen->collectVotes(nb::cast<SparseBitVect &>(bitVect));
   } else {
-    throw_value_error(
+    throw nb::value_error(
         "CollectVote can only take ExplicitBitVects or SparseBitVects");
   }
 }
 
-struct corrmat_wrap {
-  static void wrap() {
-    std::string docString =
-        "A class to generate a pairwise correlation matrix between a list of "
-        "bits\n"
-        "The mode of operation for this class is something like this\n\n"
-        "   >>> cmg = BitCorrMatGenerator() \n"
-        "   >>> cmg.SetBitList(blist) \n"
-        "   >>> for fp in fpList:  \n"
-        "   >>>    cmg.CollectVotes(fp)  \n"
-        "   >>> corrMat = cmg.GetCorrMatrix() \n"
-        "    \n"
-        "   The resulting correlation matrix is a one dimensional nummeric "
-        "array containing the \n"
-        "   lower triangle elements\n";
-    python::class_<BitCorrMatGenerator>("BitCorrMatGenerator",
-                                        docString.c_str())
-        .def("SetBitList", setBitList, python::args("self", "bitList"),
-             "Set the list of bits that need to be correllated\n\n"
-             " This may for example be their top ranking ensemble bits\n\n"
-             "ARGUMENTS:\n\n"
-             "  - bitList : an integer list of bit IDs\n")
-        .def("CollectVotes", CollectVotes, python::args("self", "bitVect"),
-             "For each pair of on bits (bi, bj) in fp increase the correlation "
-             "count for the pair by 1\n\n"
-             "ARGUMENTS:\n\n"
-             "  - fp : a bit vector to collect the fingerprints from\n")
-        .def("GetCorrMatrix", getCorrMatrix, python::args("self"),
-             "Get the correlation matrix following the collection of votes "
-             "from a bunch of fingerprints\n");
-  };
-};
 }  // namespace RDInfoTheory
 
-void wrap_corrmatgen() { RDInfoTheory::corrmat_wrap::wrap(); }
+void wrap_corrmatgen(nb::module_ &m) {
+  nb::class_<RDInfoTheory::BitCorrMatGenerator>(m, "BitCorrMatGenerator",
+      R"DOC(A class to generate a pairwise correlation matrix between a list of bits
+The mode of operation for this class is something like this
+
+   >>> cmg = BitCorrMatGenerator()
+   >>> cmg.SetBitList(blist)
+   >>> for fp in fpList:
+   >>>    cmg.CollectVotes(fp)
+   >>> corrMat = cmg.GetCorrMatrix()
+
+   The resulting correlation matrix is a one dimensional nummeric array containing the
+   lower triangle elements
+)DOC")
+      .def(nb::init<>())
+      .def("SetBitList", RDInfoTheory::setBitList, "bitList"_a,
+           R"DOC(Set the list of bits that need to be correllated
+
+This may for example be their top ranking ensemble bits
+
+ARGUMENTS:
+
+  - bitList : an integer list of bit IDs
+)DOC")
+      .def("CollectVotes", RDInfoTheory::CollectVotes, "bitVect"_a,
+           R"DOC(For each pair of on bits (bi, bj) in fp increase the correlation count for the pair by 1
+
+ARGUMENTS:
+
+  - fp : a bit vector to collect the fingerprints from
+)DOC")
+      .def("GetCorrMatrix", RDInfoTheory::getCorrMatrix,
+           R"DOC(Get the correlation matrix following the collection of votes from a bunch of fingerprints
+)DOC");
+}

--- a/Code/ML/InfoTheory/nbWrap/BitCorrMatGenerator.cpp
+++ b/Code/ML/InfoTheory/nbWrap/BitCorrMatGenerator.cpp
@@ -7,12 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-#define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
-
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <ML/InfoTheory/CorrMatGenerator.h>
 #include <RDGeneral/types.h>
 
@@ -21,14 +17,18 @@ using namespace nb::literals;
 
 namespace RDInfoTheory {
 
-nb::object getCorrMatrix(BitCorrMatGenerator *cmGen) {
+nb::ndarray<nb::numpy, double, nb::ndim<1>> getCorrMatrix(
+    BitCorrMatGenerator *cmGen) {
   double *dres = cmGen->getCorrMat();
   unsigned int nb_size = cmGen->getCorrBitList().size();
-  npy_intp dim = nb_size * (nb_size - 1) / 2;
-  auto *res = (PyArrayObject *)PyArray_SimpleNew(1, &dim, NPY_DOUBLE);
-  memcpy(static_cast<void *>(PyArray_DATA(res)), static_cast<void *>(dres),
+  size_t dim = (size_t)nb_size * (nb_size - 1) / 2;
+  auto *data = new double[dim];
+  memcpy(static_cast<void *>(data), static_cast<void *>(dres),
          dim * sizeof(double));
-  return nb::steal<nb::object>(PyArray_Return(res));
+  nb::capsule owner(data, [](void *f) noexcept {
+    delete[] reinterpret_cast<double *>(f);
+  });
+  return nb::ndarray<nb::numpy, double, nb::ndim<1>>(data, {dim}, owner);
 }
 
 void setBitList(BitCorrMatGenerator *cmGen, nb::iterable bitList) {

--- a/Code/ML/InfoTheory/nbWrap/CMakeLists.txt
+++ b/Code/ML/InfoTheory/nbWrap/CMakeLists.txt
@@ -1,0 +1,9 @@
+remove_definitions(-DRDKIT_INFOTHEORY_BUILD)
+rdkit_python_extension(rdInfoTheory 
+                       InfoBitRanker.cpp BitCorrMatGenerator.cpp 
+                       rdInfoTheory.cpp 
+                       DEST ML/InfoTheory
+                       LINK_LIBRARIES
+                       InfoTheory)
+
+add_pytest(pyRanker ${CMAKE_CURRENT_SOURCE_DIR}/testRanker.py)

--- a/Code/ML/InfoTheory/nbWrap/CMakeLists.txt
+++ b/Code/ML/InfoTheory/nbWrap/CMakeLists.txt
@@ -1,9 +1,9 @@
 remove_definitions(-DRDKIT_INFOTHEORY_BUILD)
-rdkit_python_extension(rdInfoTheory 
-                       InfoBitRanker.cpp BitCorrMatGenerator.cpp 
-                       rdInfoTheory.cpp 
-                       DEST ML/InfoTheory
-                       LINK_LIBRARIES
-                       InfoTheory)
+rdkit_nanobind_extension(rdInfoTheory
+                         InfoBitRanker.cpp BitCorrMatGenerator.cpp
+                         rdInfoTheory.cpp
+                         DEST ML/InfoTheory
+                         LINK_LIBRARIES
+                         InfoTheory)
 
-add_pytest(pyRanker ${CMAKE_CURRENT_SOURCE_DIR}/testRanker.py)
+add_pytest(pyRanker ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testRanker.py)

--- a/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
@@ -1,0 +1,194 @@
+// $Id$
+//
+//  Copyright (C) 2003-2008 Greg Landrum and  Rational Discovery LLC
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#define NO_IMPORT_ARRAY
+#include <RDBoost/python.h>
+
+#define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+#include <RDBoost/Wrap.h>
+#include <ML/InfoTheory/InfoBitRanker.h>
+#include <DataStructs/BitVects.h>
+#include <RDBoost/PySequenceHolder.h>
+
+namespace python = boost::python;
+
+namespace RDInfoTheory {
+
+PyObject *getTopNbits(InfoBitRanker *ranker,
+                      int num) {  // int ignoreNoClass=-1) {
+  double *dres = ranker->getTopN(num);
+  npy_intp dims[2];
+  dims[0] = num;
+  dims[1] = ranker->getNumClasses() + 2;
+  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  memcpy(static_cast<void *>(PyArray_DATA(res)), static_cast<void *>(dres),
+         dims[0] * dims[1] * sizeof(double));
+  return PyArray_Return(res);
+}
+
+void AccumulateVotes(InfoBitRanker *ranker, python::object bitVect, int label) {
+  python::extract<ExplicitBitVect> ebvWorks(bitVect);
+  python::extract<SparseBitVect> sbvWorks(bitVect);
+  if (ebvWorks.check()) {
+    ExplicitBitVect ev = python::extract<ExplicitBitVect>(bitVect);
+    ranker->accumulateVotes(ev, label);
+  } else if (sbvWorks.check()) {
+    SparseBitVect sv = python::extract<SparseBitVect>(bitVect);
+    ranker->accumulateVotes(sv, label);
+  } else {
+    throw_value_error(
+        "Accumulate Vote can only take a explicitBitVects or SparseBitvects");
+  }
+}
+
+void SetBiasList(InfoBitRanker *ranker, python::object classList) {
+  RDKit::INT_VECT cList;
+  PySequenceHolder<int> bList(classList);
+  cList.reserve(bList.size());
+  for (unsigned int i = 0; i < bList.size(); i++) {
+    cList.push_back(bList[i]);
+  }
+  ranker->setBiasList(cList);
+}
+
+void SetMaskBits(InfoBitRanker *ranker, python::object maskBits) {
+  RDKit::INT_VECT cList;
+  PySequenceHolder<int> bList(maskBits);
+  cList.reserve(bList.size());
+  for (unsigned int i = 0; i < bList.size(); i++) {
+    cList.push_back(bList[i]);
+  }
+  ranker->setMaskBits(cList);
+}
+
+void tester(InfoBitRanker *, python::object bitVect) {
+  python::extract<SparseBitVect> sbvWorks(bitVect);
+  if (sbvWorks.check()) {
+    SparseBitVect sv = python::extract<SparseBitVect>(bitVect);
+    std::cout << "Num of on bits: " << sv.getNumOnBits() << "\n";
+  }
+}
+
+struct ranker_wrap {
+  static void wrap() {
+    std::string docString =
+        "A class to rank the bits from a series of labelled fingerprints\n"
+        "A simple demonstration may help clarify what this class does. \n"
+        "Here's a small set of vectors:\n\n"
+        ">>> for i,bv in enumerate(bvs): print(bv.ToBitString(),acts[i])\n"
+        "... \n"
+        "0001 0\n"
+        "0101 0\n"
+        "0010 1\n"
+        "1110 1\n"
+        "\n"
+        "Default ranker, using infogain:\n\n"
+        ">>> ranker = InfoBitRanker(4,2)  \n"
+        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
+        "... \n"
+        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): "
+        "print(int(bit),'%.3f'%gain,int(n0),int(n1))\n"
+        "... \n"
+        "3 1.000 2 0\n"
+        "2 1.000 0 2\n"
+        "0 0.311 0 1\n"
+        "\n"
+        "Using the biased infogain:\n\n"
+        ">>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.BIASENTROPY)\n"
+        ">>> ranker.SetBiasList((1,))\n"
+        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
+        "... \n"
+        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): print("
+        "int(bit),'%.3f'%gain,int(n0),int(n1))\n"
+        "... \n"
+        "2 1.000 0 2\n"
+        "0 0.311 0 1\n"
+        "1 0.000 1 1\n"
+        "\n"
+        "A chi squared ranker is also available:\n\n"
+        ">>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.CHISQUARE)\n"
+        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
+        "... \n"
+        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): print("
+        "int(bit),'%.3f'%gain,int(n0),int(n1))\n"
+        "... \n"
+        "3 4.000 2 0\n"
+        "2 4.000 0 2\n"
+        "0 1.333 0 1\n"
+        "\n"
+        "As is a biased chi squared:\n\n"
+        ">>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.BIASCHISQUARE)\n"
+        ">>> ranker.SetBiasList((1,))\n"
+        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
+        "... \n"
+        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): print("
+        "int(bit),'%.3f'%gain,int(n0),int(n1))\n"
+        "... \n"
+        "2 4.000 0 2\n"
+        "0 1.333 0 1\n"
+        "1 0.000 1 1\n";
+
+    python::class_<InfoBitRanker>(
+        "InfoBitRanker", docString.c_str(),
+        python::init<int, int>(python::args("self", "nBits", "nClasses")))
+        .def(python::init<int, int, InfoBitRanker::InfoType>(
+            python::args("self", "nBits", "nClasses", "infoType")))
+        .def("AccumulateVotes", AccumulateVotes,
+             python::args("self", "bitVect", "label"),
+             "Accumulate the votes for all the bits turned on in a bit "
+             "vector\n\n"
+             "ARGUMENTS:\n\n"
+             "  - bv : bit vector either ExplicitBitVect or SparseBitVect "
+             "operator\n"
+             "  - label : the class label for the bit vector. It is assumed "
+             "that 0 <= class < nClasses \n")
+        .def("SetBiasList", SetBiasList, python::args("self", "classList"),
+             "Set the classes to which the entropy calculation should be "
+             "biased\n\n"
+             "This list contains a set of class ids used when in the "
+             "BIASENTROPY mode of ranking bits. \n"
+             "In this mode, a bit must be correlated higher with one of the "
+             "biased classes than all the \n"
+             "other classes. For example, in a two class problem with actives "
+             "and inactives, the fraction of \n"
+             "actives that hit the bit has to be greater than the fraction of "
+             "inactives that hit the bit\n\n"
+             "ARGUMENTS: \n\n"
+             "  - classList : list of class ids that we want a bias towards\n")
+        .def("SetMaskBits", SetMaskBits, python::args("self", "maskBits"),
+             "Set the mask bits for the calculation\n\n"
+             "ARGUMENTS: \n\n"
+             "  - maskBits : list of mask bits to use\n")
+        .def("GetTopN", getTopNbits, python::args("self", "num"),
+             "Returns the top n bits ranked by the information metric\n"
+             "This is actually the function where most of the work of ranking "
+             "is happening\n\n"
+             "ARGUMENTS:\n\n"
+             "  - num : the number of top ranked bits that are required\n")
+        .def("WriteTopBitsToFile", &InfoBitRanker::writeTopBitsToFile,
+             python::args("self", "fileName"),
+             "Write the bits that have been ranked to a file")
+        .def("Tester", tester, python::args("self", "bitVect"));
+
+    python::enum_<InfoBitRanker::InfoType>("InfoType")
+        .value("ENTROPY", InfoBitRanker::ENTROPY)
+        .value("BIASENTROPY", InfoBitRanker::BIASENTROPY)
+        .value("CHISQUARE", InfoBitRanker::CHISQUARE)
+        .value("BIASCHISQUARE", InfoBitRanker::BIASCHISQUARE)
+        .export_values();
+    ;
+  };
+};
+}  // namespace RDInfoTheory
+
+void wrap_ranker() { RDInfoTheory::ranker_wrap::wrap(); }

--- a/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
@@ -1,6 +1,6 @@
-// $Id$
 //
-//  Copyright (C) 2003-2008 Greg Landrum and  Rational Discovery LLC
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
+//
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -9,23 +9,21 @@
 //
 
 #define NO_IMPORT_ARRAY
-#include <RDBoost/python.h>
-
 #define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
-#include <RDBoost/Wrap.h>
+#include <iostream>
+#include <nanobind/nanobind.h>
 #include <ML/InfoTheory/InfoBitRanker.h>
 #include <DataStructs/BitVects.h>
-#include <RDBoost/PySequenceHolder.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace RDInfoTheory {
 
-PyObject *getTopNbits(InfoBitRanker *ranker,
-                      int num) {  // int ignoreNoClass=-1) {
+nb::object getTopNbits(InfoBitRanker *ranker, int num) {
   double *dres = ranker->getTopN(num);
   npy_intp dims[2];
   dims[0] = num;
@@ -33,162 +31,152 @@ PyObject *getTopNbits(InfoBitRanker *ranker,
   auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
   memcpy(static_cast<void *>(PyArray_DATA(res)), static_cast<void *>(dres),
          dims[0] * dims[1] * sizeof(double));
-  return PyArray_Return(res);
+  return nb::steal<nb::object>(PyArray_Return(res));
 }
 
-void AccumulateVotes(InfoBitRanker *ranker, python::object bitVect, int label) {
-  python::extract<ExplicitBitVect> ebvWorks(bitVect);
-  python::extract<SparseBitVect> sbvWorks(bitVect);
-  if (ebvWorks.check()) {
-    ExplicitBitVect ev = python::extract<ExplicitBitVect>(bitVect);
-    ranker->accumulateVotes(ev, label);
-  } else if (sbvWorks.check()) {
-    SparseBitVect sv = python::extract<SparseBitVect>(bitVect);
-    ranker->accumulateVotes(sv, label);
+void AccumulateVotes(InfoBitRanker *ranker, nb::object bitVect, int label) {
+  if (nb::isinstance<ExplicitBitVect>(bitVect)) {
+    ranker->accumulateVotes(nb::cast<ExplicitBitVect &>(bitVect), label);
+  } else if (nb::isinstance<SparseBitVect>(bitVect)) {
+    ranker->accumulateVotes(nb::cast<SparseBitVect &>(bitVect), label);
   } else {
-    throw_value_error(
+    throw nb::value_error(
         "Accumulate Vote can only take a explicitBitVects or SparseBitvects");
   }
 }
 
-void SetBiasList(InfoBitRanker *ranker, python::object classList) {
+void SetBiasList(InfoBitRanker *ranker, nb::iterable classList) {
   RDKit::INT_VECT cList;
-  PySequenceHolder<int> bList(classList);
-  cList.reserve(bList.size());
-  for (unsigned int i = 0; i < bList.size(); i++) {
-    cList.push_back(bList[i]);
+  for (auto item : classList) {
+    cList.push_back(nb::cast<int>(item));
   }
   ranker->setBiasList(cList);
 }
 
-void SetMaskBits(InfoBitRanker *ranker, python::object maskBits) {
+void SetMaskBits(InfoBitRanker *ranker, nb::iterable maskBits) {
   RDKit::INT_VECT cList;
-  PySequenceHolder<int> bList(maskBits);
-  cList.reserve(bList.size());
-  for (unsigned int i = 0; i < bList.size(); i++) {
-    cList.push_back(bList[i]);
+  for (auto item : maskBits) {
+    cList.push_back(nb::cast<int>(item));
   }
   ranker->setMaskBits(cList);
 }
 
-void tester(InfoBitRanker *, python::object bitVect) {
-  python::extract<SparseBitVect> sbvWorks(bitVect);
-  if (sbvWorks.check()) {
-    SparseBitVect sv = python::extract<SparseBitVect>(bitVect);
-    std::cout << "Num of on bits: " << sv.getNumOnBits() << "\n";
+void tester(InfoBitRanker *, nb::object bitVect) {
+  if (nb::isinstance<SparseBitVect>(bitVect)) {
+    std::cout << "Num of on bits: "
+              << nb::cast<SparseBitVect &>(bitVect).getNumOnBits() << "\n";
   }
 }
 
-struct ranker_wrap {
-  static void wrap() {
-    std::string docString =
-        "A class to rank the bits from a series of labelled fingerprints\n"
-        "A simple demonstration may help clarify what this class does. \n"
-        "Here's a small set of vectors:\n\n"
-        ">>> for i,bv in enumerate(bvs): print(bv.ToBitString(),acts[i])\n"
-        "... \n"
-        "0001 0\n"
-        "0101 0\n"
-        "0010 1\n"
-        "1110 1\n"
-        "\n"
-        "Default ranker, using infogain:\n\n"
-        ">>> ranker = InfoBitRanker(4,2)  \n"
-        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
-        "... \n"
-        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): "
-        "print(int(bit),'%.3f'%gain,int(n0),int(n1))\n"
-        "... \n"
-        "3 1.000 2 0\n"
-        "2 1.000 0 2\n"
-        "0 0.311 0 1\n"
-        "\n"
-        "Using the biased infogain:\n\n"
-        ">>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.BIASENTROPY)\n"
-        ">>> ranker.SetBiasList((1,))\n"
-        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
-        "... \n"
-        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): print("
-        "int(bit),'%.3f'%gain,int(n0),int(n1))\n"
-        "... \n"
-        "2 1.000 0 2\n"
-        "0 0.311 0 1\n"
-        "1 0.000 1 1\n"
-        "\n"
-        "A chi squared ranker is also available:\n\n"
-        ">>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.CHISQUARE)\n"
-        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
-        "... \n"
-        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): print("
-        "int(bit),'%.3f'%gain,int(n0),int(n1))\n"
-        "... \n"
-        "3 4.000 2 0\n"
-        "2 4.000 0 2\n"
-        "0 1.333 0 1\n"
-        "\n"
-        "As is a biased chi squared:\n\n"
-        ">>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.BIASCHISQUARE)\n"
-        ">>> ranker.SetBiasList((1,))\n"
-        ">>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])\n"
-        "... \n"
-        ">>> for bit,gain,n0,n1 in ranker.GetTopN(3): print("
-        "int(bit),'%.3f'%gain,int(n0),int(n1))\n"
-        "... \n"
-        "2 4.000 0 2\n"
-        "0 1.333 0 1\n"
-        "1 0.000 1 1\n";
-
-    python::class_<InfoBitRanker>(
-        "InfoBitRanker", docString.c_str(),
-        python::init<int, int>(python::args("self", "nBits", "nClasses")))
-        .def(python::init<int, int, InfoBitRanker::InfoType>(
-            python::args("self", "nBits", "nClasses", "infoType")))
-        .def("AccumulateVotes", AccumulateVotes,
-             python::args("self", "bitVect", "label"),
-             "Accumulate the votes for all the bits turned on in a bit "
-             "vector\n\n"
-             "ARGUMENTS:\n\n"
-             "  - bv : bit vector either ExplicitBitVect or SparseBitVect "
-             "operator\n"
-             "  - label : the class label for the bit vector. It is assumed "
-             "that 0 <= class < nClasses \n")
-        .def("SetBiasList", SetBiasList, python::args("self", "classList"),
-             "Set the classes to which the entropy calculation should be "
-             "biased\n\n"
-             "This list contains a set of class ids used when in the "
-             "BIASENTROPY mode of ranking bits. \n"
-             "In this mode, a bit must be correlated higher with one of the "
-             "biased classes than all the \n"
-             "other classes. For example, in a two class problem with actives "
-             "and inactives, the fraction of \n"
-             "actives that hit the bit has to be greater than the fraction of "
-             "inactives that hit the bit\n\n"
-             "ARGUMENTS: \n\n"
-             "  - classList : list of class ids that we want a bias towards\n")
-        .def("SetMaskBits", SetMaskBits, python::args("self", "maskBits"),
-             "Set the mask bits for the calculation\n\n"
-             "ARGUMENTS: \n\n"
-             "  - maskBits : list of mask bits to use\n")
-        .def("GetTopN", getTopNbits, python::args("self", "num"),
-             "Returns the top n bits ranked by the information metric\n"
-             "This is actually the function where most of the work of ranking "
-             "is happening\n\n"
-             "ARGUMENTS:\n\n"
-             "  - num : the number of top ranked bits that are required\n")
-        .def("WriteTopBitsToFile", &InfoBitRanker::writeTopBitsToFile,
-             python::args("self", "fileName"),
-             "Write the bits that have been ranked to a file")
-        .def("Tester", tester, python::args("self", "bitVect"));
-
-    python::enum_<InfoBitRanker::InfoType>("InfoType")
-        .value("ENTROPY", InfoBitRanker::ENTROPY)
-        .value("BIASENTROPY", InfoBitRanker::BIASENTROPY)
-        .value("CHISQUARE", InfoBitRanker::CHISQUARE)
-        .value("BIASCHISQUARE", InfoBitRanker::BIASCHISQUARE)
-        .export_values();
-    ;
-  };
-};
 }  // namespace RDInfoTheory
 
-void wrap_ranker() { RDInfoTheory::ranker_wrap::wrap(); }
+void wrap_ranker(nb::module_ &m) {
+  nb::class_<RDInfoTheory::InfoBitRanker>(m, "InfoBitRanker",
+      R"DOC(A class to rank the bits from a series of labelled fingerprints
+A simple demonstration may help clarify what this class does.
+Here's a small set of vectors:
+
+>>> for i,bv in enumerate(bvs): print(bv.ToBitString(),acts[i])
+...
+0001 0
+0101 0
+0010 1
+1110 1
+
+Default ranker, using infogain:
+
+>>> ranker = InfoBitRanker(4,2)
+>>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])
+...
+>>> for bit,gain,n0,n1 in ranker.GetTopN(3): print(int(bit),'%.3f'%gain,int(n0),int(n1))
+...
+3 1.000 2 0
+2 1.000 0 2
+0 0.311 0 1
+
+Using the biased infogain:
+
+>>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.BIASENTROPY)
+>>> ranker.SetBiasList((1,))
+>>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])
+...
+>>> for bit,gain,n0,n1 in ranker.GetTopN(3): print(int(bit),'%.3f'%gain,int(n0),int(n1))
+...
+2 1.000 0 2
+0 0.311 0 1
+1 0.000 1 1
+
+A chi squared ranker is also available:
+
+>>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.CHISQUARE)
+>>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])
+...
+>>> for bit,gain,n0,n1 in ranker.GetTopN(3): print(int(bit),'%.3f'%gain,int(n0),int(n1))
+...
+3 4.000 2 0
+2 4.000 0 2
+0 1.333 0 1
+
+As is a biased chi squared:
+
+>>> ranker = InfoBitRanker(4,2,InfoTheory.InfoType.BIASCHISQUARE)
+>>> ranker.SetBiasList((1,))
+>>> for i,bv in enumerate(bvs): ranker.AccumulateVotes(bv,acts[i])
+...
+>>> for bit,gain,n0,n1 in ranker.GetTopN(3): print(int(bit),'%.3f'%gain,int(n0),int(n1))
+...
+2 4.000 0 2
+0 1.333 0 1
+1 0.000 1 1
+)DOC")
+      .def(nb::init<unsigned int, unsigned int>(), "nBits"_a, "nClasses"_a)
+      .def(nb::init<unsigned int, unsigned int, RDInfoTheory::InfoBitRanker::InfoType>(),
+           "nBits"_a, "nClasses"_a, "infoType"_a)
+      .def("AccumulateVotes", RDInfoTheory::AccumulateVotes, "bitVect"_a,
+           "label"_a,
+           R"DOC(Accumulate the votes for all the bits turned on in a bit vector
+
+ARGUMENTS:
+
+  - bv : bit vector either ExplicitBitVect or SparseBitVect operator
+  - label : the class label for the bit vector. It is assumed that 0 <= class < nClasses
+)DOC")
+      .def("SetBiasList", RDInfoTheory::SetBiasList, "classList"_a,
+           R"DOC(Set the classes to which the entropy calculation should be biased
+
+This list contains a set of class ids used when in the BIASENTROPY mode of ranking bits.
+In this mode, a bit must be correlated higher with one of the biased classes than all the
+other classes. For example, in a two class problem with actives and inactives, the fraction of
+actives that hit the bit has to be greater than the fraction of inactives that hit the bit
+
+ARGUMENTS:
+
+  - classList : list of class ids that we want a bias towards
+)DOC")
+      .def("SetMaskBits", RDInfoTheory::SetMaskBits, "maskBits"_a,
+           R"DOC(Set the mask bits for the calculation
+
+ARGUMENTS:
+
+  - maskBits : list of mask bits to use
+)DOC")
+      .def("GetTopN", RDInfoTheory::getTopNbits, "num"_a,
+           R"DOC(Returns the top n bits ranked by the information metric
+This is actually the function where most of the work of ranking is happening
+
+ARGUMENTS:
+
+  - num : the number of top ranked bits that are required
+)DOC")
+      .def("WriteTopBitsToFile", &RDInfoTheory::InfoBitRanker::writeTopBitsToFile,
+           "fileName"_a,
+           "Write the bits that have been ranked to a file")
+      .def("Tester", RDInfoTheory::tester, "bitVect"_a);
+
+  nb::enum_<RDInfoTheory::InfoBitRanker::InfoType>(m, "InfoType")
+      .value("ENTROPY", RDInfoTheory::InfoBitRanker::ENTROPY)
+      .value("BIASENTROPY", RDInfoTheory::InfoBitRanker::BIASENTROPY)
+      .value("CHISQUARE", RDInfoTheory::InfoBitRanker::CHISQUARE)
+      .value("BIASCHISQUARE", RDInfoTheory::InfoBitRanker::BIASCHISQUARE)
+      .export_values();
+}

--- a/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
@@ -8,13 +8,9 @@
 //  of the RDKit source tree.
 //
 
-#define NO_IMPORT_ARRAY
-#define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
-
 #include <iostream>
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <nanobind/stl/string.h>
 #include <ML/InfoTheory/InfoBitRanker.h>
 #include <DataStructs/BitVects.h>
@@ -24,15 +20,19 @@ using namespace nb::literals;
 
 namespace RDInfoTheory {
 
-nb::object getTopNbits(InfoBitRanker *ranker, int num) {
+nb::ndarray<nb::numpy, double, nb::ndim<2>> getTopNbits(InfoBitRanker *ranker,
+                                                         int num) {
   double *dres = ranker->getTopN(num);
-  npy_intp dims[2];
-  dims[0] = num;
-  dims[1] = ranker->getNumClasses() + 2;
-  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
-  memcpy(static_cast<void *>(PyArray_DATA(res)), static_cast<void *>(dres),
-         dims[0] * dims[1] * sizeof(double));
-  return nb::steal<nb::object>(PyArray_Return(res));
+  size_t ncols = ranker->getNumClasses() + 2;
+  size_t nrows = (size_t)num;
+  auto *data = new double[nrows * ncols];
+  memcpy(static_cast<void *>(data), static_cast<void *>(dres),
+         nrows * ncols * sizeof(double));
+  nb::capsule owner(data, [](void *f) noexcept {
+    delete[] reinterpret_cast<double *>(f);
+  });
+  return nb::ndarray<nb::numpy, double, nb::ndim<2>>(data, {nrows, ncols},
+                                                     owner);
 }
 
 void AccumulateVotes(InfoBitRanker *ranker, nb::object bitVect, int label) {

--- a/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/nbWrap/InfoBitRanker.cpp
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 #include <ML/InfoTheory/InfoBitRanker.h>
 #include <DataStructs/BitVects.h>
 

--- a/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
+++ b/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
@@ -1,0 +1,163 @@
+// $Id$
+//
+//  Copyright (C) 2003-2008 Greg Landrum and Rational Discovery LLC
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
+#include <RDBoost/Wrap.h>
+#include <RDBoost/import_array.h>
+#include <ML/InfoTheory/InfoBitRanker.h>
+#include <ML/InfoTheory/InfoGainFuncs.h>
+
+namespace python = boost::python;
+using namespace RDInfoTheory;
+
+namespace RDInfoTheory {
+double infoEntropy(python::object resArr) {
+  PyObject *matObj = resArr.ptr();
+  if (!PyArray_Check(matObj)) {
+    throw_value_error("Expecting a Numeric array object");
+  }
+  PyArrayObject *copy;
+  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
+      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 1, 1);
+  double res = 0.0;
+  // we are expecting a 1 dimensional array
+  auto ncols = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
+  CHECK_INVARIANT(ncols > 0, "");
+  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
+    auto *data = (double *)PyArray_DATA(copy);
+    res = InfoEntropy(data, ncols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
+    auto *data = (float *)PyArray_DATA(copy);
+    res = InfoEntropy(data, ncols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
+    int *data = (int *)PyArray_DATA(copy);
+    res = InfoEntropy(data, ncols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
+    auto *data = (long int *)PyArray_DATA(copy);
+    res = InfoEntropy(data, ncols);
+  }
+  Py_DECREF(copy);
+  return res;
+}
+
+double infoGain(python::object resArr) {
+  PyObject *matObj = resArr.ptr();
+  if (!PyArray_Check(matObj)) {
+    throw_value_error("Expecting a Numeric array object");
+  }
+  PyArrayObject *copy;
+  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
+      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 2, 2);
+  auto rows = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
+  auto cols = (long int)PyArray_DIM((PyArrayObject *)matObj, 1);
+  double res = 0.0;
+  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
+    auto *data = (double *)PyArray_DATA(copy);
+    res = InfoEntropyGain(data, rows, cols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
+    auto *data = (float *)PyArray_DATA(copy);
+    res = InfoEntropyGain(data, rows, cols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
+    int *data = (int *)PyArray_DATA(copy);
+    res = InfoEntropyGain(data, rows, cols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
+    auto *data = (long int *)PyArray_DATA(copy);
+    res = InfoEntropyGain(data, rows, cols);
+  } else {
+    throw_value_error(
+        "Numeric array object of type int or long or float or double");
+  }
+  Py_DECREF(copy);
+  return res;
+}
+
+double chiSquare(python::object resArr) {
+  PyObject *matObj = resArr.ptr();
+  if (!PyArray_Check(matObj)) {
+    throw_value_error("Expecting a Numeric array object");
+  }
+  PyArrayObject *copy;
+  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
+      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 2, 2);
+  auto rows = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
+  auto cols = (long int)PyArray_DIM((PyArrayObject *)matObj, 1);
+  double res = 0.0;
+  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
+    auto *data = (double *)PyArray_DATA(copy);
+    res = ChiSquare(data, rows, cols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
+    auto *data = (float *)PyArray_DATA(copy);
+    res = ChiSquare(data, rows, cols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
+    int *data = (int *)PyArray_DATA(copy);
+    res = ChiSquare(data, rows, cols);
+  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
+    auto *data = (long int *)PyArray_DATA(copy);
+    res = ChiSquare(data, rows, cols);
+  } else {
+    throw_value_error(
+        "Numeric array object of type int or long or float or double");
+  }
+  Py_DECREF(copy);
+  return res;
+}
+}  // namespace RDInfoTheory
+
+void wrap_ranker();
+void wrap_corrmatgen();
+
+BOOST_PYTHON_MODULE(rdInfoTheory) {
+  python::scope().attr("__doc__") =
+      "Module containing bunch of functions for information metrics and a "
+      "ranker to rank bits";
+
+  rdkit_import_array();
+
+  wrap_ranker();
+  wrap_corrmatgen();
+
+  std::string docString =
+      "calculates the informational entropy of the values in an array\n\n\
+  ARGUMENTS:\n\
+    \n\
+    - resMat: pointer to a long int array containing the data\n\
+    - dim: long int containing the length of the _tPtr_ array.\n\n\
+  RETURNS:\n\n\
+    a double\n";
+  python::def("InfoEntropy", RDInfoTheory::infoEntropy, docString.c_str(),
+              python::args("resArr"));
+
+  docString =
+      "Calculates the information gain for a variable\n\n\
+   ARGUMENTS:\n\n\
+     - varMat: a Numeric Array object\n\
+       varMat is a Numeric array with the number of possible occurrences\n\
+         of each result for reach possible value of the given variable.\n\n\
+       So, for a variable which adopts 4 possible values and a result which\n\
+         has 3 possible values, varMat would be 4x3\n\n\
+   RETURNS:\n\n\
+     - a Python float object\n\n\
+   NOTES\n\n\
+     - this is a dropin replacement for _PyInfoGain()_ in entropy.py\n";
+  python::def("InfoGain", RDInfoTheory::infoGain, docString.c_str(),
+              python::args("resArr"));
+
+  docString =
+      "Calculates the chi squared value for a variable\n\n\
+   ARGUMENTS:\n\n\
+     - varMat: a Numeric Array object\n\
+       varMat is a Numeric array with the number of possible occurrences\n\
+         of each result for reach possible value of the given variable.\n\n\
+       So, for a variable which adopts 4 possible values and a result which\n\
+         has 3 possible values, varMat would be 4x3\n\n\
+   RETURNS:\n\n\
+     - a Python float object\n";
+  python::def("ChiSquare", RDInfoTheory::chiSquare, docString.c_str(),
+              python::args("resArr"));
+}

--- a/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
+++ b/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
@@ -1,6 +1,6 @@
-// $Id$
 //
-//  Copyright (C) 2003-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
+//
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -8,19 +8,20 @@
 //  of the RDKit source tree.
 //
 #define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
 #include <RDBoost/import_array.h>
 #include <ML/InfoTheory/InfoBitRanker.h>
 #include <ML/InfoTheory/InfoGainFuncs.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDInfoTheory;
 
 namespace RDInfoTheory {
-double infoEntropy(python::object resArr) {
+double infoEntropy(nb::object resArr) {
   PyObject *matObj = resArr.ptr();
   if (!PyArray_Check(matObj)) {
-    throw_value_error("Expecting a Numeric array object");
+    throw nb::value_error("Expecting a Numeric array object");
   }
   PyArrayObject *copy;
   copy = (PyArrayObject *)PyArray_ContiguousFromObject(
@@ -46,10 +47,10 @@ double infoEntropy(python::object resArr) {
   return res;
 }
 
-double infoGain(python::object resArr) {
+double infoGain(nb::object resArr) {
   PyObject *matObj = resArr.ptr();
   if (!PyArray_Check(matObj)) {
-    throw_value_error("Expecting a Numeric array object");
+    throw nb::value_error("Expecting a Numeric array object");
   }
   PyArrayObject *copy;
   copy = (PyArrayObject *)PyArray_ContiguousFromObject(
@@ -70,17 +71,17 @@ double infoGain(python::object resArr) {
     auto *data = (long int *)PyArray_DATA(copy);
     res = InfoEntropyGain(data, rows, cols);
   } else {
-    throw_value_error(
+    throw nb::value_error(
         "Numeric array object of type int or long or float or double");
   }
   Py_DECREF(copy);
   return res;
 }
 
-double chiSquare(python::object resArr) {
+double chiSquare(nb::object resArr) {
   PyObject *matObj = resArr.ptr();
   if (!PyArray_Check(matObj)) {
-    throw_value_error("Expecting a Numeric array object");
+    throw nb::value_error("Expecting a Numeric array object");
   }
   PyArrayObject *copy;
   copy = (PyArrayObject *)PyArray_ContiguousFromObject(
@@ -101,7 +102,7 @@ double chiSquare(python::object resArr) {
     auto *data = (long int *)PyArray_DATA(copy);
     res = ChiSquare(data, rows, cols);
   } else {
-    throw_value_error(
+    throw nb::value_error(
         "Numeric array object of type int or long or float or double");
   }
   Py_DECREF(copy);
@@ -109,55 +110,70 @@ double chiSquare(python::object resArr) {
 }
 }  // namespace RDInfoTheory
 
-void wrap_ranker();
-void wrap_corrmatgen();
+void wrap_ranker(nb::module_ &m);
+void wrap_corrmatgen(nb::module_ &m);
 
-BOOST_PYTHON_MODULE(rdInfoTheory) {
-  python::scope().attr("__doc__") =
+NB_MODULE(rdInfoTheory, m) {
+  m.doc() =
       "Module containing bunch of functions for information metrics and a "
       "ranker to rank bits";
 
   rdkit_import_array();
 
-  wrap_ranker();
-  wrap_corrmatgen();
+  wrap_ranker(m);
+  wrap_corrmatgen(m);
 
-  std::string docString =
-      "calculates the informational entropy of the values in an array\n\n\
-  ARGUMENTS:\n\
-    \n\
-    - resMat: pointer to a long int array containing the data\n\
-    - dim: long int containing the length of the _tPtr_ array.\n\n\
-  RETURNS:\n\n\
-    a double\n";
-  python::def("InfoEntropy", RDInfoTheory::infoEntropy, docString.c_str(),
-              python::args("resArr"));
+  m.def("InfoEntropy", RDInfoTheory::infoEntropy,
+        R"DOC(calculates the informational entropy of the values in an array
 
-  docString =
-      "Calculates the information gain for a variable\n\n\
-   ARGUMENTS:\n\n\
-     - varMat: a Numeric Array object\n\
-       varMat is a Numeric array with the number of possible occurrences\n\
-         of each result for reach possible value of the given variable.\n\n\
-       So, for a variable which adopts 4 possible values and a result which\n\
-         has 3 possible values, varMat would be 4x3\n\n\
-   RETURNS:\n\n\
-     - a Python float object\n\n\
-   NOTES\n\n\
-     - this is a dropin replacement for _PyInfoGain()_ in entropy.py\n";
-  python::def("InfoGain", RDInfoTheory::infoGain, docString.c_str(),
-              python::args("resArr"));
+ARGUMENTS:
 
-  docString =
-      "Calculates the chi squared value for a variable\n\n\
-   ARGUMENTS:\n\n\
-     - varMat: a Numeric Array object\n\
-       varMat is a Numeric array with the number of possible occurrences\n\
-         of each result for reach possible value of the given variable.\n\n\
-       So, for a variable which adopts 4 possible values and a result which\n\
-         has 3 possible values, varMat would be 4x3\n\n\
-   RETURNS:\n\n\
-     - a Python float object\n";
-  python::def("ChiSquare", RDInfoTheory::chiSquare, docString.c_str(),
-              python::args("resArr"));
+  - resMat: pointer to a long int array containing the data
+  - dim: long int containing the length of the _tPtr_ array.
+
+RETURNS:
+
+  a double
+)DOC",
+        "resArr"_a);
+
+  m.def("InfoGain", RDInfoTheory::infoGain,
+        R"DOC(Calculates the information gain for a variable
+
+ARGUMENTS:
+
+  - varMat: a Numeric Array object
+    varMat is a Numeric array with the number of possible occurrences
+      of each result for reach possible value of the given variable.
+
+    So, for a variable which adopts 4 possible values and a result which
+      has 3 possible values, varMat would be 4x3
+
+RETURNS:
+
+  - a Python float object
+
+NOTES
+
+  - this is a dropin replacement for _PyInfoGain()_ in entropy.py
+)DOC",
+        "resArr"_a);
+
+  m.def("ChiSquare", RDInfoTheory::chiSquare,
+        R"DOC(Calculates the chi squared value for a variable
+
+ARGUMENTS:
+
+  - varMat: a Numeric Array object
+    varMat is a Numeric array with the number of possible occurrences
+      of each result for reach possible value of the given variable.
+
+    So, for a variable which adopts 4 possible values and a result which
+      has 3 possible values, varMat would be 4x3
+
+RETURNS:
+
+  - a Python float object
+)DOC",
+        "resArr"_a);
 }

--- a/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
+++ b/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
@@ -7,9 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define PY_ARRAY_UNIQUE_SYMBOL rdinfotheory_array_API
 #include <nanobind/nanobind.h>
-#include <RDBoost/import_array.h>
+#include <nanobind/ndarray.h>
 #include <ML/InfoTheory/InfoBitRanker.h>
 #include <ML/InfoTheory/InfoGainFuncs.h>
 
@@ -17,96 +16,76 @@ namespace nb = nanobind;
 using namespace nb::literals;
 
 namespace RDInfoTheory {
-double infoEntropy(nb::object resArr) {
-  PyObject *matObj = resArr.ptr();
-  if (!PyArray_Check(matObj)) {
-    throw nb::value_error("Expecting a Numeric array object");
-  }
-  PyArrayObject *copy;
-  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
-      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 1, 1);
-  double res = 0.0;
-  // we are expecting a 1 dimensional array
-  auto ncols = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
+
+template <class T>
+double infoEntropyHelper(nb::ndarray<nb::numpy, nb::ndim<1>> arr) {
+  auto ncols = (long int)arr.shape(0);
   CHECK_INVARIANT(ncols > 0, "");
-  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
-    auto *data = (double *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
-    auto *data = (float *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
-    int *data = (int *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
-    auto *data = (long int *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
-  }
-  Py_DECREF(copy);
-  return res;
+  auto *data = reinterpret_cast<T *>(arr.data());
+  return InfoEntropy(data, ncols);
 }
 
-double infoGain(nb::object resArr) {
-  PyObject *matObj = resArr.ptr();
-  if (!PyArray_Check(matObj)) {
-    throw nb::value_error("Expecting a Numeric array object");
+double infoEntropy(nb::ndarray<nb::numpy, nb::ndim<1>> resArr) {
+  if (resArr.dtype() == nb::dtype<double>()) {
+    return infoEntropyHelper<double>(resArr);
+  } else if (resArr.dtype() == nb::dtype<float>()) {
+    return infoEntropyHelper<float>(resArr);
+  } else if (resArr.dtype() == nb::dtype<int>()) {
+    return infoEntropyHelper<int>(resArr);
+  } else if (resArr.dtype() == nb::dtype<long int>()) {
+    return infoEntropyHelper<long int>(resArr);
+  } else {
+    throw nb::value_error(
+        "Expecting a Numeric array object of type int, long, float, or double");
   }
-  PyArrayObject *copy;
-  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
-      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 2, 2);
-  auto rows = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
-  auto cols = (long int)PyArray_DIM((PyArrayObject *)matObj, 1);
-  double res = 0.0;
-  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
-    auto *data = (double *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
-    auto *data = (float *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
-    int *data = (int *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
-    auto *data = (long int *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
+}
+
+template <class T>
+double infoGainHelper(nb::ndarray<nb::numpy, nb::ndim<2>> arr) {
+  auto rows = (long int)arr.shape(0);
+  auto cols = (long int)arr.shape(1);
+  auto *data = reinterpret_cast<T *>(arr.data());
+  return InfoEntropyGain(data, rows, cols);
+}
+
+double infoGain(nb::ndarray<nb::numpy, nb::ndim<2>> resArr) {
+  if (resArr.dtype() == nb::dtype<double>()) {
+    return infoGainHelper<double>(resArr);
+  } else if (resArr.dtype() == nb::dtype<float>()) {
+    return infoGainHelper<float>(resArr);
+  } else if (resArr.dtype() == nb::dtype<int>()) {
+    return infoGainHelper<int>(resArr);
+  } else if (resArr.dtype() == nb::dtype<long int>()) {
+    return infoGainHelper<long int>(resArr);
   } else {
     throw nb::value_error(
         "Numeric array object of type int or long or float or double");
   }
-  Py_DECREF(copy);
-  return res;
 }
 
-double chiSquare(nb::object resArr) {
-  PyObject *matObj = resArr.ptr();
-  if (!PyArray_Check(matObj)) {
-    throw nb::value_error("Expecting a Numeric array object");
-  }
-  PyArrayObject *copy;
-  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
-      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 2, 2);
-  auto rows = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
-  auto cols = (long int)PyArray_DIM((PyArrayObject *)matObj, 1);
-  double res = 0.0;
-  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
-    auto *data = (double *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
-    auto *data = (float *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
-    int *data = (int *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
-    auto *data = (long int *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
+template <class T>
+double chiSquareHelper(nb::ndarray<nb::numpy, nb::ndim<2>> arr) {
+  auto rows = (long int)arr.shape(0);
+  auto cols = (long int)arr.shape(1);
+  auto *data = reinterpret_cast<T *>(arr.data());
+  return ChiSquare(data, rows, cols);
+}
+
+double chiSquare(nb::ndarray<nb::numpy, nb::ndim<2>> resArr) {
+  if (resArr.dtype() == nb::dtype<double>()) {
+    return chiSquareHelper<double>(resArr);
+  } else if (resArr.dtype() == nb::dtype<float>()) {
+    return chiSquareHelper<float>(resArr);
+  } else if (resArr.dtype() == nb::dtype<int>()) {
+    return chiSquareHelper<int>(resArr);
+  } else if (resArr.dtype() == nb::dtype<long int>()) {
+    return chiSquareHelper<long int>(resArr);
   } else {
     throw nb::value_error(
         "Numeric array object of type int or long or float or double");
   }
-  Py_DECREF(copy);
-  return res;
 }
+
 }  // namespace RDInfoTheory
 
 void wrap_ranker(nb::module_ &m);
@@ -116,8 +95,6 @@ NB_MODULE(rdInfoTheory, m) {
   m.doc() =
       "Module containing bunch of functions for information metrics and a "
       "ranker to rank bits";
-
-  rdkit_import_array();
 
   wrap_ranker(m);
   wrap_corrmatgen(m);

--- a/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
+++ b/Code/ML/InfoTheory/nbWrap/rdInfoTheory.cpp
@@ -15,7 +15,6 @@
 
 namespace nb = nanobind;
 using namespace nb::literals;
-using namespace RDInfoTheory;
 
 namespace RDInfoTheory {
 double infoEntropy(nb::object resArr) {


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to InfoTheory.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.