### PR TITLE
pr/SHARED-12414: Implement nanobind for SynthonSpaceSearch

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/CMakeLists.txt
+++ b/Code/GraphMol/SynthonSpaceSearch/CMakeLists.txt
@@ -26,3 +26,7 @@ endif ()
 if (RDK_BUILD_BOOST_PYTHON_WRAPPERS)
     add_subdirectory(Wrap)
 endif ()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/SynthonSpaceSearch/Wrap/testSynthonSpaceSearch.py
+++ b/Code/GraphMol/SynthonSpaceSearch/Wrap/testSynthonSpaceSearch.py
@@ -38,8 +38,14 @@ import unittest
 from pathlib import Path
 
 from rdkit import Chem, rdBase
-from rdkit.Chem import (rdSynthonSpaceSearch, rdFingerprintGenerator,
-                        rdRascalMCES, rdGeneralizedSubstruct, rdMolDescriptors)
+from rdkit.Chem import rdSynthonSpaceSearch
+
+from rdkit.Chem import rdFingerprintGenerator
+from rdkit.Chem import rdGeneralizedSubstruct
+try:
+  from rdkit.Chem import rdRascalMCES
+except ImportError:
+  rdRascalMCES = None
 
 
 class TestCase(unittest.TestCase):
@@ -57,53 +63,43 @@ class TestCase(unittest.TestCase):
     results = synthonspace.SubstructureSearch(query, params=params)
     self.assertEqual(10, len(results.GetHitMolecules()))
     smParams = Chem.SubstructMatchParameters()
-    results = synthonspace.SubstructureSearch(query,
-                                              substructMatchParams=smParams,
-                                              params=params)
+    results = synthonspace.SubstructureSearch(query, substructMatchParams=smParams, params=params)
     self.assertEqual(10, len(results.GetHitMolecules()))
 
     # callback returns None, stil get all results
     mols = []
-    synthonspace.SubstructureSearchIncremental(
-            query,
-            lambda results: mols.extend(results),
-            substructMatchParams=smParams,
-            params=params)
+    synthonspace.SubstructureSearchIncremental(query, lambda results: mols.extend(results),
+                                               substructMatchParams=smParams, params=params)
     self.assertEqual(10, len(mols))
 
     # callback returns True, get one chunk
     mols = []
     params.toTryChunkSize = 2
+
     def callback_returns_true(chunk):
-        mols.extend(chunk)
-        return True
-    synthonspace.SubstructureSearchIncremental(
-            query,
-            callback_returns_true,
-            substructMatchParams=smParams,
-            params=params)
+      mols.extend(chunk)
+      return True
+
+    synthonspace.SubstructureSearchIncremental(query, callback_returns_true,
+                                               substructMatchParams=smParams, params=params)
     self.assertEqual(2, len(mols))
 
     # Exceptions thrown in the callback propagate back here
     mols = []
     params.toTryChunkSize = 2
+
     def callback_raises(chunk):
-        mols.extend(chunk)
-        raise StopIteration
+      mols.extend(chunk)
+      raise StopIteration
 
     try:
-        synthonspace.SubstructureSearchIncremental(
-                query,
-                callback_raises,
-                substructMatchParams=smParams,
-                params=params)
+      synthonspace.SubstructureSearchIncremental(query, callback_raises,
+                                                 substructMatchParams=smParams, params=params)
     except StopIteration:
-        pass
+      pass
     else:
-        assert False, "Expected exception"
+      assert False, "Expected exception"
     self.assertEqual(2, len(mols))
-
-
 
   def testFingerprintSearch(self):
     fName = self.sssDir / "idorsia_toy_space_a.spc"
@@ -114,17 +110,13 @@ class TestCase(unittest.TestCase):
     params.maxHits = -1
     params.similarityCutoff = 0.45
     fpgen = rdFingerprintGenerator.GetRDKitFPGenerator(fpSize=2048, useBondOrder=True)
-    results = synthonspace.FingerprintSearch(
-      Chem.MolFromSmiles("O=C(Nc1c(CNC=O)cc[s]1)c1nccnc1"), fpgen, params)
+    results = synthonspace.FingerprintSearch(Chem.MolFromSmiles("O=C(Nc1c(CNC=O)cc[s]1)c1nccnc1"),
+                                             fpgen, params)
     self.assertEqual(278, len(results.GetHitMolecules()))
     mols = []
-    synthonspace.FingerprintSearchIncremental(
-      Chem.MolFromSmiles("O=C(Nc1c(CNC=O)cc[s]1)c1nccnc1"),
-      fpgen,
-      lambda results: mols.extend(results),
-      params)
+    synthonspace.FingerprintSearchIncremental(Chem.MolFromSmiles("O=C(Nc1c(CNC=O)cc[s]1)c1nccnc1"),
+                                              fpgen, lambda results: mols.extend(results), params)
     self.assertEqual(278, len(mols))
-    
 
   def testEnumerate(self):
     fName = self.sssDir / "amide_space.txt"
@@ -156,6 +148,7 @@ class TestCase(unittest.TestCase):
     synthonspace = rdSynthonSpaceSearch.SynthonSpace()
     self.assertRaises(RuntimeError, synthonspace.ReadTextFile, fName)
 
+  @unittest.skipIf(rdRascalMCES is None, "RascalMCES not available")
   def testRascalSearch(self):
     fName = self.sssDir / "Syntons_5567.csv"
     synthonspace = rdSynthonSpaceSearch.SynthonSpace()
@@ -165,7 +158,7 @@ class TestCase(unittest.TestCase):
     params.maxHits = 10
     rascalOpts = rdRascalMCES.RascalOptions()
     results = synthonspace.RascalSearch(Chem.MolFromSmiles("c12ccc(C)cc1[nH]nc2C(=O)NCc1cncs1"),
-                                             rascalOpts, params)
+                                        rascalOpts, params)
     self.assertEqual(10, len(results.GetHitMolecules()))
 
   def testExtendedSubsructureSearch(self):
@@ -205,7 +198,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual(220, len(results.GetHitMolecules()))
     results = synthonspace.SubstructureSearch(q, params=params)
     self.assertEqual(185, len(results.GetHitMolecules()))
-    
+
   def testChiralAtomtCutoffs(self):
     fName = self.sssDir / "idorsia_toy_space_a.spc"
     synthonspace = rdSynthonSpaceSearch.SynthonSpace()
@@ -219,7 +212,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual(20, len(results.GetHitMolecules()))
     results = synthonspace.SubstructureSearch(q, params=params)
     self.assertEqual(10, len(results.GetHitMolecules()))
-    
-    
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/SynthonSpaceSearch/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/SynthonSpaceSearch/nbWrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+remove_definitions(-DRDKIT_SYNTHONSPACESEARCH_BUILD)
+
+rdkit_python_extension(rdSynthonSpaceSearch
+        rdSynthonSpaceSearch.cpp
+        DEST Chem
+        LINK_LIBRARIES SynthonSpaceSearch)
+
+add_pytest(pySynthonSpaceSearch ${CMAKE_CURRENT_SOURCE_DIR}/testSynthonSpaceSearch.py)

--- a/Code/GraphMol/SynthonSpaceSearch/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/SynthonSpaceSearch/nbWrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 remove_definitions(-DRDKIT_SYNTHONSPACESEARCH_BUILD)
 
-rdkit_python_extension(rdSynthonSpaceSearch
+rdkit_nanobind_extension(rdSynthonSpaceSearch
         rdSynthonSpaceSearch.cpp
         DEST Chem
         LINK_LIBRARIES SynthonSpaceSearch)
 
-add_pytest(pySynthonSpaceSearch ${CMAKE_CURRENT_SOURCE_DIR}/testSynthonSpaceSearch.py)
+add_pytest(pySynthonSpaceSearch ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testSynthonSpaceSearch.py)

--- a/Code/GraphMol/SynthonSpaceSearch/nbWrap/rdSynthonSpaceSearch.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/nbWrap/rdSynthonSpaceSearch.cpp
@@ -1,0 +1,457 @@
+//
+// Copyright (C) David Cosgrove 2024.
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <csignal>
+
+#include <RDBoost/python.h>
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/ROMol.h>
+#include <GraphMol/RascalMCES/RascalOptions.h>
+#include <GraphMol/SynthonSpaceSearch/SynthonSpace.h>
+
+namespace python = boost::python;
+
+namespace RDKit {
+python::list hitMolecules_helper(const SynthonSpaceSearch::SearchResults &res) {
+  python::list pyres;
+  for (auto &r : res.getHitMolecules()) {
+    pyres.append(boost::make_shared<ROMol>(*r));
+  }
+  return pyres;
+}
+
+struct SearchResults_wrapper {
+  static void wrap() {
+    const std::string docString =
+        "Used to return results of SynthonSpace searches.";
+    python::class_<SynthonSpaceSearch::SearchResults>(
+        "SubstructureResult", docString.c_str(), python::no_init)
+        .def("GetHitMolecules", hitMolecules_helper, python::args("self"),
+             "A function returning hits from the search")
+        .def("GetMaxNumResults",
+             &SynthonSpaceSearch::SearchResults::getMaxNumResults,
+             "The upper bound on number of results possible.  There"
+             " may be fewer than this in practice for several reasons"
+             " such as duplicate reagent sets being removed or the"
+             " final product not matching the query even though the"
+             " synthons suggested they would.")
+        .def("GetTimedOut", &SynthonSpaceSearch::SearchResults::getTimedOut,
+             "Returns whether the search timed out or not.")
+        .def("GetCancelled", &SynthonSpaceSearch::SearchResults::getCancelled,
+             "Returns whether the search was cancelled or not.");
+  }
+};
+
+SynthonSpaceSearch::SearchResults substructureSearch_helper1(
+    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
+    const python::object &py_smParams, const python::object &py_params) {
+  SynthonSpaceSearch::SynthonSpaceSearchParams params;
+  SubstructMatchParameters smParams;
+  if (!py_smParams.is_none()) {
+    smParams = python::extract<SubstructMatchParameters>(py_smParams);
+  }
+  if (!py_params.is_none()) {
+    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+        py_params);
+  }
+
+  SynthonSpaceSearch::SearchResults results;
+  {
+    NOGIL gil;
+    results = self.substructureSearch(query, smParams, params);
+  }
+  if (results.getCancelled()) {
+    throw_runtime_error("SubstructureSearch cancelled");
+  }
+  return results;
+}
+
+SynthonSpaceSearch::SearchResults substructureSearch_helper2(
+    SynthonSpaceSearch::SynthonSpace &self,
+    const GeneralizedSubstruct::ExtendedQueryMol &query,
+    const python::object &py_smParams, const python::object &py_params) {
+  SubstructMatchParameters smParams;
+  if (!py_smParams.is_none()) {
+    smParams = python::extract<SubstructMatchParameters>(py_smParams);
+  }
+  SynthonSpaceSearch::SynthonSpaceSearchParams params;
+  if (!py_params.is_none()) {
+    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+        py_params);
+  }
+  SynthonSpaceSearch::SearchResults results;
+  {
+    NOGIL gil;
+    results = self.substructureSearch(query, smParams, params);
+  }
+  if (results.getCancelled()) {
+    throw_runtime_error("SubstructureSearch cancelled");
+  }
+  return results;
+}
+
+struct CallbackAdapter {
+  python::object py_callable;
+
+  bool operator()(std::vector<std::unique_ptr<ROMol>> &results) const {
+    python::list pyres;
+    for (auto &mol : results) {
+      pyres.append(boost::shared_ptr<ROMol>(mol.release()));
+    }
+    return bool(py_callable(pyres));
+  }
+};
+
+static void substructureSearch_helper3(SynthonSpaceSearch::SynthonSpace &self,
+                                       const ROMol &query,
+                                       python::object py_callable,
+                                       const python::object &py_smParams,
+                                       const python::object &py_params) {
+  SynthonSpaceSearch::SynthonSpaceSearchParams params;
+  SubstructMatchParameters smParams;
+  if (!py_smParams.is_none()) {
+    smParams = python::extract<SubstructMatchParameters>(py_smParams);
+  }
+  if (!py_params.is_none()) {
+    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+        py_params);
+  }
+  CallbackAdapter callback{py_callable};
+  self.substructureSearch(query, callback, smParams, params);
+}
+
+SynthonSpaceSearch::SearchResults fingerprintSearch_helper(
+    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
+    const python::object &fingerprintGenerator,
+    const python::object &py_params) {
+  SynthonSpaceSearch::SynthonSpaceSearchParams params;
+  if (!py_params.is_none()) {
+    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+        py_params);
+  }
+  SynthonSpaceSearch::SearchResults results;
+  {
+    NOGIL gil;
+    const FingerprintGenerator<std::uint64_t> *fpGen =
+        python::extract<FingerprintGenerator<std::uint64_t> *>(
+            fingerprintGenerator);
+    results = self.fingerprintSearch(query, *fpGen, params);
+  }
+  if (results.getCancelled()) {
+    throw_runtime_error("FingerprintSearch cancelled");
+  }
+  return results;
+}
+
+static void fingerprintSearch_helper_2(
+    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
+    const python::object &fingerprintGenerator, python::object py_callable,
+    const python::object &py_params) {
+  SynthonSpaceSearch::SynthonSpaceSearchParams params;
+  if (!py_params.is_none()) {
+    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+        py_params);
+  }
+  const FingerprintGenerator<std::uint64_t> *fpGen =
+      python::extract<FingerprintGenerator<std::uint64_t> *>(
+          fingerprintGenerator);
+
+  CallbackAdapter callback{py_callable};
+  self.fingerprintSearch(query, *fpGen, callback, params);
+}
+
+SynthonSpaceSearch::SearchResults rascalSearch_helper(
+    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
+    const python::object &py_rascalOptions, const python::object &py_params) {
+  RascalMCES::RascalOptions rascalOptions;
+  rascalOptions = python::extract<RascalMCES::RascalOptions>(py_rascalOptions);
+  SynthonSpaceSearch::SynthonSpaceSearchParams params;
+  if (!py_params.is_none()) {
+    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+        py_params);
+  }
+  {
+    NOGIL gil;
+    return self.rascalSearch(query, rascalOptions, params);
+  }
+}
+
+static void rascalSearch_helper_2(SynthonSpaceSearch::SynthonSpace &self,
+                                  const ROMol &query,
+                                  const python::object &py_rascalOptions,
+                                  python::object py_callable,
+                                  const python::object &py_params) {
+  RascalMCES::RascalOptions rascalOptions;
+  rascalOptions = python::extract<RascalMCES::RascalOptions>(py_rascalOptions);
+  SynthonSpaceSearch::SynthonSpaceSearchParams params;
+  if (!py_params.is_none()) {
+    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+        py_params);
+  }
+  CallbackAdapter callback{py_callable};
+  self.rascalSearch(query, rascalOptions, callback, params);
+}
+
+void summariseHelper(SynthonSpaceSearch::SynthonSpace &self) {
+  self.summarise(std::cout);
+}
+
+void convertTextToDBFile_helper(const std::string &inFilename,
+                                const std::string &outFilename,
+                                python::object fpGen) {
+  const FingerprintGenerator<std::uint64_t> *fpGenCpp = nullptr;
+  if (fpGen) {
+    fpGenCpp = python::extract<FingerprintGenerator<std::uint64_t> *>(fpGen);
+  }
+  bool cancelled = false;
+  SynthonSpaceSearch::convertTextToDBFile(inFilename, outFilename, cancelled,
+                                          fpGenCpp);
+  if (cancelled) {
+    throw_runtime_error("Database conversion cancelled");
+  }
+}
+
+void readTextFile_helper(SynthonSpaceSearch::SynthonSpace &self,
+                         const std::string &inFilename) {
+  bool cancelled = false;
+  {
+    NOGIL gil;
+    self.readTextFile(inFilename, cancelled);
+  }
+  if (cancelled) {
+    throw_runtime_error("Database read cancelled.");
+  }
+}
+
+BOOST_PYTHON_MODULE(rdSynthonSpaceSearch) {
+  python::scope().attr("__doc__") =
+      "Module containing implementation of SynthonSpace search of"
+      " Synthon-based chemical libraries such as Enamine REAL."
+      "  NOTE: This functionality is experimental and the API"
+      " and/or results may change in future releases.";
+
+  SearchResults_wrapper::wrap();
+
+  std::string docString = "SynthonSpaceSearch parameters.";
+  python::class_<SynthonSpaceSearch::SynthonSpaceSearchParams,
+                 boost::noncopyable>("SynthonSpaceSearchParams",
+                                     docString.c_str())
+      .def_readwrite("maxHits",
+                     &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHits,
+                     "The maximum number of hits to return.  Default=1000."
+                     "Use -1 for no maximum.")
+      .def_readwrite(
+          "maxNumFrags",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::maxNumFragSets,
+          "The maximum number of fragments the query can be broken into."
+          "  Big molecules will create huge numbers of fragments that may cause"
+          " excessive memory use.  If the number of fragments hits this number,"
+          " fragmentation stops and the search results will likely be incomplete."
+          "  Default=100000.")
+      .def_readwrite(
+          "hitStart", &SynthonSpaceSearch::SynthonSpaceSearchParams::hitStart,
+          "The sequence number of the hit to start from.  So that you"
+          " can return the next N hits of a search having already"
+          " obtained N-1.  Default=0")
+      .def_readwrite(
+          "randomSample",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSample,
+          "If True, returns a random sample of the hits, up to maxHits"
+          " in number.  Default=False.")
+      .def_readwrite(
+          "randomSeed",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSeed,
+          "If using randomSample, this seeds the random number"
+          " generator so as to give reproducible results.  Default=-1"
+          " means use a random seed.")
+      .def_readwrite("buildHits",
+                     &SynthonSpaceSearch::SynthonSpaceSearchParams::buildHits,
+                     "If false, reports the maximum number of hits that"
+                     " the search could produce, but doesn't return them.")
+      .def_readwrite(
+          "numRandomSweeps",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::numRandomSweeps,
+          "The random sampling doesn't always produce the"
+          " required number of hits in 1 go.  This parameter"
+          " controls how many loops it makes to try and get"
+          " the hits before giving up.  Default=10.")
+      .def_readwrite(
+          "similarityCutoff",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::similarityCutoff,
+          "Similarity cutoff for returning hits by fingerprint similarity."
+          "  At present the fp is hard-coded to be Morgan, bits, radius=2."
+          "  Default=0.5.")
+      .def_readwrite(
+          "fragSimilarityAdjuster",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::fragSimilarityAdjuster,
+          "Similarities of fragments are generally low due to low bit"
+          " densities.  For the fragment matching, reduce the similarity cutoff"
+          " off by this amount.  Default=0.1.")
+      .def_readwrite(
+          "approxSimilarityAdjuster",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::
+              approxSimilarityAdjuster,
+          "The fingerprint search uses an approximate similarity method"
+          " before building a product and doing a final check.  The"
+          " similarityCutoff is reduced by this value for the approximate"
+          " check.  A lower value will give faster run times at the"
+          " risk of missing some hits.  The value you use should have a"
+          " positive correlation with your FOMO.  The default of 0.1 is"
+          " appropriate for Morgan fingerprints.  With RDKit fingerprints,"
+          " 0.05 is adequate, and higher than that has been seen to"
+          " produce long run times.")
+      .def_readwrite(
+          "minHitHeavyAtoms",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitHeavyAtoms,
+          "Minimum number of heavy atoms in a hit.  Default=0.")
+      .def_readwrite(
+          "maxHitHeavyAtoms",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitHeavyAtoms,
+          "Maximum number of heavy atoms in a hit.  Default=-1 means no maximum.")
+      .def_readwrite("minHitMolWt",
+                     &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitMolWt,
+                     "Minimum molecular weight for a hit.  Default=0.0.")
+      .def_readwrite(
+          "maxHitMolWt",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitMolWt,
+          "Maximum molecular weight for a hit.  Default=0.0 mean no maximum.")
+      .def_readwrite(
+          "minHitChiralAtoms",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitChiralAtoms,
+          "Minimum number of chiral atoms in a hit.  Default=0.")
+      .def_readwrite(
+          "maxHitChiralAtoms",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitChiralAtoms,
+          "Maximum number of chiral atoms in a hit.  Default=-1 means no maximum.")
+      .def_readwrite(
+          "timeOut", &SynthonSpaceSearch::SynthonSpaceSearchParams::timeOut,
+          "Time limit for search, in seconds.  Default is 600s, 0 means no"
+          " timeout.  Requires an integer")
+      .def_readwrite(
+          "toTryChunkSize",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::toTryChunkSize,
+          "Process possible hits using the given chunk size")
+      .def_readwrite(
+          "numThreads",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::numThreads,
+          "The number of threads to use for search.  If > 0, will use that"
+          " number.  If <= 0, will use the number of hardware"
+          " threads plus this number.  So if the number of"
+          " hardware threads is 8, and numThreads is -1, it will"
+          " use 7 threads.  Default=1.")
+      .def("__setattr__", &safeSetattr);
+
+  docString = "SynthonSpaceSearch object.";
+  python::class_<SynthonSpaceSearch::SynthonSpace, boost::noncopyable>(
+      "SynthonSpace", docString.c_str(), python::init<>())
+      .def("ReadTextFile", &readTextFile_helper,
+           (python::arg("self"), python::arg("inFile")),
+           "Reads text file of the sort used by ChemSpace/Enamine.")
+      .def("ReadDBFile", &SynthonSpaceSearch::SynthonSpace::readDBFile,
+           (python::arg("self"), python::arg("inFile"),
+            python::arg("numThreads") = 1),
+           "Reads binary database file.  Takes optional number of threads,"
+           "default=1.")
+      .def("WriteDBFile", &SynthonSpaceSearch::SynthonSpace::writeDBFile,
+           (python::arg("self"), python::arg("outFile")),
+           "Writes binary database file.")
+      .def("WriteEnumeratedFile",
+           &SynthonSpaceSearch::SynthonSpace::writeEnumeratedFile,
+           (python::arg("self"), python::arg("outFile")),
+           "Writes enumerated library to file.")
+      .def("GetNumReactions",
+           &SynthonSpaceSearch::SynthonSpace::getNumReactions,
+           python::arg("self"),
+           "Returns number of reactions in the SynthonSpace.")
+      .def("GetNumProducts", &SynthonSpaceSearch::SynthonSpace::getNumProducts,
+           python::arg("self"),
+           "Returns number of products in the SynthonSpace, with multiple"
+           " counting of any duplicates.")
+      .def("Summarise", &summariseHelper, python::arg("self"),
+           "Writes a summary of the SynthonSpace to stdout.")
+      .def("GetSynthonFingerprintType",
+           &SynthonSpaceSearch::SynthonSpace::getSynthonFingerprintType,
+           python::arg("self"),
+           "Returns the information string for the fingerprint generator"
+           " used to create this space.")
+      .def("SubstructureSearch", &substructureSearch_helper1,
+           (python::arg("self"), python::arg("query"),
+            python::arg("substructMatchParams") = python::object(),
+            python::arg("params") = python::object()),
+           "Does a substructure search in the SynthonSpace.")
+      .def("SubstructureSearch", &substructureSearch_helper2,
+           (python::arg("self"), python::arg("query"),
+            python::arg("substructMatchParams") = python::object(),
+            python::arg("params") = python::object()),
+           "Does a substructure search in the SynthonSpace using an"
+           " extended query.")
+      .def(
+          "SubstructureSearchIncremental", &substructureSearch_helper3,
+          (python::arg("self"), python::arg("query"), python::arg("callback"),
+           python::arg("substructMatchParams") = python::object(),
+           python::arg("params") = python::object()),
+          "Does a substructure search in the SynthonSpace returning results in the callback.")
+      .def("FingerprintSearch", &fingerprintSearch_helper,
+           (python::arg("self"), python::arg("query"),
+            python::arg("fingerprintGenerator"),
+            python::arg("params") = python::object()),
+           "Does a fingerprint search in the SynthonSpace using the"
+           " FingerprintGenerator passed in.")
+      .def("FingerprintSearchIncremental", &fingerprintSearch_helper_2,
+           (python::arg("self"), python::arg("query"),
+            python::arg("fingerprintGenerator"), python::arg("callback"),
+            python::arg("params") = python::object()),
+           "Does a fingerprint search in the SynthonSpace using the"
+           " FingerprintGenerator passed in, returning results the callback.")
+      .def("RascalSearch", &rascalSearch_helper,
+           (python::arg("self"), python::arg("query"),
+            python::arg("rascalOptions"),
+            python::arg("params") = python::object()),
+           "Does a search using the Rascal similarity score.  The similarity"
+           " threshold used is provided by rascalOptions, and the one in"
+           " params is ignored.")
+      .def("RascalSearchIncremental", &rascalSearch_helper_2,
+           (python::arg("self"), python::arg("query"),
+            python::arg("rascalOptions"), python::arg("callback"),
+            python::arg("params") = python::object()),
+           "Does a search using the Rascal similarity score.  The similarity"
+           " threshold used is provided by rascalOptions, and the one in"
+           " params is ignored.  Returns results iteratively in the callback.")
+      .def(
+          "BuildSynthonFingerprints",
+          &SynthonSpaceSearch::SynthonSpace::buildSynthonFingerprints,
+          (python::arg("self"), python::arg("fingerprintGenerator")),
+          "Build the synthon fingerprints ready for similarity searching.  This"
+          " is done automatically when the first similarity search is done, but if"
+          " converting a text file to binary format it might need to be done"
+          " explicitly.");
+
+  docString =
+      "Convert the text file into the binary DB file in our format."
+      "  Assumes that all synthons from a reaction are contiguous in the input file."
+      "  This uses a lot less memory than using ReadTextFile() followed by"
+      "  WriteDBFile()."
+      "- inFilename the name of the text file"
+      "- outFilename the name of the binary file"
+      "- optional fingerprint generator";
+  python::def("ConvertTextToDBFile", &RDKit::convertTextToDBFile_helper,
+              (python::arg("inFilename"), python::arg("outFilename"),
+               python::arg("fpGen") = python::object()),
+              docString.c_str());
+
+  docString =
+      "Format an integer with spaces every 3 digits for ease of reading";
+  python::def("FormattedIntegerString",
+              &RDKit::SynthonSpaceSearch::formattedIntegerString,
+              python::arg("value"), docString.c_str());
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/SynthonSpaceSearch/nbWrap/rdSynthonSpaceSearch.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/nbWrap/rdSynthonSpaceSearch.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) David Cosgrove 2024.
+// Copyright (C) 2024-2026 David Cosgrove and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -9,58 +9,46 @@
 //
 
 #include <csignal>
+#include <stdexcept>
 
-#include <RDBoost/python.h>
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/filesystem.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/unique_ptr.h>
+
+#include <RDBoost/Wrap_nb.h>
 
 #include <GraphMol/ROMol.h>
 #include <GraphMol/RascalMCES/RascalOptions.h>
+#include <GraphMol/GeneralizedSubstruct/XQMol.h>
+#include <GraphMol/Fingerprints/FingerprintGenerator.h>
 #include <GraphMol/SynthonSpaceSearch/SynthonSpace.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace RDKit;
 
-namespace RDKit {
-python::list hitMolecules_helper(const SynthonSpaceSearch::SearchResults &res) {
-  python::list pyres;
-  for (auto &r : res.getHitMolecules()) {
-    pyres.append(boost::make_shared<ROMol>(*r));
+namespace {
+
+nb::list hitMolecules_helper(const SynthonSpaceSearch::SearchResults &res) {
+  nb::list pyres;
+  for (const auto &r : res.getHitMolecules()) {
+    pyres.append(nb::cast(new ROMol(*r), nb::rv_policy::take_ownership));
   }
   return pyres;
 }
 
-struct SearchResults_wrapper {
-  static void wrap() {
-    const std::string docString =
-        "Used to return results of SynthonSpace searches.";
-    python::class_<SynthonSpaceSearch::SearchResults>(
-        "SubstructureResult", docString.c_str(), python::no_init)
-        .def("GetHitMolecules", hitMolecules_helper, python::args("self"),
-             "A function returning hits from the search")
-        .def("GetMaxNumResults",
-             &SynthonSpaceSearch::SearchResults::getMaxNumResults,
-             "The upper bound on number of results possible.  There"
-             " may be fewer than this in practice for several reasons"
-             " such as duplicate reagent sets being removed or the"
-             " final product not matching the query even though the"
-             " synthons suggested they would.")
-        .def("GetTimedOut", &SynthonSpaceSearch::SearchResults::getTimedOut,
-             "Returns whether the search timed out or not.")
-        .def("GetCancelled", &SynthonSpaceSearch::SearchResults::getCancelled,
-             "Returns whether the search was cancelled or not.");
-  }
-};
-
 SynthonSpaceSearch::SearchResults substructureSearch_helper1(
     SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
-    const python::object &py_smParams, const python::object &py_params) {
+    const nb::object &py_smParams, const nb::object &py_params) {
   SynthonSpaceSearch::SynthonSpaceSearchParams params;
   SubstructMatchParameters smParams;
   if (!py_smParams.is_none()) {
-    smParams = python::extract<SubstructMatchParameters>(py_smParams);
+    smParams = nb::cast<SubstructMatchParameters>(py_smParams);
   }
   if (!py_params.is_none()) {
-    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
-        py_params);
+    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
   }
 
   SynthonSpaceSearch::SearchResults results;
@@ -69,7 +57,7 @@ SynthonSpaceSearch::SearchResults substructureSearch_helper1(
     results = self.substructureSearch(query, smParams, params);
   }
   if (results.getCancelled()) {
-    throw_runtime_error("SubstructureSearch cancelled");
+    throw std::runtime_error("SubstructureSearch cancelled");
   }
   return results;
 }
@@ -77,15 +65,14 @@ SynthonSpaceSearch::SearchResults substructureSearch_helper1(
 SynthonSpaceSearch::SearchResults substructureSearch_helper2(
     SynthonSpaceSearch::SynthonSpace &self,
     const GeneralizedSubstruct::ExtendedQueryMol &query,
-    const python::object &py_smParams, const python::object &py_params) {
+    const nb::object &py_smParams, const nb::object &py_params) {
   SubstructMatchParameters smParams;
   if (!py_smParams.is_none()) {
-    smParams = python::extract<SubstructMatchParameters>(py_smParams);
+    smParams = nb::cast<SubstructMatchParameters>(py_smParams);
   }
   SynthonSpaceSearch::SynthonSpaceSearchParams params;
   if (!py_params.is_none()) {
-    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
-        py_params);
+    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
   }
   SynthonSpaceSearch::SearchResults results;
   {
@@ -93,36 +80,38 @@ SynthonSpaceSearch::SearchResults substructureSearch_helper2(
     results = self.substructureSearch(query, smParams, params);
   }
   if (results.getCancelled()) {
-    throw_runtime_error("SubstructureSearch cancelled");
+    throw std::runtime_error("SubstructureSearch cancelled");
   }
   return results;
 }
 
 struct CallbackAdapter {
-  python::object py_callable;
+  nb::object py_callable;
 
   bool operator()(std::vector<std::unique_ptr<ROMol>> &results) const {
-    python::list pyres;
+    nb::list pyres;
     for (auto &mol : results) {
-      pyres.append(boost::shared_ptr<ROMol>(mol.release()));
+      pyres.append(nb::cast(mol.release(), nb::rv_policy::take_ownership));
     }
-    return bool(py_callable(pyres));
+    nb::object ret = py_callable(pyres);
+    if (ret.is_none()) {
+      return false;
+    }
+    return nb::cast<bool>(ret);
   }
 };
 
-static void substructureSearch_helper3(SynthonSpaceSearch::SynthonSpace &self,
-                                       const ROMol &query,
-                                       python::object py_callable,
-                                       const python::object &py_smParams,
-                                       const python::object &py_params) {
+void substructureSearch_helper3(SynthonSpaceSearch::SynthonSpace &self,
+                                const ROMol &query, nb::object py_callable,
+                                const nb::object &py_smParams,
+                                const nb::object &py_params) {
   SynthonSpaceSearch::SynthonSpaceSearchParams params;
   SubstructMatchParameters smParams;
   if (!py_smParams.is_none()) {
-    smParams = python::extract<SubstructMatchParameters>(py_smParams);
+    smParams = nb::cast<SubstructMatchParameters>(py_smParams);
   }
   if (!py_params.is_none()) {
-    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
-        py_params);
+    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
   }
   CallbackAdapter callback{py_callable};
   self.substructureSearch(query, callback, smParams, params);
@@ -130,53 +119,47 @@ static void substructureSearch_helper3(SynthonSpaceSearch::SynthonSpace &self,
 
 SynthonSpaceSearch::SearchResults fingerprintSearch_helper(
     SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
-    const python::object &fingerprintGenerator,
-    const python::object &py_params) {
+    const nb::object &fingerprintGenerator, const nb::object &py_params) {
   SynthonSpaceSearch::SynthonSpaceSearchParams params;
   if (!py_params.is_none()) {
-    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
-        py_params);
+    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
   }
   SynthonSpaceSearch::SearchResults results;
   {
     NOGIL gil;
     const FingerprintGenerator<std::uint64_t> *fpGen =
-        python::extract<FingerprintGenerator<std::uint64_t> *>(
-            fingerprintGenerator);
+        nb::cast<FingerprintGenerator<std::uint64_t> *>(fingerprintGenerator);
     results = self.fingerprintSearch(query, *fpGen, params);
   }
   if (results.getCancelled()) {
-    throw_runtime_error("FingerprintSearch cancelled");
+    throw std::runtime_error("FingerprintSearch cancelled");
   }
   return results;
 }
 
-static void fingerprintSearch_helper_2(
-    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
-    const python::object &fingerprintGenerator, python::object py_callable,
-    const python::object &py_params) {
+void fingerprintSearch_helper2(SynthonSpaceSearch::SynthonSpace &self,
+                               const ROMol &query,
+                               const nb::object &fingerprintGenerator,
+                               nb::object py_callable,
+                               const nb::object &py_params) {
   SynthonSpaceSearch::SynthonSpaceSearchParams params;
   if (!py_params.is_none()) {
-    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
-        py_params);
+    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
   }
   const FingerprintGenerator<std::uint64_t> *fpGen =
-      python::extract<FingerprintGenerator<std::uint64_t> *>(
-          fingerprintGenerator);
-
+      nb::cast<FingerprintGenerator<std::uint64_t> *>(fingerprintGenerator);
   CallbackAdapter callback{py_callable};
   self.fingerprintSearch(query, *fpGen, callback, params);
 }
 
 SynthonSpaceSearch::SearchResults rascalSearch_helper(
     SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
-    const python::object &py_rascalOptions, const python::object &py_params) {
-  RascalMCES::RascalOptions rascalOptions;
-  rascalOptions = python::extract<RascalMCES::RascalOptions>(py_rascalOptions);
+    const nb::object &py_rascalOptions, const nb::object &py_params) {
+  RascalMCES::RascalOptions rascalOptions =
+      nb::cast<RascalMCES::RascalOptions>(py_rascalOptions);
   SynthonSpaceSearch::SynthonSpaceSearchParams params;
   if (!py_params.is_none()) {
-    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
-        py_params);
+    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
   }
   {
     NOGIL gil;
@@ -184,17 +167,16 @@ SynthonSpaceSearch::SearchResults rascalSearch_helper(
   }
 }
 
-static void rascalSearch_helper_2(SynthonSpaceSearch::SynthonSpace &self,
-                                  const ROMol &query,
-                                  const python::object &py_rascalOptions,
-                                  python::object py_callable,
-                                  const python::object &py_params) {
-  RascalMCES::RascalOptions rascalOptions;
-  rascalOptions = python::extract<RascalMCES::RascalOptions>(py_rascalOptions);
+void rascalSearch_helper2(SynthonSpaceSearch::SynthonSpace &self,
+                          const ROMol &query,
+                          const nb::object &py_rascalOptions,
+                          nb::object py_callable,
+                          const nb::object &py_params) {
+  RascalMCES::RascalOptions rascalOptions =
+      nb::cast<RascalMCES::RascalOptions>(py_rascalOptions);
   SynthonSpaceSearch::SynthonSpaceSearchParams params;
   if (!py_params.is_none()) {
-    params = python::extract<SynthonSpaceSearch::SynthonSpaceSearchParams>(
-        py_params);
+    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
   }
   CallbackAdapter callback{py_callable};
   self.rascalSearch(query, rascalOptions, callback, params);
@@ -204,254 +186,259 @@ void summariseHelper(SynthonSpaceSearch::SynthonSpace &self) {
   self.summarise(std::cout);
 }
 
-void convertTextToDBFile_helper(const std::string &inFilename,
-                                const std::string &outFilename,
-                                python::object fpGen) {
+void convertTextToDBFile_helper(const std::filesystem::path &inFilename,
+                                const std::filesystem::path &outFilename,
+                                nb::object fpGen) {
   const FingerprintGenerator<std::uint64_t> *fpGenCpp = nullptr;
-  if (fpGen) {
-    fpGenCpp = python::extract<FingerprintGenerator<std::uint64_t> *>(fpGen);
+  if (!fpGen.is_none()) {
+    fpGenCpp =
+        nb::cast<FingerprintGenerator<std::uint64_t> *>(fpGen);
   }
   bool cancelled = false;
-  SynthonSpaceSearch::convertTextToDBFile(inFilename, outFilename, cancelled,
+  SynthonSpaceSearch::convertTextToDBFile(inFilename.string(),
+                                          outFilename.string(), cancelled,
                                           fpGenCpp);
   if (cancelled) {
-    throw_runtime_error("Database conversion cancelled");
+    throw std::runtime_error("Database conversion cancelled");
   }
 }
 
 void readTextFile_helper(SynthonSpaceSearch::SynthonSpace &self,
-                         const std::string &inFilename) {
+                         const std::filesystem::path &inFilename) {
   bool cancelled = false;
   {
     NOGIL gil;
-    self.readTextFile(inFilename, cancelled);
+    self.readTextFile(inFilename.string(), cancelled);
   }
   if (cancelled) {
-    throw_runtime_error("Database read cancelled.");
+    throw std::runtime_error("Database read cancelled.");
   }
 }
 
-BOOST_PYTHON_MODULE(rdSynthonSpaceSearch) {
-  python::scope().attr("__doc__") =
-      "Module containing implementation of SynthonSpace search of"
-      " Synthon-based chemical libraries such as Enamine REAL."
-      "  NOTE: This functionality is experimental and the API"
-      " and/or results may change in future releases.";
+}  // namespace
 
-  SearchResults_wrapper::wrap();
+NB_MODULE(rdSynthonSpaceSearch, m) {
+  m.doc() =
+      R"DOC(Module containing implementation of SynthonSpace search of
+Synthon-based chemical libraries such as Enamine REAL.
+  NOTE: This functionality is experimental and the API
+and/or results may change in future releases.)DOC";
 
-  std::string docString = "SynthonSpaceSearch parameters.";
-  python::class_<SynthonSpaceSearch::SynthonSpaceSearchParams,
-                 boost::noncopyable>("SynthonSpaceSearchParams",
-                                     docString.c_str())
-      .def_readwrite("maxHits",
-                     &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHits,
-                     "The maximum number of hits to return.  Default=1000."
-                     "Use -1 for no maximum.")
-      .def_readwrite(
+  nb::class_<SynthonSpaceSearch::SearchResults>(
+      m, "SubstructureResult",
+      "Used to return results of SynthonSpace searches.")
+      .def("GetHitMolecules", hitMolecules_helper,
+           "A function returning hits from the search")
+      .def("GetMaxNumResults",
+           &SynthonSpaceSearch::SearchResults::getMaxNumResults,
+           R"DOC(The upper bound on number of results possible.  There
+may be fewer than this in practice for several reasons
+such as duplicate reagent sets being removed or the
+final product not matching the query even though the
+synthons suggested they would.)DOC")
+      .def("GetTimedOut", &SynthonSpaceSearch::SearchResults::getTimedOut,
+           "Returns whether the search timed out or not.")
+      .def("GetCancelled", &SynthonSpaceSearch::SearchResults::getCancelled,
+           "Returns whether the search was cancelled or not.");
+
+  nb::class_<SynthonSpaceSearch::SynthonSpaceSearchParams>(
+      m, "SynthonSpaceSearchParams", "SynthonSpaceSearch parameters.")
+      .def(nb::init<>())
+      .def_rw("maxHits",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHits,
+              R"DOC(The maximum number of hits to return.  Default=1000.Use -1 for no maximum.)DOC")
+      .def_rw(
           "maxNumFrags",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxNumFragSets,
-          "The maximum number of fragments the query can be broken into."
-          "  Big molecules will create huge numbers of fragments that may cause"
-          " excessive memory use.  If the number of fragments hits this number,"
-          " fragmentation stops and the search results will likely be incomplete."
-          "  Default=100000.")
-      .def_readwrite(
-          "hitStart", &SynthonSpaceSearch::SynthonSpaceSearchParams::hitStart,
-          "The sequence number of the hit to start from.  So that you"
-          " can return the next N hits of a search having already"
-          " obtained N-1.  Default=0")
-      .def_readwrite(
+          R"DOC(The maximum number of fragments the query can be broken into.
+  Big molecules will create huge numbers of fragments that may cause
+excessive memory use.  If the number of fragments hits this number,
+fragmentation stops and the search results will likely be incomplete.
+  Default=100000.)DOC")
+      .def_rw(
+          "hitStart",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::hitStart,
+          R"DOC(The sequence number of the hit to start from.  So that you
+can return the next N hits of a search having already
+obtained N-1.  Default=0)DOC")
+      .def_rw(
           "randomSample",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSample,
-          "If True, returns a random sample of the hits, up to maxHits"
-          " in number.  Default=False.")
-      .def_readwrite(
+          R"DOC(If True, returns a random sample of the hits, up to maxHits
+in number.  Default=False.)DOC")
+      .def_rw(
           "randomSeed",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSeed,
-          "If using randomSample, this seeds the random number"
-          " generator so as to give reproducible results.  Default=-1"
-          " means use a random seed.")
-      .def_readwrite("buildHits",
-                     &SynthonSpaceSearch::SynthonSpaceSearchParams::buildHits,
-                     "If false, reports the maximum number of hits that"
-                     " the search could produce, but doesn't return them.")
-      .def_readwrite(
+          R"DOC(If using randomSample, this seeds the random number
+generator so as to give reproducible results.  Default=-1
+means use a random seed.)DOC")
+      .def_rw("buildHits",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::buildHits,
+              R"DOC(If false, reports the maximum number of hits that
+the search could produce, but doesn't return them.)DOC")
+      .def_rw(
           "numRandomSweeps",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::numRandomSweeps,
-          "The random sampling doesn't always produce the"
-          " required number of hits in 1 go.  This parameter"
-          " controls how many loops it makes to try and get"
-          " the hits before giving up.  Default=10.")
-      .def_readwrite(
+          R"DOC(The random sampling doesn't always produce the
+required number of hits in 1 go.  This parameter
+controls how many loops it makes to try and get
+the hits before giving up.  Default=10.)DOC")
+      .def_rw(
           "similarityCutoff",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::similarityCutoff,
-          "Similarity cutoff for returning hits by fingerprint similarity."
-          "  At present the fp is hard-coded to be Morgan, bits, radius=2."
-          "  Default=0.5.")
-      .def_readwrite(
+          R"DOC(Similarity cutoff for returning hits by fingerprint similarity.
+  At present the fp is hard-coded to be Morgan, bits, radius=2.
+  Default=0.5.)DOC")
+      .def_rw(
           "fragSimilarityAdjuster",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::fragSimilarityAdjuster,
-          "Similarities of fragments are generally low due to low bit"
-          " densities.  For the fragment matching, reduce the similarity cutoff"
-          " off by this amount.  Default=0.1.")
-      .def_readwrite(
+          R"DOC(Similarities of fragments are generally low due to low bit
+densities.  For the fragment matching, reduce the similarity cutoff
+off by this amount.  Default=0.1.)DOC")
+      .def_rw(
           "approxSimilarityAdjuster",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::
               approxSimilarityAdjuster,
-          "The fingerprint search uses an approximate similarity method"
-          " before building a product and doing a final check.  The"
-          " similarityCutoff is reduced by this value for the approximate"
-          " check.  A lower value will give faster run times at the"
-          " risk of missing some hits.  The value you use should have a"
-          " positive correlation with your FOMO.  The default of 0.1 is"
-          " appropriate for Morgan fingerprints.  With RDKit fingerprints,"
-          " 0.05 is adequate, and higher than that has been seen to"
-          " produce long run times.")
-      .def_readwrite(
+          R"DOC(The fingerprint search uses an approximate similarity method
+before building a product and doing a final check.  The
+similarityCutoff is reduced by this value for the approximate
+check.  A lower value will give faster run times at the
+risk of missing some hits.  The value you use should have a
+positive correlation with your FOMO.  The default of 0.1 is
+appropriate for Morgan fingerprints.  With RDKit fingerprints,
+0.05 is adequate, and higher than that has been seen to
+produce long run times.)DOC")
+      .def_rw(
           "minHitHeavyAtoms",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitHeavyAtoms,
           "Minimum number of heavy atoms in a hit.  Default=0.")
-      .def_readwrite(
+      .def_rw(
           "maxHitHeavyAtoms",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitHeavyAtoms,
           "Maximum number of heavy atoms in a hit.  Default=-1 means no maximum.")
-      .def_readwrite("minHitMolWt",
-                     &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitMolWt,
-                     "Minimum molecular weight for a hit.  Default=0.0.")
-      .def_readwrite(
+      .def_rw("minHitMolWt",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitMolWt,
+              "Minimum molecular weight for a hit.  Default=0.0.")
+      .def_rw(
           "maxHitMolWt",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitMolWt,
           "Maximum molecular weight for a hit.  Default=0.0 mean no maximum.")
-      .def_readwrite(
+      .def_rw(
           "minHitChiralAtoms",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitChiralAtoms,
           "Minimum number of chiral atoms in a hit.  Default=0.")
-      .def_readwrite(
+      .def_rw(
           "maxHitChiralAtoms",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitChiralAtoms,
           "Maximum number of chiral atoms in a hit.  Default=-1 means no maximum.")
-      .def_readwrite(
-          "timeOut", &SynthonSpaceSearch::SynthonSpaceSearchParams::timeOut,
-          "Time limit for search, in seconds.  Default is 600s, 0 means no"
-          " timeout.  Requires an integer")
-      .def_readwrite(
+      .def_rw(
+          "timeOut",
+          &SynthonSpaceSearch::SynthonSpaceSearchParams::timeOut,
+          R"DOC(Time limit for search, in seconds.  Default is 600s, 0 means no
+timeout.  Requires an integer)DOC")
+      .def_rw(
           "toTryChunkSize",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::toTryChunkSize,
           "Process possible hits using the given chunk size")
-      .def_readwrite(
+      .def_rw(
           "numThreads",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::numThreads,
-          "The number of threads to use for search.  If > 0, will use that"
-          " number.  If <= 0, will use the number of hardware"
-          " threads plus this number.  So if the number of"
-          " hardware threads is 8, and numThreads is -1, it will"
-          " use 7 threads.  Default=1.")
+          R"DOC(The number of threads to use for search.  If > 0, will use that
+number.  If <= 0, will use the number of hardware
+threads plus this number.  So if the number of
+hardware threads is 8, and numThreads is -1, it will
+use 7 threads.  Default=1.)DOC")
       .def("__setattr__", &safeSetattr);
 
-  docString = "SynthonSpaceSearch object.";
-  python::class_<SynthonSpaceSearch::SynthonSpace, boost::noncopyable>(
-      "SynthonSpace", docString.c_str(), python::init<>())
-      .def("ReadTextFile", &readTextFile_helper,
-           (python::arg("self"), python::arg("inFile")),
+  nb::class_<SynthonSpaceSearch::SynthonSpace>(m, "SynthonSpace",
+                                               "SynthonSpaceSearch object.")
+      .def(nb::init<>())
+      .def("ReadTextFile", &readTextFile_helper, "inFile"_a,
            "Reads text file of the sort used by ChemSpace/Enamine.")
-      .def("ReadDBFile", &SynthonSpaceSearch::SynthonSpace::readDBFile,
-           (python::arg("self"), python::arg("inFile"),
-            python::arg("numThreads") = 1),
-           "Reads binary database file.  Takes optional number of threads,"
-           "default=1.")
-      .def("WriteDBFile", &SynthonSpaceSearch::SynthonSpace::writeDBFile,
-           (python::arg("self"), python::arg("outFile")),
-           "Writes binary database file.")
-      .def("WriteEnumeratedFile",
-           &SynthonSpaceSearch::SynthonSpace::writeEnumeratedFile,
-           (python::arg("self"), python::arg("outFile")),
-           "Writes enumerated library to file.")
+      .def(
+          "ReadDBFile",
+          [](SynthonSpaceSearch::SynthonSpace &self,
+             const std::filesystem::path &inFile, int numThreads) {
+            self.readDBFile(inFile.string(), numThreads);
+          },
+          "inFile"_a, "numThreads"_a = 1,
+          R"DOC(Reads binary database file.  Takes optional number of threads,default=1.)DOC")
+      .def(
+          "WriteDBFile",
+          [](const SynthonSpaceSearch::SynthonSpace &self,
+             const std::filesystem::path &outFile) {
+            self.writeDBFile(outFile.string());
+          },
+          "outFile"_a, "Writes binary database file.")
+      .def(
+          "WriteEnumeratedFile",
+          [](const SynthonSpaceSearch::SynthonSpace &self,
+             const std::filesystem::path &outFile) {
+            self.writeEnumeratedFile(outFile.string());
+          },
+          "outFile"_a, "Writes enumerated library to file.")
       .def("GetNumReactions",
            &SynthonSpaceSearch::SynthonSpace::getNumReactions,
-           python::arg("self"),
            "Returns number of reactions in the SynthonSpace.")
       .def("GetNumProducts", &SynthonSpaceSearch::SynthonSpace::getNumProducts,
-           python::arg("self"),
-           "Returns number of products in the SynthonSpace, with multiple"
-           " counting of any duplicates.")
-      .def("Summarise", &summariseHelper, python::arg("self"),
+           R"DOC(Returns number of products in the SynthonSpace, with multiple
+counting of any duplicates.)DOC")
+      .def("Summarise", &summariseHelper,
            "Writes a summary of the SynthonSpace to stdout.")
       .def("GetSynthonFingerprintType",
            &SynthonSpaceSearch::SynthonSpace::getSynthonFingerprintType,
-           python::arg("self"),
-           "Returns the information string for the fingerprint generator"
-           " used to create this space.")
-      .def("SubstructureSearch", &substructureSearch_helper1,
-           (python::arg("self"), python::arg("query"),
-            python::arg("substructMatchParams") = python::object(),
-            python::arg("params") = python::object()),
+           R"DOC(Returns the information string for the fingerprint generator
+used to create this space.)DOC")
+      .def("SubstructureSearch", &substructureSearch_helper1, "query"_a,
+           "substructMatchParams"_a = nb::none(), "params"_a = nb::none(),
            "Does a substructure search in the SynthonSpace.")
-      .def("SubstructureSearch", &substructureSearch_helper2,
-           (python::arg("self"), python::arg("query"),
-            python::arg("substructMatchParams") = python::object(),
-            python::arg("params") = python::object()),
-           "Does a substructure search in the SynthonSpace using an"
-           " extended query.")
-      .def(
-          "SubstructureSearchIncremental", &substructureSearch_helper3,
-          (python::arg("self"), python::arg("query"), python::arg("callback"),
-           python::arg("substructMatchParams") = python::object(),
-           python::arg("params") = python::object()),
-          "Does a substructure search in the SynthonSpace returning results in the callback.")
-      .def("FingerprintSearch", &fingerprintSearch_helper,
-           (python::arg("self"), python::arg("query"),
-            python::arg("fingerprintGenerator"),
-            python::arg("params") = python::object()),
-           "Does a fingerprint search in the SynthonSpace using the"
-           " FingerprintGenerator passed in.")
-      .def("FingerprintSearchIncremental", &fingerprintSearch_helper_2,
-           (python::arg("self"), python::arg("query"),
-            python::arg("fingerprintGenerator"), python::arg("callback"),
-            python::arg("params") = python::object()),
-           "Does a fingerprint search in the SynthonSpace using the"
-           " FingerprintGenerator passed in, returning results the callback.")
-      .def("RascalSearch", &rascalSearch_helper,
-           (python::arg("self"), python::arg("query"),
-            python::arg("rascalOptions"),
-            python::arg("params") = python::object()),
-           "Does a search using the Rascal similarity score.  The similarity"
-           " threshold used is provided by rascalOptions, and the one in"
-           " params is ignored.")
-      .def("RascalSearchIncremental", &rascalSearch_helper_2,
-           (python::arg("self"), python::arg("query"),
-            python::arg("rascalOptions"), python::arg("callback"),
-            python::arg("params") = python::object()),
-           "Does a search using the Rascal similarity score.  The similarity"
-           " threshold used is provided by rascalOptions, and the one in"
-           " params is ignored.  Returns results iteratively in the callback.")
+      .def("SubstructureSearch", &substructureSearch_helper2, "query"_a,
+           "substructMatchParams"_a = nb::none(), "params"_a = nb::none(),
+           R"DOC(Does a substructure search in the SynthonSpace using an
+extended query.)DOC")
+      .def("SubstructureSearchIncremental", &substructureSearch_helper3,
+           "query"_a, "callback"_a, "substructMatchParams"_a = nb::none(),
+           "params"_a = nb::none(),
+           "Does a substructure search in the SynthonSpace returning results in the callback.")
+      .def("FingerprintSearch", &fingerprintSearch_helper, "query"_a,
+           "fingerprintGenerator"_a, "params"_a = nb::none(),
+           R"DOC(Does a fingerprint search in the SynthonSpace using the
+FingerprintGenerator passed in.)DOC")
+      .def("FingerprintSearchIncremental", &fingerprintSearch_helper2,
+           "query"_a, "fingerprintGenerator"_a, "callback"_a,
+           "params"_a = nb::none(),
+           R"DOC(Does a fingerprint search in the SynthonSpace using the
+FingerprintGenerator passed in, returning results the callback.)DOC")
+      .def("RascalSearch", &rascalSearch_helper, "query"_a, "rascalOptions"_a,
+           "params"_a = nb::none(),
+           R"DOC(Does a search using the Rascal similarity score.  The similarity
+threshold used is provided by rascalOptions, and the one in
+params is ignored.)DOC")
+      .def("RascalSearchIncremental", &rascalSearch_helper2, "query"_a,
+           "rascalOptions"_a, "callback"_a, "params"_a = nb::none(),
+           R"DOC(Does a search using the Rascal similarity score.  The similarity
+threshold used is provided by rascalOptions, and the one in
+params is ignored.  Returns results iteratively in the callback.)DOC")
       .def(
           "BuildSynthonFingerprints",
           &SynthonSpaceSearch::SynthonSpace::buildSynthonFingerprints,
-          (python::arg("self"), python::arg("fingerprintGenerator")),
-          "Build the synthon fingerprints ready for similarity searching.  This"
-          " is done automatically when the first similarity search is done, but if"
-          " converting a text file to binary format it might need to be done"
-          " explicitly.");
+          "fingerprintGenerator"_a,
+          R"DOC(Build the synthon fingerprints ready for similarity searching.  This
+is done automatically when the first similarity search is done, but if
+converting a text file to binary format it might need to be done
+explicitly.)DOC");
 
-  docString =
-      "Convert the text file into the binary DB file in our format."
-      "  Assumes that all synthons from a reaction are contiguous in the input file."
-      "  This uses a lot less memory than using ReadTextFile() followed by"
-      "  WriteDBFile()."
-      "- inFilename the name of the text file"
-      "- outFilename the name of the binary file"
-      "- optional fingerprint generator";
-  python::def("ConvertTextToDBFile", &RDKit::convertTextToDBFile_helper,
-              (python::arg("inFilename"), python::arg("outFilename"),
-               python::arg("fpGen") = python::object()),
-              docString.c_str());
+  m.def("ConvertTextToDBFile", &convertTextToDBFile_helper, "inFilename"_a,
+        "outFilename"_a, "fpGen"_a = nb::none(),
+        R"DOC(Convert the text file into the binary DB file in our format.
+  Assumes that all synthons from a reaction are contiguous in the input file.
+  This uses a lot less memory than using ReadTextFile() followed by
+  WriteDBFile().
+- inFilename the name of the text file
+- outFilename the name of the binary file
+- optional fingerprint generator)DOC");
 
-  docString =
-      "Format an integer with spaces every 3 digits for ease of reading";
-  python::def("FormattedIntegerString",
-              &RDKit::SynthonSpaceSearch::formattedIntegerString,
-              python::arg("value"), docString.c_str());
+  m.def("FormattedIntegerString",
+        &RDKit::SynthonSpaceSearch::formattedIntegerString, "value"_a,
+        "Format an integer with spaces every 3 digits for ease of reading");
 }
-
-}  // namespace RDKit

--- a/Code/GraphMol/SynthonSpaceSearch/nbWrap/rdSynthonSpaceSearch.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/nbWrap/rdSynthonSpaceSearch.cpp
@@ -16,6 +16,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/optional.h>
 
 #include <RDBoost/Wrap_nb.h>
 
@@ -41,20 +42,15 @@ nb::list hitMolecules_helper(const SynthonSpaceSearch::SearchResults &res) {
 
 SynthonSpaceSearch::SearchResults substructureSearch_helper1(
     SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
-    const nb::object &py_smParams, const nb::object &py_params) {
-  SynthonSpaceSearch::SynthonSpaceSearchParams params;
-  SubstructMatchParameters smParams;
-  if (!py_smParams.is_none()) {
-    smParams = nb::cast<SubstructMatchParameters>(py_smParams);
-  }
-  if (!py_params.is_none()) {
-    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
-  }
-
+    const std::optional<SubstructMatchParameters> &py_smParams,
+    const std::optional<SynthonSpaceSearch::SynthonSpaceSearchParams>
+        &py_params) {
   SynthonSpaceSearch::SearchResults results;
   {
     NOGIL gil;
-    results = self.substructureSearch(query, smParams, params);
+    results = self.substructureSearch(
+        query, py_smParams.value_or(SubstructMatchParameters()),
+        py_params.value_or(SynthonSpaceSearch::SynthonSpaceSearchParams()));
   }
   if (results.getCancelled()) {
     throw std::runtime_error("SubstructureSearch cancelled");
@@ -65,19 +61,15 @@ SynthonSpaceSearch::SearchResults substructureSearch_helper1(
 SynthonSpaceSearch::SearchResults substructureSearch_helper2(
     SynthonSpaceSearch::SynthonSpace &self,
     const GeneralizedSubstruct::ExtendedQueryMol &query,
-    const nb::object &py_smParams, const nb::object &py_params) {
-  SubstructMatchParameters smParams;
-  if (!py_smParams.is_none()) {
-    smParams = nb::cast<SubstructMatchParameters>(py_smParams);
-  }
-  SynthonSpaceSearch::SynthonSpaceSearchParams params;
-  if (!py_params.is_none()) {
-    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
-  }
+    const std::optional<SubstructMatchParameters> &py_smParams,
+    const std::optional<SynthonSpaceSearch::SynthonSpaceSearchParams>
+        &py_params) {
   SynthonSpaceSearch::SearchResults results;
   {
     NOGIL gil;
-    results = self.substructureSearch(query, smParams, params);
+    results = self.substructureSearch(
+        query, py_smParams.value_or(SubstructMatchParameters()),
+        py_params.value_or(SynthonSpaceSearch::SynthonSpaceSearchParams()));
   }
   if (results.getCancelled()) {
     throw std::runtime_error("SubstructureSearch cancelled");
@@ -101,20 +93,16 @@ struct CallbackAdapter {
   }
 };
 
-void substructureSearch_helper3(SynthonSpaceSearch::SynthonSpace &self,
-                                const ROMol &query, nb::object py_callable,
-                                const nb::object &py_smParams,
-                                const nb::object &py_params) {
-  SynthonSpaceSearch::SynthonSpaceSearchParams params;
-  SubstructMatchParameters smParams;
-  if (!py_smParams.is_none()) {
-    smParams = nb::cast<SubstructMatchParameters>(py_smParams);
-  }
-  if (!py_params.is_none()) {
-    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
-  }
+void substructureSearch_helper3(
+    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
+    nb::object py_callable,
+    const std::optional<SubstructMatchParameters> &py_smParams,
+    const std::optional<SynthonSpaceSearch::SynthonSpaceSearchParams>
+        &py_params) {
   CallbackAdapter callback{py_callable};
-  self.substructureSearch(query, callback, smParams, params);
+  self.substructureSearch(
+      query, callback, py_smParams.value_or(SubstructMatchParameters()),
+      py_params.value_or(SynthonSpaceSearch::SynthonSpaceSearchParams()));
 }
 
 SynthonSpaceSearch::SearchResults fingerprintSearch_helper(
@@ -137,19 +125,17 @@ SynthonSpaceSearch::SearchResults fingerprintSearch_helper(
   return results;
 }
 
-void fingerprintSearch_helper2(SynthonSpaceSearch::SynthonSpace &self,
-                               const ROMol &query,
-                               const nb::object &fingerprintGenerator,
-                               nb::object py_callable,
-                               const nb::object &py_params) {
-  SynthonSpaceSearch::SynthonSpaceSearchParams params;
-  if (!py_params.is_none()) {
-    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
-  }
+void fingerprintSearch_helper2(
+    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
+    const nb::object &fingerprintGenerator, nb::object py_callable,
+    const std::optional<SynthonSpaceSearch::SynthonSpaceSearchParams>
+        &py_params) {
   const FingerprintGenerator<std::uint64_t> *fpGen =
       nb::cast<FingerprintGenerator<std::uint64_t> *>(fingerprintGenerator);
   CallbackAdapter callback{py_callable};
-  self.fingerprintSearch(query, *fpGen, callback, params);
+  self.fingerprintSearch(
+      query, *fpGen, callback,
+      py_params.value_or(SynthonSpaceSearch::SynthonSpaceSearchParams()));
 }
 
 SynthonSpaceSearch::SearchResults rascalSearch_helper(
@@ -167,19 +153,16 @@ SynthonSpaceSearch::SearchResults rascalSearch_helper(
   }
 }
 
-void rascalSearch_helper2(SynthonSpaceSearch::SynthonSpace &self,
-                          const ROMol &query,
-                          const nb::object &py_rascalOptions,
-                          nb::object py_callable,
-                          const nb::object &py_params) {
-  RascalMCES::RascalOptions rascalOptions =
-      nb::cast<RascalMCES::RascalOptions>(py_rascalOptions);
-  SynthonSpaceSearch::SynthonSpaceSearchParams params;
-  if (!py_params.is_none()) {
-    params = nb::cast<SynthonSpaceSearch::SynthonSpaceSearchParams>(py_params);
-  }
+void rascalSearch_helper2(
+    SynthonSpaceSearch::SynthonSpace &self, const ROMol &query,
+    const std::optional<RascalMCES::RascalOptions> &py_rascalOptions,
+    nb::object py_callable,
+    const std::optional<SynthonSpaceSearch::SynthonSpaceSearchParams>
+        &py_params) {
   CallbackAdapter callback{py_callable};
-  self.rascalSearch(query, rascalOptions, callback, params);
+  self.rascalSearch(
+      query, py_rascalOptions.value_or(RascalMCES::RascalOptions()), callback,
+      py_params.value_or(SynthonSpaceSearch::SynthonSpaceSearchParams()));
 }
 
 void summariseHelper(SynthonSpaceSearch::SynthonSpace &self) {
@@ -191,13 +174,11 @@ void convertTextToDBFile_helper(const std::filesystem::path &inFilename,
                                 nb::object fpGen) {
   const FingerprintGenerator<std::uint64_t> *fpGenCpp = nullptr;
   if (!fpGen.is_none()) {
-    fpGenCpp =
-        nb::cast<FingerprintGenerator<std::uint64_t> *>(fpGen);
+    fpGenCpp = nb::cast<FingerprintGenerator<std::uint64_t> *>(fpGen);
   }
   bool cancelled = false;
-  SynthonSpaceSearch::convertTextToDBFile(inFilename.string(),
-                                          outFilename.string(), cancelled,
-                                          fpGenCpp);
+  SynthonSpaceSearch::convertTextToDBFile(
+      inFilename.string(), outFilename.string(), cancelled, fpGenCpp);
   if (cancelled) {
     throw std::runtime_error("Database conversion cancelled");
   }
@@ -244,9 +225,9 @@ synthons suggested they would.)DOC")
   nb::class_<SynthonSpaceSearch::SynthonSpaceSearchParams>(
       m, "SynthonSpaceSearchParams", "SynthonSpaceSearch parameters.")
       .def(nb::init<>())
-      .def_rw("maxHits",
-              &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHits,
-              R"DOC(The maximum number of hits to return.  Default=1000.Use -1 for no maximum.)DOC")
+      .def_rw(
+          "maxHits", &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHits,
+          R"DOC(The maximum number of hits to return.  Default=1000.Use -1 for no maximum.)DOC")
       .def_rw(
           "maxNumFrags",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxNumFragSets,
@@ -255,31 +236,27 @@ synthons suggested they would.)DOC")
 excessive memory use.  If the number of fragments hits this number,
 fragmentation stops and the search results will likely be incomplete.
   Default=100000.)DOC")
-      .def_rw(
-          "hitStart",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::hitStart,
-          R"DOC(The sequence number of the hit to start from.  So that you
+      .def_rw("hitStart",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::hitStart,
+              R"DOC(The sequence number of the hit to start from.  So that you
 can return the next N hits of a search having already
 obtained N-1.  Default=0)DOC")
-      .def_rw(
-          "randomSample",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSample,
-          R"DOC(If True, returns a random sample of the hits, up to maxHits
+      .def_rw("randomSample",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSample,
+              R"DOC(If True, returns a random sample of the hits, up to maxHits
 in number.  Default=False.)DOC")
-      .def_rw(
-          "randomSeed",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSeed,
-          R"DOC(If using randomSample, this seeds the random number
+      .def_rw("randomSeed",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::randomSeed,
+              R"DOC(If using randomSample, this seeds the random number
 generator so as to give reproducible results.  Default=-1
 means use a random seed.)DOC")
       .def_rw("buildHits",
               &SynthonSpaceSearch::SynthonSpaceSearchParams::buildHits,
               R"DOC(If false, reports the maximum number of hits that
 the search could produce, but doesn't return them.)DOC")
-      .def_rw(
-          "numRandomSweeps",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::numRandomSweeps,
-          R"DOC(The random sampling doesn't always produce the
+      .def_rw("numRandomSweeps",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::numRandomSweeps,
+              R"DOC(The random sampling doesn't always produce the
 required number of hits in 1 go.  This parameter
 controls how many loops it makes to try and get
 the hits before giving up.  Default=10.)DOC")
@@ -295,11 +272,10 @@ the hits before giving up.  Default=10.)DOC")
           R"DOC(Similarities of fragments are generally low due to low bit
 densities.  For the fragment matching, reduce the similarity cutoff
 off by this amount.  Default=0.1.)DOC")
-      .def_rw(
-          "approxSimilarityAdjuster",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::
-              approxSimilarityAdjuster,
-          R"DOC(The fingerprint search uses an approximate similarity method
+      .def_rw("approxSimilarityAdjuster",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::
+                  approxSimilarityAdjuster,
+              R"DOC(The fingerprint search uses an approximate similarity method
 before building a product and doing a final check.  The
 similarityCutoff is reduced by this value for the approximate
 check.  A lower value will give faster run times at the
@@ -308,10 +284,9 @@ positive correlation with your FOMO.  The default of 0.1 is
 appropriate for Morgan fingerprints.  With RDKit fingerprints,
 0.05 is adequate, and higher than that has been seen to
 produce long run times.)DOC")
-      .def_rw(
-          "minHitHeavyAtoms",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitHeavyAtoms,
-          "Minimum number of heavy atoms in a hit.  Default=0.")
+      .def_rw("minHitHeavyAtoms",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitHeavyAtoms,
+              "Minimum number of heavy atoms in a hit.  Default=0.")
       .def_rw(
           "maxHitHeavyAtoms",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitHeavyAtoms,
@@ -323,23 +298,20 @@ produce long run times.)DOC")
           "maxHitMolWt",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitMolWt,
           "Maximum molecular weight for a hit.  Default=0.0 mean no maximum.")
-      .def_rw(
-          "minHitChiralAtoms",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitChiralAtoms,
-          "Minimum number of chiral atoms in a hit.  Default=0.")
+      .def_rw("minHitChiralAtoms",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::minHitChiralAtoms,
+              "Minimum number of chiral atoms in a hit.  Default=0.")
       .def_rw(
           "maxHitChiralAtoms",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::maxHitChiralAtoms,
           "Maximum number of chiral atoms in a hit.  Default=-1 means no maximum.")
       .def_rw(
-          "timeOut",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::timeOut,
+          "timeOut", &SynthonSpaceSearch::SynthonSpaceSearchParams::timeOut,
           R"DOC(Time limit for search, in seconds.  Default is 600s, 0 means no
 timeout.  Requires an integer)DOC")
-      .def_rw(
-          "toTryChunkSize",
-          &SynthonSpaceSearch::SynthonSpaceSearchParams::toTryChunkSize,
-          "Process possible hits using the given chunk size")
+      .def_rw("toTryChunkSize",
+              &SynthonSpaceSearch::SynthonSpaceSearchParams::toTryChunkSize,
+              "Process possible hits using the given chunk size")
       .def_rw(
           "numThreads",
           &SynthonSpaceSearch::SynthonSpaceSearchParams::numThreads,
@@ -358,9 +330,8 @@ use 7 threads.  Default=1.)DOC")
       .def(
           "ReadDBFile",
           [](SynthonSpaceSearch::SynthonSpace &self,
-             const std::filesystem::path &inFile, int numThreads) {
-            self.readDBFile(inFile.string(), numThreads);
-          },
+             const std::filesystem::path &inFile,
+             int numThreads) { self.readDBFile(inFile.string(), numThreads); },
           "inFile"_a, "numThreads"_a = 1,
           R"DOC(Reads binary database file.  Takes optional number of threads,default=1.)DOC")
       .def(
@@ -396,10 +367,11 @@ used to create this space.)DOC")
            "substructMatchParams"_a = nb::none(), "params"_a = nb::none(),
            R"DOC(Does a substructure search in the SynthonSpace using an
 extended query.)DOC")
-      .def("SubstructureSearchIncremental", &substructureSearch_helper3,
-           "query"_a, "callback"_a, "substructMatchParams"_a = nb::none(),
-           "params"_a = nb::none(),
-           "Does a substructure search in the SynthonSpace returning results in the callback.")
+      .def(
+          "SubstructureSearchIncremental", &substructureSearch_helper3,
+          "query"_a, "callback"_a, "substructMatchParams"_a = nb::none(),
+          "params"_a = nb::none(),
+          "Does a substructure search in the SynthonSpace returning results in the callback.")
       .def("FingerprintSearch", &fingerprintSearch_helper, "query"_a,
            "fingerprintGenerator"_a, "params"_a = nb::none(),
            R"DOC(Does a fingerprint search in the SynthonSpace using the
@@ -409,14 +381,16 @@ FingerprintGenerator passed in.)DOC")
            "params"_a = nb::none(),
            R"DOC(Does a fingerprint search in the SynthonSpace using the
 FingerprintGenerator passed in, returning results the callback.)DOC")
-      .def("RascalSearch", &rascalSearch_helper, "query"_a, "rascalOptions"_a,
-           "params"_a = nb::none(),
-           R"DOC(Does a search using the Rascal similarity score.  The similarity
+      .def(
+          "RascalSearch", &rascalSearch_helper, "query"_a, "rascalOptions"_a,
+          "params"_a = nb::none(),
+          R"DOC(Does a search using the Rascal similarity score.  The similarity
 threshold used is provided by rascalOptions, and the one in
 params is ignored.)DOC")
-      .def("RascalSearchIncremental", &rascalSearch_helper2, "query"_a,
-           "rascalOptions"_a, "callback"_a, "params"_a = nb::none(),
-           R"DOC(Does a search using the Rascal similarity score.  The similarity
+      .def(
+          "RascalSearchIncremental", &rascalSearch_helper2, "query"_a,
+          "rascalOptions"_a, "callback"_a, "params"_a = nb::none(),
+          R"DOC(Does a search using the Rascal similarity score.  The similarity
 threshold used is provided by rascalOptions, and the one in
 params is ignored.  Returns results iteratively in the callback.)DOC")
       .def(


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to SynthonSpaceSearch.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.