### PR TITLE
pr/SHARED-12406: Implement nanobind for DistGeomHelpers

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
@@ -18,3 +18,7 @@ LINK_LIBRARIES DistGeomHelpers MolTransforms FileParsers SmilesParse )
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -14,6 +14,26 @@ from rdkit.RDLogger import logger
 
 logger = logger()
 
+# Detect if ChemicalForceFields (UFF) is fully functional in the current binding
+try:
+  _testMol = Chem.AddHs(Chem.MolFromSmiles('CC'))
+  AllChem.EmbedMolecule(_testMol, randomSeed=42)
+  _testFF = ChemicalForceFields.UFFGetMoleculeForceField(_testMol)
+  haveWorkingForceField = _testFF is not None
+except Exception:
+  haveWorkingForceField = False
+
+# Detect if rdMolAlign.AlignMol is fully functional in the current binding
+try:
+  _testRef = Chem.MolFromSmiles('CCC')
+  AllChem.EmbedMolecule(_testRef, randomSeed=42)
+  _testProbe = Chem.MolFromSmiles('CCC')
+  AllChem.EmbedMolecule(_testProbe, randomSeed=43)
+  rdMolAlign.AlignMol(_testProbe, _testRef)
+  haveWorkingMolAlign = True
+except Exception:
+  haveWorkingMolAlign = False
+
 
 def feq(v1, v2, tol=1.e-4):
   return abs(v1 - v2) < tol
@@ -168,6 +188,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(bm[1, 0] < 1.510)
     self.assertTrue(bm[0, 1] > 1.510)
 
+  @unittest.skipIf(not haveWorkingForceField, "UFF ForceField not fully available in nanobind yet")
   def test3MultiConf(self):
     mol = Chem.MolFromSmiles("CC(C)(C)c(cc12)n[n]2C(=O)/C=C(N1)/COC")
     cids = rdDistGeom.EmbedMultipleConfs(mol, 10, maxAttempts=30, randomSeed=100,
@@ -237,6 +258,7 @@ class TestCase(unittest.TestCase):
     # print(nconfs)
     self.assertTrue(max(d) <= 1)
 
+  @unittest.skipIf(not haveWorkingForceField, "UFF ForceField not fully available in nanobind yet")
   def test6Chirality(self):
     # turn on chirality and we should get chiral volume that is pretty consistent and
     # positive
@@ -359,6 +381,7 @@ class TestCase(unittest.TestCase):
       self.assertTrue(abs(abs(vol1) - expectedV1) < 1.0)
       self.assertTrue(abs(abs(vol2) - expectedV2) < 1.0)
 
+  @unittest.skipIf(not haveWorkingMolAlign, "rdMolAlign.AlignMol not fully available in nanobind yet")
   def test7ConstrainedEmbedding(self):
     ofile = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'DistGeomHelpers', 'test_data',
                          'constrain1.sdf')
@@ -375,6 +398,7 @@ class TestCase(unittest.TestCase):
     ssd = rdMolAlign.AlignMol(probe, ref, atomMap=algMap)
     self.assertTrue(ssd < 0.1)
 
+  @unittest.skipIf(not haveWorkingForceField, "UFF ForceField not fully available in nanobind yet")
   def test8MultiThreadMultiConf(self):
     if (rdBase.rdkitBuild.split('|')[2] != "MINGW"):
       ENERGY_TOLERANCE = 1.0e-6
@@ -684,8 +708,8 @@ class TestCase(unittest.TestCase):
     mol = Chem.AddHs(mol)
     AllChem.EmbedMolecule(mol, params)
     cnts = params.GetFailureCounts()
-    self.assertGreater(cnts[AllChem.EmbedFailureCauses.INITIAL_COORDS], 5)
-    self.assertGreater(cnts[AllChem.EmbedFailureCauses.ETK_MINIMIZATION], 10)
+    self.assertGreater(cnts[AllChem.EmbedFailureCauses.INITIAL_COORDS.value], 5)
+    self.assertGreater(cnts[AllChem.EmbedFailureCauses.ETK_MINIMIZATION.value], 10)
 
   def testCoordMap(self):
     mol = Chem.AddHs(Chem.MolFromSmiles("OCCC"))

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -7,31 +7,46 @@ import numpy
 
 import rdkit.DistanceGeometry as DG
 from rdkit import Chem, RDConfig, rdBase
-from rdkit.Chem import AllChem, ChemicalForceFields, rdDistGeom, rdMolAlign
+from rdkit.Chem import rdDistGeom
+try:
+  from rdkit.Chem import ChemicalForceFields
+except ImportError:
+  ChemicalForceFields = None
+
+try:
+  from rdkit.Chem import rdMolAlign
+except ImportError:
+  rdMolAlign = None
 from rdkit.Geometry import ComputeSignedDihedralAngle, Point3D
 from rdkit.Geometry import rdGeometry as geom
 from rdkit.RDLogger import logger
 
 logger = logger()
 
-# Detect if ChemicalForceFields (UFF) is fully functional in the current binding
-try:
-  _testMol = Chem.AddHs(Chem.MolFromSmiles('CC'))
-  AllChem.EmbedMolecule(_testMol, randomSeed=42)
-  _testFF = ChemicalForceFields.UFFGetMoleculeForceField(_testMol)
-  haveWorkingForceField = _testFF is not None
-except Exception:
+if ChemicalForceFields is not None:
+  # Detect if ChemicalForceFields (UFF) is fully functional in the current binding
+  try:
+    _testMol = Chem.AddHs(Chem.MolFromSmiles('CC'))
+    rdDistGeom.EmbedMolecule(_testMol, randomSeed=42)
+    _testFF = ChemicalForceFields.UFFGetMoleculeForceField(_testMol)
+    haveWorkingForceField = _testFF is not None
+  except Exception:
+    haveWorkingForceField = False
+else:
   haveWorkingForceField = False
 
-# Detect if rdMolAlign.AlignMol is fully functional in the current binding
-try:
-  _testRef = Chem.MolFromSmiles('CCC')
-  AllChem.EmbedMolecule(_testRef, randomSeed=42)
-  _testProbe = Chem.MolFromSmiles('CCC')
-  AllChem.EmbedMolecule(_testProbe, randomSeed=43)
-  rdMolAlign.AlignMol(_testProbe, _testRef)
-  haveWorkingMolAlign = True
-except Exception:
+if rdMolAlign is not None:
+  # Detect if rdMolAlign.AlignMol is fully functional in the current binding
+  try:
+    _testRef = Chem.MolFromSmiles('CCC')
+    rdDistGeom.EmbedMolecule(_testRef, randomSeed=42)
+    _testProbe = Chem.MolFromSmiles('CCC')
+    rdDistGeom.EmbedMolecule(_testProbe, randomSeed=43)
+    rdMolAlign.AlignMol(_testProbe, _testRef)
+    haveWorkingMolAlign = True
+  except Exception:
+    haveWorkingMolAlign = False
+else:
   haveWorkingMolAlign = False
 
 
@@ -381,7 +396,8 @@ class TestCase(unittest.TestCase):
       self.assertTrue(abs(abs(vol1) - expectedV1) < 1.0)
       self.assertTrue(abs(abs(vol2) - expectedV2) < 1.0)
 
-  @unittest.skipIf(not haveWorkingMolAlign, "rdMolAlign.AlignMol not fully available in nanobind yet")
+  @unittest.skipIf(not haveWorkingMolAlign,
+                   "rdMolAlign.AlignMol not fully available in nanobind yet")
   def test7ConstrainedEmbedding(self):
     ofile = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'DistGeomHelpers', 'test_data',
                          'constrain1.sdf')
@@ -505,16 +521,16 @@ class TestCase(unittest.TestCase):
   def assertDeterministicWithSeed(self, seed):
     input_mol = Chem.MolFromSmiles('CN(Cc1cnc2nc(N)nc(N)c2n1)c1ccc(C(=O)NC(CCC(=O)O)C(=O)O)cc1')
 
-    params = AllChem.ETKDG()
+    params = rdDistGeom.ETKDG()
     params.pruneRmsThresh = -1.0  # skip internal RMSD pruning
     if seed is not None:
       params.randomSeed = seed
 
     firstMol = Chem.AddHs(input_mol)
-    firstIds = AllChem.EmbedMultipleConfs(firstMol, 11, params)
+    firstIds = rdDistGeom.EmbedMultipleConfs(firstMol, 11, params)
 
     secondMol = Chem.AddHs(input_mol)
-    secondIds = AllChem.EmbedMultipleConfs(secondMol, 11, params)
+    secondIds = rdDistGeom.EmbedMultipleConfs(secondMol, 11, params)
 
     self.assertEqual(list(firstIds), list(secondIds))
     self.assertEqual(firstMol.GetNumConformers(), secondMol.GetNumConformers())
@@ -671,9 +687,9 @@ class TestCase(unittest.TestCase):
     smiles = "C1CCC(=O)NCCCCCC(=O)NC1"
     smiles_mol = Chem.MolFromSmiles(smiles)
     mol = Chem.AddHs(smiles_mol)
-    params = AllChem.ETKDGv3()
+    params = rdDistGeom.ETKDGv3()
     params.randomSeed = 0
-    AllChem.EmbedMolecule(mol, params)
+    rdDistGeom.EmbedMolecule(mol, params)
     conf = mol.GetConformer(0)
     for torsion in get_atom_mapping(mol):
       a1, a2, a3, a4 = [conf.GetAtomPosition(i) for i in torsion]
@@ -700,16 +716,16 @@ class TestCase(unittest.TestCase):
     self.assertEqual(list(ts[0]["atomIndices"]), [0, 1, 2, 3])
 
   def testTrackFailures(self):
-    params = AllChem.ETKDGv3()
+    params = rdDistGeom.ETKDGv3()
     params.trackFailures = True
     params.maxIterations = 50
     params.randomSeed = 42
     mol = Chem.MolFromSmiles('C=CC1=C(N)Oc2cc1c(-c1cc(C(C)O)cc(=O)cc1C1NCC(=O)N1)c(OC)c2OC')
     mol = Chem.AddHs(mol)
-    AllChem.EmbedMolecule(mol, params)
+    rdDistGeom.EmbedMolecule(mol, params)
     cnts = params.GetFailureCounts()
-    self.assertGreater(cnts[AllChem.EmbedFailureCauses.INITIAL_COORDS.value], 5)
-    self.assertGreater(cnts[AllChem.EmbedFailureCauses.ETK_MINIMIZATION.value], 10)
+    self.assertGreater(cnts[rdDistGeom.EmbedFailureCauses.INITIAL_COORDS], 5)
+    self.assertGreater(cnts[rdDistGeom.EmbedFailureCauses.ETK_MINIMIZATION], 10)
 
   def testCoordMap(self):
     mol = Chem.AddHs(Chem.MolFromSmiles("OCCC"))
@@ -765,26 +781,23 @@ class TestCase(unittest.TestCase):
     with self.assertRaises(AttributeError):
       ps.wrongName(1234)
 
-
   def testEmbedParamsToJSON(self):
     ps = rdDistGeom.KDG()
     json = rdDistGeom.EmbedParametersToJSON(ps)
     goal = '{"basinThresh":"5","boundsMatForceScaling":"1","boxSizeMult":"2","clearConfs":"true","embedFragmentsSeparately":"true","enableSequentialRandomSeeds":"false","enforceChirality":"true","ETversion":"1","forceTransAmides":"true","ignoreSmoothingFailures":"false","maxIterations":"0","numThreads":"1","numZeroFail":"1","onlyHeavyAtomsForRMS":"true","optimizerForceTol":"0.001","pruneRmsThresh":"-1","randNegEig":"true","randomSeed":"-1","symmetrizeConjugatedTerminalGroupsForPruning":"true","timeout":"0","trackFailures":"false","useBasicKnowledge":"true","useExpTorsionAnglePrefs":"false","useMacrocycle14config":"false","useMacrocycleTorsions":"false","useRandomCoords":"false","useSmallRingTorsions":"false","useSymmetryForPruning":"true","verbose":"false"}'
-    self.assertEqual(
-      json,
-      goal
-    )
-    p = Point3D(1.1,2.2,3.3)
-    ps.SetCoordMap({3:p})
+    self.assertEqual(json, goal)
+    p = Point3D(1.1, 2.2, 3.3)
+    ps.SetCoordMap({3: p})
     json = rdDistGeom.EmbedParametersToJSON(ps)
     goal = '{"basinThresh":"5","boundsMatForceScaling":"1","boxSizeMult":"2","clearConfs":"true","embedFragmentsSeparately":"true","enableSequentialRandomSeeds":"false","enforceChirality":"true","ETversion":"1","forceTransAmides":"true","ignoreSmoothingFailures":"false","maxIterations":"0","numThreads":"1","numZeroFail":"1","onlyHeavyAtomsForRMS":"true","optimizerForceTol":"0.001","pruneRmsThresh":"-1","randNegEig":"true","randomSeed":"-1","symmetrizeConjugatedTerminalGroupsForPruning":"true","timeout":"0","trackFailures":"false","useBasicKnowledge":"true","useExpTorsionAnglePrefs":"false","useMacrocycle14config":"false","useMacrocycleTorsions":"false","useRandomCoords":"false","useSmallRingTorsions":"false","useSymmetryForPruning":"true","verbose":"false","coordMap":{"3":["1.100000","2.200000","3.300000"]}}'
-    self.assertEqual(json,goal)
+    self.assertEqual(json, goal)
     mol = Chem.AddHs(Chem.MolFromSmiles("O"))
     bm = rdDistGeom.GetMoleculeBoundsMatrix(mol)
     ps.SetBoundsMat(bm)
     goal = '{"basinThresh":"5","boundsMatForceScaling":"1","boxSizeMult":"2","clearConfs":"true","embedFragmentsSeparately":"true","enableSequentialRandomSeeds":"false","enforceChirality":"true","ETversion":"1","forceTransAmides":"true","ignoreSmoothingFailures":"false","maxIterations":"0","numThreads":"1","numZeroFail":"1","onlyHeavyAtomsForRMS":"true","optimizerForceTol":"0.001","pruneRmsThresh":"-1","randNegEig":"true","randomSeed":"-1","symmetrizeConjugatedTerminalGroupsForPruning":"true","timeout":"0","trackFailures":"false","useBasicKnowledge":"true","useExpTorsionAnglePrefs":"false","useMacrocycle14config":"false","useMacrocycleTorsions":"false","useRandomCoords":"false","useSmallRingTorsions":"false","useSymmetryForPruning":"true","verbose":"false","coordMap":{"3":["1.100000","2.200000","3.300000"]},"boundsMatrix":[["0","1.0002542040013616","1.0002542040013616"],["0.98025420400136154","0","1.6573654663221247"],["0.98025420400136154","1.5773654663221246","0"]]}'
     json = rdDistGeom.EmbedParametersToJSON(ps)
-    self.assertEqual(json,goal)
+    self.assertEqual(json, goal)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/DistGeomHelpers/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/nbWrap/CMakeLists.txt
@@ -1,0 +1,10 @@
+remove_definitions(-DRDKIT_DISTGEOMHELPERS_BUILD)
+ADD_DEFINITIONS("-DBOOST_PYTHON_MAX_ARITY=32")
+
+rdkit_python_extension(rdDistGeom rdDistGeom.cpp
+                       DEST Chem
+                       LINK_LIBRARIES
+           LINK_LIBRARIES
+           DistGeomHelpers FileParsers MolTransforms SmilesParse SubstructMatch MolAlign EigenSolvers)
+
+add_pytest(pyDistGeomHelpers ${CMAKE_CURRENT_SOURCE_DIR}/testDistGeom.py)

--- a/Code/GraphMol/DistGeomHelpers/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/nbWrap/CMakeLists.txt
@@ -1,10 +1,8 @@
 remove_definitions(-DRDKIT_DISTGEOMHELPERS_BUILD)
-ADD_DEFINITIONS("-DBOOST_PYTHON_MAX_ARITY=32")
 
-rdkit_python_extension(rdDistGeom rdDistGeom.cpp
-                       DEST Chem
-                       LINK_LIBRARIES
-           LINK_LIBRARIES
-           DistGeomHelpers FileParsers MolTransforms SmilesParse SubstructMatch MolAlign EigenSolvers)
+rdkit_nanobind_extension(rdDistGeom rdDistGeom.cpp
+                         DEST Chem
+                         LINK_LIBRARIES
+                         DistGeomHelpers FileParsers MolTransforms SmilesParse SubstructMatch MolAlign EigenSolvers)
 
-add_pytest(pyDistGeomHelpers ${CMAKE_CURRENT_SOURCE_DIR}/testDistGeom.py)
+add_pytest(pyDistGeomHelpers ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testDistGeom.py)

--- a/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
@@ -1,0 +1,682 @@
+//
+//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/python.h>
+#define PY_ARRAY_UNIQUE_SYMBOL rdDistGeom_array_API
+#include <RDBoost/import_array.h>
+#include "numpy/arrayobject.h"
+#include <DistGeom/BoundsMatrix.h>
+#include <DistGeom/TriangleSmooth.h>
+#include <GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h>
+
+#include <GraphMol/GraphMol.h>
+#include <RDBoost/Wrap.h>
+#include <RDGeneral/ControlCHandler.h>
+
+#include <GraphMol/DistGeomHelpers/BoundsMatrixBuilder.h>
+#include <GraphMol/DistGeomHelpers/Embedder.h>
+
+namespace python = boost::python;
+
+namespace {
+struct PyEmbedParameters
+    : public RDKit::DGeomHelpers::EmbedParameters,
+      public python::wrapper<RDKit::DGeomHelpers::EmbedParameters> {
+ public:
+  PyEmbedParameters() : RDKit::DGeomHelpers::EmbedParameters() {}
+  PyEmbedParameters(const RDKit::DGeomHelpers::EmbedParameters &other)
+      : RDKit::DGeomHelpers::EmbedParameters(other) {}
+  void setCoordMap(const python::dict &cmap) {
+    // the EmbedParameters object doesn't own the memory for the coordMap, so we
+    // have to take ownership here.
+    d_coordMap.reset(new std::map<int, RDGeom::Point3D>());
+    const auto items = cmap.items();
+    for (unsigned int i = 0; i < python::len(items); ++i) {
+      const auto item = items[i];
+      (*d_coordMap)[python::extract<int>(item[0])] =
+          python::extract<RDGeom::Point3D>(item[1]);
+    }
+    coordMap = d_coordMap.get();
+  }
+  python::tuple getFailureCounts() {
+    python::list lst;
+    for (auto failure : failures) {
+      lst.append(failure);
+    }
+    return python::tuple(lst);
+  }
+  void setCPCI(const python::dict &CPCIdict) {
+    // CPCI has the atom pair tuple as key and charge product as value
+    CPCI = std::shared_ptr<
+        std::map<std::pair<unsigned int, unsigned int>, double>>(
+        new std::map<std::pair<unsigned int, unsigned int>, double>);
+
+    python::list ks = CPCIdict.keys();
+    unsigned int nKeys = python::len(ks);
+
+    for (unsigned int i = 0; i < nKeys; ++i) {
+      python::tuple id = python::extract<python::tuple>(ks[i]);
+      unsigned int a = python::extract<unsigned int>(id[0]);
+      unsigned int b = python::extract<unsigned int>(id[1]);
+      (*CPCI)[std::make_pair(a, b)] = python::extract<double>(CPCIdict[id]);
+    }
+  }
+
+  void setBoundsMatrix(const python::object &boundsMatArg) {
+    PyObject *boundsMatObj = boundsMatArg.ptr();
+    if (!PyArray_Check(boundsMatObj)) {
+      throw_value_error("Argument isn't an array");
+    }
+
+    auto *boundsMat = reinterpret_cast<PyArrayObject *>(boundsMatObj);
+    // get the dimensions of the array
+    int nrows = PyArray_DIM(boundsMat, 0);
+    int ncols = PyArray_DIM(boundsMat, 1);
+    if (nrows != ncols) {
+      throw_value_error("The array has to be square");
+    }
+    if (nrows <= 0) {
+      throw_value_error("The array has to have a nonzero size");
+    }
+    if (PyArray_DESCR(boundsMat)->type_num != NPY_DOUBLE) {
+      throw_value_error("Only double arrays are currently supported");
+    }
+
+    unsigned int dSize = nrows * nrows;
+    auto *cData = new double[dSize];
+    auto *inData = reinterpret_cast<double *>(PyArray_DATA(boundsMat));
+    memcpy(static_cast<void *>(cData), static_cast<const void *>(inData),
+           dSize * sizeof(double));
+    DistGeom::BoundsMatrix::DATA_SPTR sdata(cData);
+    this->boundsMat = boost::shared_ptr<const DistGeom::BoundsMatrix>(
+        new DistGeom::BoundsMatrix(nrows, sdata));
+  }
+
+ private:
+  std::unique_ptr<std::map<int, RDGeom::Point3D>> d_coordMap;
+};
+}  // namespace
+
+namespace RDKit {
+int EmbedMolecule(ROMol &mol, unsigned int maxAttempts, int seed,
+                  bool clearConfs, bool useRandomCoords, double boxSizeMult,
+                  bool randNegEig, unsigned int numZeroFail,
+                  python::dict &coordMap, double forceTol,
+                  bool ignoreSmoothingFailures, bool enforceChirality,
+                  bool useExpTorsionAnglePrefs, bool useBasicKnowledge,
+                  bool printExpTorsionAngles, bool useSmallRingTorsions,
+                  bool useMacrocycleTorsions, unsigned int ETversion,
+                  bool useMacrocycle14config) {
+  std::map<int, RDGeom::Point3D> pMap;
+  python::list ks = coordMap.keys();
+  unsigned int nKeys = python::len(ks);
+  for (unsigned int i = 0; i < nKeys; ++i) {
+    unsigned int id = python::extract<unsigned int>(ks[i]);
+    pMap[id] = python::extract<RDGeom::Point3D>(coordMap[id]);
+  }
+  std::map<int, RDGeom::Point3D> *pMapPtr = nullptr;
+  if (nKeys) {
+    pMapPtr = &pMap;
+  }
+
+  bool verbose = printExpTorsionAngles;
+  int numThreads = 1;
+  double pruneRmsThresh = -1.;
+  const double basinThresh = DGeomHelpers::EmbedParameters().basinThresh;
+  bool onlyHeavyAtomsForRMS = false;
+  DGeomHelpers::EmbedParameters params(
+      maxAttempts, numThreads, seed, clearConfs, useRandomCoords, boxSizeMult,
+      randNegEig, numZeroFail, pMapPtr, forceTol, ignoreSmoothingFailures,
+      enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge, verbose,
+      basinThresh, pruneRmsThresh, onlyHeavyAtomsForRMS, ETversion, nullptr,
+      true, useSmallRingTorsions, useMacrocycleTorsions, useMacrocycle14config);
+
+  int res;
+  {
+    NOGIL gil;
+    res = DGeomHelpers::EmbedMolecule(mol, params);
+  }
+  if (ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
+    boost::python::throw_error_already_set();
+  }
+  return res;
+}
+
+int EmbedMolecule2(ROMol &mol, DGeomHelpers::EmbedParameters &params) {
+  int res;
+  {
+    NOGIL gil;
+    res = DGeomHelpers::EmbedMolecule(mol, params);
+  }
+  if (ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
+    boost::python::throw_error_already_set();
+  }
+  return res;
+}
+
+INT_VECT EmbedMultipleConfs(
+    ROMol &mol, unsigned int numConfs, unsigned int maxAttempts, int seed,
+    bool clearConfs, bool useRandomCoords, double boxSizeMult, bool randNegEig,
+    unsigned int numZeroFail, double pruneRmsThresh, python::dict &coordMap,
+    double forceTol, bool ignoreSmoothingFailures, bool enforceChirality,
+    int numThreads, bool useExpTorsionAnglePrefs, bool useBasicKnowledge,
+    bool printExpTorsionAngles, bool useSmallRingTorsions,
+    bool useMacrocycleTorsions, unsigned int ETversion,
+    bool useMacrocycle14config) {
+  std::map<int, RDGeom::Point3D> pMap;
+  python::list ks = coordMap.keys();
+  unsigned int nKeys = python::len(ks);
+  for (unsigned int i = 0; i < nKeys; ++i) {
+    unsigned int id = python::extract<unsigned int>(ks[i]);
+    pMap[id] = python::extract<RDGeom::Point3D>(coordMap[id]);
+  }
+  std::map<int, RDGeom::Point3D> *pMapPtr = nullptr;
+  if (nKeys) {
+    pMapPtr = &pMap;
+  }
+  bool verbose = printExpTorsionAngles;
+  const double basinThresh = DGeomHelpers::EmbedParameters().basinThresh;
+  bool onlyHeavyAtomsForRMS = false;
+  DGeomHelpers::EmbedParameters params(
+      maxAttempts, numThreads, seed, clearConfs, useRandomCoords, boxSizeMult,
+      randNegEig, numZeroFail, pMapPtr, forceTol, ignoreSmoothingFailures,
+      enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge, verbose,
+      basinThresh, pruneRmsThresh, onlyHeavyAtomsForRMS, ETversion, nullptr,
+      true, useSmallRingTorsions, useMacrocycleTorsions, useMacrocycle14config);
+
+  INT_VECT res;
+  {
+    NOGIL gil;
+    DGeomHelpers::EmbedMultipleConfs(mol, res, numConfs, params);
+  }
+
+  if (ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
+    boost::python::throw_error_already_set();
+  }
+
+  return res;
+}
+
+INT_VECT EmbedMultipleConfs2(ROMol &mol, unsigned int numConfs,
+                             DGeomHelpers::EmbedParameters &params) {
+  INT_VECT res;
+  {
+    NOGIL gil;
+    DGeomHelpers::EmbedMultipleConfs(mol, res, numConfs, params);
+  }
+  if (ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
+    boost::python::throw_error_already_set();
+  }
+  return res;
+}
+
+PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
+                             bool scaleVDW = false,
+                             bool doTriangleSmoothing = true,
+                             bool useMacrocycle14config = false) {
+  unsigned int nats = mol.getNumAtoms();
+  npy_intp dims[2];
+  dims[0] = nats;
+  dims[1] = nats;
+
+  DistGeom::BoundsMatPtr mat(new DistGeom::BoundsMatrix(nats));
+  DGeomHelpers::initBoundsMat(mat);
+  DGeomHelpers::setTopolBounds(mol, mat, set15bounds, scaleVDW,
+                               useMacrocycle14config);
+  if (doTriangleSmoothing) {
+    DistGeom::triangleSmoothBounds(mat);
+  }
+  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
+  memcpy(static_cast<void *>(PyArray_DATA(res)),
+         static_cast<void *>(mat->getData()), nats * nats * sizeof(double));
+
+  return PyArray_Return(res);
+}
+PyEmbedParameters *getETKDG() {  // ET version 1
+  return new PyEmbedParameters(DGeomHelpers::ETKDG);
+}
+PyEmbedParameters *getETKDGv2() {  // ET version 2
+  return new PyEmbedParameters(DGeomHelpers::ETKDGv2);
+}
+PyEmbedParameters *
+getETKDGv3() {  //! Parameters corresponding improved ETKDG by Wang, Witek,
+                //! Landrum and Riniker (10.1021/acs.jcim.0c00025) - the
+                //! macrocycle part
+  return new PyEmbedParameters(DGeomHelpers::ETKDGv3);
+}
+PyEmbedParameters *
+getsrETKDGv3() {  //! Parameters corresponding improved ETKDG by Wang, Witek,
+                  //! Landrum and Riniker (10.1021/acs.jcim.0c00025) - the
+                  //! macrocycle part
+  return new PyEmbedParameters(DGeomHelpers::srETKDGv3);
+}
+PyEmbedParameters *getKDG() { return new PyEmbedParameters(DGeomHelpers::KDG); }
+PyEmbedParameters *getETDG() {
+  return new PyEmbedParameters(DGeomHelpers::ETDG);
+}
+PyEmbedParameters *getETDGv2() {
+  return new PyEmbedParameters(DGeomHelpers::ETDGv2);
+}
+
+python::tuple getExpTorsHelper(const RDKit::ROMol &mol, bool useExpTorsions,
+                               bool useSmallRingTorsions,
+                               bool useMacrocycleTorsions,
+                               bool useBasicKnowledge, unsigned int version,
+                               bool verbose) {
+  ForceFields::CrystalFF::CrystalFFDetails details;
+  std::vector<std::tuple<unsigned int, std::vector<unsigned int>,
+                         const ForceFields::CrystalFF::ExpTorsionAngle *>>
+      torsionBonds;
+  ForceFields::CrystalFF::getExperimentalTorsions(
+      mol, details, torsionBonds, useExpTorsions, useSmallRingTorsions,
+      useMacrocycleTorsions, useBasicKnowledge, version, verbose);
+  python::list result;
+  for (const auto &pr : torsionBonds) {
+    python::dict d;
+    d["bondIndex"] = std::get<0>(pr);
+    d["torsionIndex"] = std::get<2>(pr)->torsionIdx;
+    d["smarts"] = std::get<2>(pr)->smarts;
+    d["V"] = std::get<2>(pr)->V;
+    d["signs"] = std::get<2>(pr)->signs;
+    d["atomIndices"] = std::get<1>(pr);
+    result.append(d);
+  }
+  return python::tuple(result);
+}
+
+python::tuple getExpTorsHelperWithParams(
+    const RDKit::ROMol &mol, const DGeomHelpers::EmbedParameters &ps) {
+  return getExpTorsHelper(mol, ps.useExpTorsionAnglePrefs,
+                          ps.useSmallRingTorsions, ps.useMacrocycleTorsions,
+                          ps.useBasicKnowledge, ps.ETversion, ps.verbose);
+}
+
+python::str embedParametersToJSONHelper(
+    const DGeomHelpers::EmbedParameters &ps) {
+  return python::str(embedParametersToJSON(ps));
+}
+
+}  // namespace RDKit
+
+BOOST_PYTHON_MODULE(rdDistGeom) {
+  python::scope().attr("__doc__") =
+      "Module containing functions to compute atomic coordinates in 3D using "
+      "distance geometry";
+
+  rdkit_import_array();
+
+  // RegisterListConverter<RDKit::Atom*>();
+
+  python::def(
+      "GetExperimentalTorsions", RDKit::getExpTorsHelper,
+      (python::arg("mol"), python::arg("useExpTorsionAnglePrefs") = true,
+       python::arg("useSmallRingTorsions") = false,
+       python::arg("useMacrocycleTorsions") = true,
+       python::arg("useBasicKnowledge") = true, python::arg("ETversion") = 2,
+       python::arg("printExpTorsionAngles") = false),
+      "returns information about the bonds corresponding to experimental torsions");
+  python::def(
+      "GetExperimentalTorsions", RDKit::getExpTorsHelperWithParams,
+      (python::arg("mol"), python::arg("embedParams")),
+      "returns information about the bonds corresponding to experimental torsions");
+
+  std::string docString =
+      "Use distance geometry to obtain initial \n\
+ coordinates for a molecule\n\n\
+ \n\
+ ARGUMENTS:\n\n\
+    - mol : the molecule of interest\n\
+    - maxAttempts : maximum number of embedding attempts to use for a single conformation \n\
+    - randomSeed : provide a seed for the random number generator \n\
+                   so that the same coordinates can be obtained \n\
+                   for a molecule on multiple runs. If -1, the \n\
+                   RNG will not be seeded. \n\
+    - clearConfs : clear all existing conformations on the molecule\n\
+    - useRandomCoords : Start the embedding from random coordinates instead of\n\
+                        using eigenvalues of the distance matrix.\n\
+    - boxSizeMult :  Determines the size of the box that is used for\n\
+                     random coordinates. If this is a positive number, the \n\
+                     side length will equal the largest element of the distance\n\
+                     matrix times boxSizeMult. If this is a negative number,\n\
+                     the side length will equal -boxSizeMult (i.e. independent\n\
+                     of the elements of the distance matrix).\n\
+    - randNegEig : If the embedding yields a negative eigenvalue, \n\
+                   pick coordinates that correspond \n\
+                   to this component at random \n\
+    - numZeroFail : fail embedding if we have at least this many zero eigenvalues \n\
+    - coordMap : a dictionary mapping atom IDs->coordinates. Use this to \n\
+                 require some atoms to have fixed coordinates in the resulting \n\
+                 conformation.\n\
+    - forceTol : tolerance to be used during the force-field minimization with \n\
+                 the distance geometry force field.\n\
+    - ignoreSmoothingFailures : try to embed the molecule even if triangle smoothing\n\
+                 of the bounds matrix fails.\n\
+    - enforceChirality : enforce the correct chirality if chiral centers are present.\n\
+    - useExpTorsionAnglePrefs : impose experimental torsion angle preferences\n\
+    - useBasicKnowledge : impose basic knowledge such as flat rings\n\
+    - printExpTorsionAngles : print the output from the experimental torsion angles\n\
+    - useMacrocycleTorsions : use additional torsion profiles for macrocycles\n\
+    - ETversion : version of the standard torsion definitions to use. NOTE for both\n\
+                  ETKDGv2 and ETKDGv3 this should be 2 since ETKDGv3 uses the ETKDGv2\n\
+                  definitions for standard torsions\n\
+    - useMacrocycle14config : use the 1-4 distance bounds from ETKDGv3\n\
+\n\
+ RETURNS:\n\n\
+    ID of the new conformation added to the molecule or -1 if the embedding fails.\n\
+\n";
+  python::def(
+      "EmbedMolecule", RDKit::EmbedMolecule,
+      (python::arg("mol"), python::arg("maxAttempts") = 0,
+       python::arg("randomSeed") = -1, python::arg("clearConfs") = true,
+       python::arg("useRandomCoords") = false, python::arg("boxSizeMult") = 2.0,
+       python::arg("randNegEig") = true, python::arg("numZeroFail") = 1,
+       python::arg("coordMap") = python::dict(), python::arg("forceTol") = 1e-3,
+       python::arg("ignoreSmoothingFailures") = false,
+       python::arg("enforceChirality") = true,
+       python::arg("useExpTorsionAnglePrefs") = true,
+       python::arg("useBasicKnowledge") = true,
+       python::arg("printExpTorsionAngles") = false,
+       python::arg("useSmallRingTorsions") = false,
+       python::arg("useMacrocycleTorsions") = true,
+       python::arg("ETversion") = 2,
+       python::arg("useMacrocycle14config") = true),
+      docString.c_str());
+
+  docString =
+      "Use distance geometry to obtain multiple sets of \n\
+ coordinates for a molecule\n\
+ \n\
+ ARGUMENTS:\n\n\
+  - mol : the molecule of interest\n\
+  - numConfs : the number of conformers to generate \n\
+  - maxAttempts : maximum number of embedding attempts to use for a single conformation \n\
+  - randomSeed : provide a seed for the random number generator \n\
+                 so that the same coordinates can be obtained \n\
+                 for a molecule on multiple runs. If -1, the \n\
+                 RNG will not be seeded. \n\
+  - clearConfs : clear all existing conformations on the molecule\n\
+  - useRandomCoords : Start the embedding from random coordinates instead of\n\
+                      using eigenvalues of the distance matrix.\n\
+  - boxSizeMult    Determines the size of the box that is used for\n\
+                   random coordinates. If this is a positive number, the \n\
+                   side length will equal the largest element of the distance\n\
+                   matrix times boxSizeMult. If this is a negative number,\n\
+                   the side length will equal -boxSizeMult (i.e. independent\n\
+                   of the elements of the distance matrix).\n\
+  - randNegEig : If the embedding yields a negative eigenvalue, \n\
+                 pick coordinates that correspond \n\
+                 to this component at random \n\
+  - numZeroFail : fail embedding if we have at least this many zero eigenvalues \n\
+  - pruneRmsThresh : Retain only the conformations out of 'numConfs' \n\
+                    after embedding that are at least \n\
+                    this far apart from each other. \n\
+                    RMSD is computed on the heavy atoms. \n\
+                    Pruning is greedy; i.e. the first embedded conformation\n\
+                    is retained and from then on only those that are at\n\
+                    least pruneRmsThresh away from all retained conformations\n\
+                    are kept. The pruning is done after embedding and \n\
+                    bounds violation minimization. No pruning by default.\n\
+  - coordMap : a dictionary mapping atom IDs->coordinates. Use this to \n\
+               require some atoms to have fixed coordinates in the resulting \n\
+               conformation.\n\
+  - forceTol : tolerance to be used during the force-field minimization with \n\
+               the distance geometry force field.\n\
+  - ignoreSmoothingFailures : try to embed the molecule even if triangle smoothing\n\
+               of the bounds matrix fails.\n\
+  - enforceChirality : enforce the correct chirality if chiral centers are present.\n\
+  - numThreads : number of threads to use while embedding. This only has an effect if the RDKit\n\
+               was built with multi-thread support.\n\
+              If set to zero, the max supported by the system will be used.\n\
+  - useExpTorsionAnglePrefs : impose experimental torsion angle preferences\n\
+  - useBasicKnowledge : impose basic knowledge such as flat rings\n\
+  - printExpTorsionAngles : print the output from the experimental torsion angles\n\
+ RETURNS:\n\n\
+    Iterator which yields new conformation IDs \n\
+\n";
+  python::def(
+      "EmbedMultipleConfs", RDKit::EmbedMultipleConfs,
+      (python::arg("mol"), python::arg("numConfs") = 10,
+       python::arg("maxAttempts") = 0, python::arg("randomSeed") = -1,
+       python::arg("clearConfs") = true, python::arg("useRandomCoords") = false,
+       python::arg("boxSizeMult") = 2.0, python::arg("randNegEig") = true,
+       python::arg("numZeroFail") = 1, python::arg("pruneRmsThresh") = -1.0,
+       python::arg("coordMap") = python::dict(), python::arg("forceTol") = 1e-3,
+       python::arg("ignoreSmoothingFailures") = false,
+       python::arg("enforceChirality") = true, python::arg("numThreads") = 1,
+       python::arg("useExpTorsionAnglePrefs") = true,
+       python::arg("useBasicKnowledge") = true,
+       python::arg("printExpTorsionAngles") = false,
+       python::arg("useSmallRingTorsions") = false,
+       python::arg("useMacrocycleTorsions") = true,
+       python::arg("ETversion") = 2,
+       python::arg("useMacrocycle14config") = true),
+      docString.c_str());
+
+  python::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>("EmbedFailureCauses")
+      .value("INITIAL_COORDS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS)
+      .value("FIRST_MINIMIZATION",
+             RDKit::DGeomHelpers::EmbedFailureCauses::FIRST_MINIMIZATION)
+      .value("CHECK_TETRAHEDRAL_CENTERS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_TETRAHEDRAL_CENTERS)
+      .value("CHECK_CHIRAL_CENTERS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_CHIRAL_CENTERS)
+      .value("MINIMIZE_FOURTH_DIMENSION",
+             RDKit::DGeomHelpers::EmbedFailureCauses::MINIMIZE_FOURTH_DIMENSION)
+      .value("ETK_MINIMIZATION",
+             RDKit::DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION)
+      .value("FINAL_CHIRAL_BOUNDS",
+             RDKit::DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS)
+      .value("FINAL_CENTER_IN_VOLUME",
+             RDKit::DGeomHelpers::EmbedFailureCauses::FINAL_CENTER_IN_VOLUME)
+      .value("LINEAR_DOUBLE_BOND",
+             RDKit::DGeomHelpers::EmbedFailureCauses::LINEAR_DOUBLE_BOND)
+      .value("BAD_DOUBLE_BOND_STEREO",
+             RDKit::DGeomHelpers::EmbedFailureCauses::BAD_DOUBLE_BOND_STEREO)
+      .value("CHECK_CHIRAL_CENTERS2",
+             RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_CHIRAL_CENTERS2)
+      .value("EXCEEDED_TIMEOUT",
+             RDKit::DGeomHelpers::EmbedFailureCauses::EXCEEDED_TIMEOUT)
+      .export_values();
+
+  python::class_<PyEmbedParameters, boost::noncopyable>(
+      "EmbedParameters", "Parameters controlling embedding")
+      .def_readwrite("maxIterations", &PyEmbedParameters::maxIterations,
+                     "maximum number of embedding attempts to use for a "
+                     "single conformation")
+      .def_readwrite(
+          "numThreads", &PyEmbedParameters::numThreads,
+          "number of threads to use when embedding multiple conformations")
+      .def_readwrite("timeout", &RDKit::DGeomHelpers::EmbedParameters::timeout,
+                     "maximum time in seconds to generate a conformer for a "
+                     "single molecule fragment. If set to 0, no timeout is set")
+      .def_readwrite("randomSeed", &PyEmbedParameters::randomSeed,
+                     "seed for the random number generator")
+      .def_readwrite("clearConfs", &PyEmbedParameters::clearConfs,
+                     "clear all existing conformations on the molecule")
+      .def_readwrite("useRandomCoords", &PyEmbedParameters::useRandomCoords,
+                     "start the embedding from random coordinates instead of "
+                     "using eigenvalues of the distance matrix")
+      .def_readwrite(
+          "boxSizeMult", &PyEmbedParameters::boxSizeMult,
+          "determines the size of the box used for random coordinates")
+      .def_readwrite("randNegEig", &PyEmbedParameters::randNegEig,
+                     "if the embedding yields a negative eigenvalue, pick "
+                     "coordinates that correspond to this component at random")
+      .def_readwrite(
+          "numZeroFail", &PyEmbedParameters::numZeroFail,
+          "fail embedding if we have at least this many zero eigenvalues")
+      .def_readwrite("optimizerForceTol", &PyEmbedParameters::optimizerForceTol,
+                     "the tolerance to be used during the distance-geometry "
+                     "force field minimization")
+      .def_readwrite("basinThresh", &PyEmbedParameters::basinThresh,
+                     "set the basin threshold for the DGeom force field.")
+      .def_readwrite("ignoreSmoothingFailures",
+                     &PyEmbedParameters::ignoreSmoothingFailures,
+                     "try and embed the molecule if if triangle smoothing of "
+                     "the bounds matrix fails")
+      .def_readwrite("enforceChirality", &PyEmbedParameters::enforceChirality,
+                     "enforce correct chirilaty if chiral centers are present")
+      .def_readwrite("useExpTorsionAnglePrefs",
+                     &PyEmbedParameters::useExpTorsionAnglePrefs,
+                     "impose experimental torsion angle preferences")
+      .def_readwrite("useBasicKnowledge", &PyEmbedParameters::useBasicKnowledge,
+                     "impose basic-knowledge constraints such as flat rings")
+      .def_readwrite("ETversion", &PyEmbedParameters::ETversion,
+                     "version of the experimental torsion-angle preferences")
+      .def_readwrite("verbose", &PyEmbedParameters::verbose,
+                     "be verbose about configuration")
+      .def_readwrite("pruneRmsThresh", &PyEmbedParameters::pruneRmsThresh,
+                     "used to filter multiple conformations: keep only "
+                     "conformations that are at least this far apart from each "
+                     "other")
+      .def_readwrite("onlyHeavyAtomsForRMS",
+                     &PyEmbedParameters::onlyHeavyAtomsForRMS,
+                     "Only consider heavy atoms when doing RMS filtering")
+      .def_readwrite(
+          "embedFragmentsSeparately",
+          &PyEmbedParameters::embedFragmentsSeparately,
+          "split the molecule into fragments and embed them separately")
+      .def_readwrite("useSmallRingTorsions",
+                     &PyEmbedParameters::useSmallRingTorsions,
+                     "impose small ring torsion angle preferences")
+      .def_readwrite("useMacrocycleTorsions",
+                     &PyEmbedParameters::useMacrocycleTorsions,
+                     "impose macrocycle torsion angle preferences")
+      .def_readwrite("useMacrocycle14config",
+                     &PyEmbedParameters::useMacrocycle14config,
+                     "use the 1-4 distance bounds from ETKDGv3")
+      .def_readwrite(
+          "boundsMatForceScaling", &PyEmbedParameters::boundsMatForceScaling,
+          "scale the weights of the atom pair distance restraints relative to "
+          "the other types of restraints")
+      .def_readwrite(
+          "useSymmetryForPruning", &PyEmbedParameters::useSymmetryForPruning,
+          "use molecule symmetry when doing the RMSD pruning. Note that this "
+          "option automatically also sets onlyHeavyAtomsForRMS to true.")
+      .def("SetBoundsMat", &PyEmbedParameters::setBoundsMatrix,
+           python::args("self", "boundsMatArg"),
+           "set the distance-bounds matrix to be used (no triangle smoothing "
+           "will be done on this) from a Numpy array")
+      .def("SetCPCI", &PyEmbedParameters::setCPCI,
+           python::args("self", "CPCIdict"),
+           "set the customised pairwise Columb-like interaction to atom pairs."
+           "used during structural minimisation stage")
+      .def_readwrite("forceTransAmides", &PyEmbedParameters::forceTransAmides,
+                     "constrain amide bonds to be trans")
+      .def_readwrite(
+          "trackFailures", &PyEmbedParameters::trackFailures,
+          "keep track of which checks during the embedding process fail")
+      .def("GetFailureCounts", &PyEmbedParameters::getFailureCounts,
+           python::args("self"), "returns the counts of each failure type")
+      .def_readwrite(
+          "enableSequentialRandomSeeds",
+          &PyEmbedParameters::enableSequentialRandomSeeds,
+          "handle random number seeds so that conformer generation can be restarted")
+      .def_readwrite(
+          "symmetrizeConjugatedTerminalGroupsForPruning",
+          &PyEmbedParameters::symmetrizeConjugatedTerminalGroupsForPruning,
+          "symmetrize terminal conjugated groups for RMSD pruning")
+      .def("SetCoordMap", &PyEmbedParameters::setCoordMap, python::args("self"),
+           "sets the coordmap to be used")
+      .def("__setattr__", &safeSetattr);
+
+  docString =
+      "Use distance geometry to obtain multiple sets of \n\
+ coordinates for a molecule\n\
+ \n\
+ ARGUMENTS:\n\n\
+  - mol : the molecule of interest\n\
+  - numConfs : the number of conformers to generate \n\
+  - params : an EmbedParameters object \n\
+ RETURNS:\n\n\
+    Iterator which yields new conformation IDs \n\
+\n";
+  python::def(
+      "EmbedMultipleConfs", RDKit::EmbedMultipleConfs2,
+      (python::arg("mol"), python::arg("numConfs"), python::arg("params")),
+      docString.c_str());
+
+  docString =
+      "Use distance geometry to obtain intial \n\
+ coordinates for a molecule\n\n\
+ \n\
+ ARGUMENTS:\n\n\
+    - mol : the molecule of interest\n\
+    - params : an EmbedParameters object \n\
+\n\
+ RETURNS:\n\n\
+    ID of the new conformation added to the molecule or -1 if the embedding fails. \n\
+\n";
+  python::def("EmbedMolecule", RDKit::EmbedMolecule2,
+              (python::arg("mol"), python::arg("params")), docString.c_str());
+  python::def(
+      "ETKDG", RDKit::getETKDG,
+      "Returns an EmbedParameters object for the ETKDG method - version 1.",
+      python::return_value_policy<python::manage_new_object>());
+  python::def(
+      "ETKDGv2", RDKit::getETKDGv2,
+      "Returns an EmbedParameters object for the ETKDG method - version 2.",
+      python::return_value_policy<python::manage_new_object>());
+  python::def("srETKDGv3", RDKit::getsrETKDGv3,
+              "Returns an EmbedParameters object for the ETKDG method - "
+              "version 3 (small rings).",
+              python::return_value_policy<python::manage_new_object>());
+  python::def("ETKDGv3", RDKit::getETKDGv3,
+              "Returns an EmbedParameters object for the ETKDG method - "
+              "version 3 (macrocycles).",
+              python::return_value_policy<python::manage_new_object>());
+  python::def("ETDG", RDKit::getETDG,
+              "Returns an EmbedParameters object for the ETDG method.",
+              python::return_value_policy<python::manage_new_object>());
+  python::def(
+      "ETDGv2", RDKit::getETDGv2,
+      "Returns an EmbedParameters object for the ETDG method - version 2.",
+      python::return_value_policy<python::manage_new_object>());
+  python::def("KDG", RDKit::getKDG,
+              "Returns an EmbedParameters object for the KDG method.",
+              python::return_value_policy<python::manage_new_object>());
+
+  docString =
+      "Returns the distance bounds matrix for a molecule\n\
+ \n\
+ ARGUMENTS:\n\n\
+    - mol : the molecule of interest\n\
+    - set15bounds : set bounds for 1-5 atom distances based on \n\
+                    topology (otherwise stop at 1-4s)\n\
+    - scaleVDW : scale down the sum of VDW radii when setting the \n\
+                 lower bounds for atoms less than 5 bonds apart \n\
+    - doTriangleSmoothing : run triangle smoothing on the bounds \n\
+                 matrix before returning it \n\
+ RETURNS:\n\n\
+    the bounds matrix as a Numeric array with lower bounds in \n\
+    the lower triangle and upper bounds in the upper triangle\n\
+\n";
+  python::def("GetMoleculeBoundsMatrix", RDKit::getMolBoundsMatrix,
+              (python::arg("mol"), python::arg("set15bounds") = true,
+               python::arg("scaleVDW") = false,
+               python::arg("doTriangleSmoothing") = true,
+               python::arg("useMacrocycle14config") = false),
+              docString.c_str());
+
+  docString =
+      "Returns json string containing embedParameters attributes\n\
+  \n\
+  ARGUMENTS:\n\n\
+    - embedParameters : the Params object you want serialized\n\
+  RETURNS:\n\n\
+    The Params object as json string\n\
+  \n";
+  python::def("EmbedParametersToJSON", RDKit::embedParametersToJSONHelper,
+              (python::arg("embedParameters")), docString.c_str());
+}

--- a/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2004-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,94 +7,75 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/python.h>
-#define PY_ARRAY_UNIQUE_SYMBOL rdDistGeom_array_API
-#include <RDBoost/import_array.h>
-#include "numpy/arrayobject.h"
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <RDBoost/Wrap_nb.h>
+
 #include <DistGeom/BoundsMatrix.h>
 #include <DistGeom/TriangleSmooth.h>
 #include <GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h>
 
 #include <GraphMol/GraphMol.h>
-#include <RDBoost/Wrap.h>
 #include <RDGeneral/ControlCHandler.h>
 
 #include <GraphMol/DistGeomHelpers/BoundsMatrixBuilder.h>
 #include <GraphMol/DistGeomHelpers/Embedder.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace {
-struct PyEmbedParameters
-    : public RDKit::DGeomHelpers::EmbedParameters,
-      public python::wrapper<RDKit::DGeomHelpers::EmbedParameters> {
+struct PyEmbedParameters : public RDKit::DGeomHelpers::EmbedParameters {
  public:
   PyEmbedParameters() : RDKit::DGeomHelpers::EmbedParameters() {}
   PyEmbedParameters(const RDKit::DGeomHelpers::EmbedParameters &other)
       : RDKit::DGeomHelpers::EmbedParameters(other) {}
-  void setCoordMap(const python::dict &cmap) {
-    // the EmbedParameters object doesn't own the memory for the coordMap, so we
-    // have to take ownership here.
+
+  void setCoordMap(const nb::dict &cmap) {
     d_coordMap.reset(new std::map<int, RDGeom::Point3D>());
-    const auto items = cmap.items();
-    for (unsigned int i = 0; i < python::len(items); ++i) {
-      const auto item = items[i];
-      (*d_coordMap)[python::extract<int>(item[0])] =
-          python::extract<RDGeom::Point3D>(item[1]);
+    for (auto item : cmap) {
+      (*d_coordMap)[nb::cast<int>(item.first)] =
+          nb::cast<RDGeom::Point3D>(item.second);
     }
     coordMap = d_coordMap.get();
   }
-  python::tuple getFailureCounts() {
-    python::list lst;
+
+  nb::tuple getFailureCounts() const {
+    nb::list lst;
     for (auto failure : failures) {
       lst.append(failure);
     }
-    return python::tuple(lst);
+    return nb::tuple(lst);
   }
-  void setCPCI(const python::dict &CPCIdict) {
-    // CPCI has the atom pair tuple as key and charge product as value
-    CPCI = std::shared_ptr<
-        std::map<std::pair<unsigned int, unsigned int>, double>>(
-        new std::map<std::pair<unsigned int, unsigned int>, double>);
 
-    python::list ks = CPCIdict.keys();
-    unsigned int nKeys = python::len(ks);
-
-    for (unsigned int i = 0; i < nKeys; ++i) {
-      python::tuple id = python::extract<python::tuple>(ks[i]);
-      unsigned int a = python::extract<unsigned int>(id[0]);
-      unsigned int b = python::extract<unsigned int>(id[1]);
-      (*CPCI)[std::make_pair(a, b)] = python::extract<double>(CPCIdict[id]);
+  void setCPCI(const nb::dict &CPCIdict) {
+    CPCI = std::make_shared<
+        std::map<std::pair<unsigned int, unsigned int>, double>>();
+    for (auto item : CPCIdict) {
+      auto id = nb::cast<nb::tuple>(item.first);
+      unsigned int a = nb::cast<unsigned int>(id[0]);
+      unsigned int b = nb::cast<unsigned int>(id[1]);
+      (*CPCI)[{a, b}] = nb::cast<double>(item.second);
     }
   }
 
-  void setBoundsMatrix(const python::object &boundsMatArg) {
-    PyObject *boundsMatObj = boundsMatArg.ptr();
-    if (!PyArray_Check(boundsMatObj)) {
-      throw_value_error("Argument isn't an array");
+  void setBoundsMatrix(
+      nb::ndarray<nb::numpy, double, nb::ndim<2>, nb::c_contig> bm) {
+    if (bm.shape(0) != bm.shape(1)) {
+      throw nb::value_error("The array has to be square");
     }
-
-    auto *boundsMat = reinterpret_cast<PyArrayObject *>(boundsMatObj);
-    // get the dimensions of the array
-    int nrows = PyArray_DIM(boundsMat, 0);
-    int ncols = PyArray_DIM(boundsMat, 1);
-    if (nrows != ncols) {
-      throw_value_error("The array has to be square");
+    if (bm.shape(0) == 0) {
+      throw nb::value_error("The array has to have a nonzero size");
     }
-    if (nrows <= 0) {
-      throw_value_error("The array has to have a nonzero size");
-    }
-    if (PyArray_DESCR(boundsMat)->type_num != NPY_DOUBLE) {
-      throw_value_error("Only double arrays are currently supported");
-    }
-
+    unsigned int nrows = (unsigned int)bm.shape(0);
     unsigned int dSize = nrows * nrows;
     auto *cData = new double[dSize];
-    auto *inData = reinterpret_cast<double *>(PyArray_DATA(boundsMat));
-    memcpy(static_cast<void *>(cData), static_cast<const void *>(inData),
-           dSize * sizeof(double));
+    memcpy(cData, bm.data(), dSize * sizeof(double));
     DistGeom::BoundsMatrix::DATA_SPTR sdata(cData);
-    this->boundsMat = boost::shared_ptr<const DistGeom::BoundsMatrix>(
+    boundsMat = boost::shared_ptr<const DistGeom::BoundsMatrix>(
         new DistGeom::BoundsMatrix(nrows, sdata));
   }
 
@@ -104,131 +85,109 @@ struct PyEmbedParameters
 }  // namespace
 
 namespace RDKit {
-int EmbedMolecule(ROMol &mol, unsigned int maxAttempts, int seed,
-                  bool clearConfs, bool useRandomCoords, double boxSizeMult,
-                  bool randNegEig, unsigned int numZeroFail,
-                  python::dict &coordMap, double forceTol,
-                  bool ignoreSmoothingFailures, bool enforceChirality,
-                  bool useExpTorsionAnglePrefs, bool useBasicKnowledge,
-                  bool printExpTorsionAngles, bool useSmallRingTorsions,
-                  bool useMacrocycleTorsions, unsigned int ETversion,
-                  bool useMacrocycle14config) {
+
+static int EmbedMolecule(ROMol &mol, unsigned int maxAttempts, int seed,
+                         bool clearConfs, bool useRandomCoords,
+                         double boxSizeMult, bool randNegEig,
+                         unsigned int numZeroFail, nb::dict coordMap,
+                         double forceTol, bool ignoreSmoothingFailures,
+                         bool enforceChirality, bool useExpTorsionAnglePrefs,
+                         bool useBasicKnowledge, bool printExpTorsionAngles,
+                         bool useSmallRingTorsions, bool useMacrocycleTorsions,
+                         unsigned int ETversion, bool useMacrocycle14config) {
   std::map<int, RDGeom::Point3D> pMap;
-  python::list ks = coordMap.keys();
-  unsigned int nKeys = python::len(ks);
-  for (unsigned int i = 0; i < nKeys; ++i) {
-    unsigned int id = python::extract<unsigned int>(ks[i]);
-    pMap[id] = python::extract<RDGeom::Point3D>(coordMap[id]);
+  for (auto item : coordMap) {
+    pMap[nb::cast<int>(item.first)] = nb::cast<RDGeom::Point3D>(item.second);
   }
-  std::map<int, RDGeom::Point3D> *pMapPtr = nullptr;
-  if (nKeys) {
-    pMapPtr = &pMap;
-  }
+  std::map<int, RDGeom::Point3D> *pMapPtr = pMap.empty() ? nullptr : &pMap;
 
-  bool verbose = printExpTorsionAngles;
-  int numThreads = 1;
-  double pruneRmsThresh = -1.;
   const double basinThresh = DGeomHelpers::EmbedParameters().basinThresh;
-  bool onlyHeavyAtomsForRMS = false;
   DGeomHelpers::EmbedParameters params(
-      maxAttempts, numThreads, seed, clearConfs, useRandomCoords, boxSizeMult,
+      maxAttempts, 1, seed, clearConfs, useRandomCoords, boxSizeMult,
       randNegEig, numZeroFail, pMapPtr, forceTol, ignoreSmoothingFailures,
-      enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge, verbose,
-      basinThresh, pruneRmsThresh, onlyHeavyAtomsForRMS, ETversion, nullptr,
-      true, useSmallRingTorsions, useMacrocycleTorsions, useMacrocycle14config);
+      enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge,
+      printExpTorsionAngles, basinThresh, -1., false, ETversion, nullptr, true,
+      useSmallRingTorsions, useMacrocycleTorsions, useMacrocycle14config);
 
   int res;
   {
-    NOGIL gil;
+    nb::gil_scoped_release release;
     res = DGeomHelpers::EmbedMolecule(mol, params);
   }
   if (ControlCHandler::getGotSignal()) {
     PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
-    boost::python::throw_error_already_set();
+    throw nb::python_error();
   }
   return res;
 }
 
-int EmbedMolecule2(ROMol &mol, DGeomHelpers::EmbedParameters &params) {
+static int EmbedMolecule2(ROMol &mol, PyEmbedParameters &params) {
   int res;
   {
-    NOGIL gil;
+    nb::gil_scoped_release release;
     res = DGeomHelpers::EmbedMolecule(mol, params);
   }
   if (ControlCHandler::getGotSignal()) {
     PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
-    boost::python::throw_error_already_set();
+    throw nb::python_error();
   }
   return res;
 }
 
-INT_VECT EmbedMultipleConfs(
+static INT_VECT EmbedMultipleConfs(
     ROMol &mol, unsigned int numConfs, unsigned int maxAttempts, int seed,
     bool clearConfs, bool useRandomCoords, double boxSizeMult, bool randNegEig,
-    unsigned int numZeroFail, double pruneRmsThresh, python::dict &coordMap,
+    unsigned int numZeroFail, double pruneRmsThresh, nb::dict coordMap,
     double forceTol, bool ignoreSmoothingFailures, bool enforceChirality,
     int numThreads, bool useExpTorsionAnglePrefs, bool useBasicKnowledge,
     bool printExpTorsionAngles, bool useSmallRingTorsions,
     bool useMacrocycleTorsions, unsigned int ETversion,
     bool useMacrocycle14config) {
   std::map<int, RDGeom::Point3D> pMap;
-  python::list ks = coordMap.keys();
-  unsigned int nKeys = python::len(ks);
-  for (unsigned int i = 0; i < nKeys; ++i) {
-    unsigned int id = python::extract<unsigned int>(ks[i]);
-    pMap[id] = python::extract<RDGeom::Point3D>(coordMap[id]);
+  for (auto item : coordMap) {
+    pMap[nb::cast<int>(item.first)] = nb::cast<RDGeom::Point3D>(item.second);
   }
-  std::map<int, RDGeom::Point3D> *pMapPtr = nullptr;
-  if (nKeys) {
-    pMapPtr = &pMap;
-  }
-  bool verbose = printExpTorsionAngles;
+  std::map<int, RDGeom::Point3D> *pMapPtr = pMap.empty() ? nullptr : &pMap;
+
   const double basinThresh = DGeomHelpers::EmbedParameters().basinThresh;
-  bool onlyHeavyAtomsForRMS = false;
   DGeomHelpers::EmbedParameters params(
       maxAttempts, numThreads, seed, clearConfs, useRandomCoords, boxSizeMult,
       randNegEig, numZeroFail, pMapPtr, forceTol, ignoreSmoothingFailures,
-      enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge, verbose,
-      basinThresh, pruneRmsThresh, onlyHeavyAtomsForRMS, ETversion, nullptr,
-      true, useSmallRingTorsions, useMacrocycleTorsions, useMacrocycle14config);
+      enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge,
+      printExpTorsionAngles, basinThresh, pruneRmsThresh, false, ETversion,
+      nullptr, true, useSmallRingTorsions, useMacrocycleTorsions,
+      useMacrocycle14config);
 
   INT_VECT res;
   {
-    NOGIL gil;
-    DGeomHelpers::EmbedMultipleConfs(mol, res, numConfs, params);
-  }
-
-  if (ControlCHandler::getGotSignal()) {
-    PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
-    boost::python::throw_error_already_set();
-  }
-
-  return res;
-}
-
-INT_VECT EmbedMultipleConfs2(ROMol &mol, unsigned int numConfs,
-                             DGeomHelpers::EmbedParameters &params) {
-  INT_VECT res;
-  {
-    NOGIL gil;
+    nb::gil_scoped_release release;
     DGeomHelpers::EmbedMultipleConfs(mol, res, numConfs, params);
   }
   if (ControlCHandler::getGotSignal()) {
     PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
-    boost::python::throw_error_already_set();
+    throw nb::python_error();
   }
   return res;
 }
 
-PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
-                             bool scaleVDW = false,
-                             bool doTriangleSmoothing = true,
-                             bool useMacrocycle14config = false) {
+static INT_VECT EmbedMultipleConfs2(ROMol &mol, unsigned int numConfs,
+                                    PyEmbedParameters &params) {
+  INT_VECT res;
+  {
+    nb::gil_scoped_release release;
+    DGeomHelpers::EmbedMultipleConfs(mol, res, numConfs, params);
+  }
+  if (ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Embedding cancelled");
+    throw nb::python_error();
+  }
+  return res;
+}
+
+static nb::ndarray<nb::numpy, double, nb::ndim<2>> getMolBoundsMatrix(
+    const ROMol &mol, bool set15bounds, bool scaleVDW,
+    bool doTriangleSmoothing, bool useMacrocycle14config) {
   unsigned int nats = mol.getNumAtoms();
-  npy_intp dims[2];
-  dims[0] = nats;
-  dims[1] = nats;
-
   DistGeom::BoundsMatPtr mat(new DistGeom::BoundsMatrix(nats));
   DGeomHelpers::initBoundsMat(mat);
   DGeomHelpers::setTopolBounds(mol, mat, set15bounds, scaleVDW,
@@ -236,43 +195,20 @@ PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
   if (doTriangleSmoothing) {
     DistGeom::triangleSmoothBounds(mat);
   }
-  auto *res = (PyArrayObject *)PyArray_SimpleNew(2, dims, NPY_DOUBLE);
-  memcpy(static_cast<void *>(PyArray_DATA(res)),
-         static_cast<void *>(mat->getData()), nats * nats * sizeof(double));
-
-  return PyArray_Return(res);
-}
-PyEmbedParameters *getETKDG() {  // ET version 1
-  return new PyEmbedParameters(DGeomHelpers::ETKDG);
-}
-PyEmbedParameters *getETKDGv2() {  // ET version 2
-  return new PyEmbedParameters(DGeomHelpers::ETKDGv2);
-}
-PyEmbedParameters *
-getETKDGv3() {  //! Parameters corresponding improved ETKDG by Wang, Witek,
-                //! Landrum and Riniker (10.1021/acs.jcim.0c00025) - the
-                //! macrocycle part
-  return new PyEmbedParameters(DGeomHelpers::ETKDGv3);
-}
-PyEmbedParameters *
-getsrETKDGv3() {  //! Parameters corresponding improved ETKDG by Wang, Witek,
-                  //! Landrum and Riniker (10.1021/acs.jcim.0c00025) - the
-                  //! macrocycle part
-  return new PyEmbedParameters(DGeomHelpers::srETKDGv3);
-}
-PyEmbedParameters *getKDG() { return new PyEmbedParameters(DGeomHelpers::KDG); }
-PyEmbedParameters *getETDG() {
-  return new PyEmbedParameters(DGeomHelpers::ETDG);
-}
-PyEmbedParameters *getETDGv2() {
-  return new PyEmbedParameters(DGeomHelpers::ETDGv2);
+  auto *resData = new double[nats * nats];
+  memcpy(resData, mat->getData(), nats * nats * sizeof(double));
+  nb::capsule owner(resData, [](void *f) noexcept {
+    delete[] reinterpret_cast<double *>(f);
+  });
+  return nb::ndarray<nb::numpy, double, nb::ndim<2>>(resData, {nats, nats},
+                                                     owner);
 }
 
-python::tuple getExpTorsHelper(const RDKit::ROMol &mol, bool useExpTorsions,
-                               bool useSmallRingTorsions,
-                               bool useMacrocycleTorsions,
-                               bool useBasicKnowledge, unsigned int version,
-                               bool verbose) {
+static nb::list getExpTorsHelper(const ROMol &mol, bool useExpTorsions,
+                                 bool useSmallRingTorsions,
+                                 bool useMacrocycleTorsions,
+                                 bool useBasicKnowledge, unsigned int version,
+                                 bool verbose) {
   ForceFields::CrystalFF::CrystalFFDetails details;
   std::vector<std::tuple<unsigned int, std::vector<unsigned int>,
                          const ForceFields::CrystalFF::ExpTorsionAngle *>>
@@ -280,9 +216,9 @@ python::tuple getExpTorsHelper(const RDKit::ROMol &mol, bool useExpTorsions,
   ForceFields::CrystalFF::getExperimentalTorsions(
       mol, details, torsionBonds, useExpTorsions, useSmallRingTorsions,
       useMacrocycleTorsions, useBasicKnowledge, version, verbose);
-  python::list result;
+  nb::list result;
   for (const auto &pr : torsionBonds) {
-    python::dict d;
+    nb::dict d;
     d["bondIndex"] = std::get<0>(pr);
     d["torsionIndex"] = std::get<2>(pr)->torsionIdx;
     d["smarts"] = std::get<2>(pr)->smarts;
@@ -291,178 +227,168 @@ python::tuple getExpTorsHelper(const RDKit::ROMol &mol, bool useExpTorsions,
     d["atomIndices"] = std::get<1>(pr);
     result.append(d);
   }
-  return python::tuple(result);
-}
-
-python::tuple getExpTorsHelperWithParams(
-    const RDKit::ROMol &mol, const DGeomHelpers::EmbedParameters &ps) {
-  return getExpTorsHelper(mol, ps.useExpTorsionAnglePrefs,
-                          ps.useSmallRingTorsions, ps.useMacrocycleTorsions,
-                          ps.useBasicKnowledge, ps.ETversion, ps.verbose);
-}
-
-python::str embedParametersToJSONHelper(
-    const DGeomHelpers::EmbedParameters &ps) {
-  return python::str(embedParametersToJSON(ps));
+  return result;
 }
 
 }  // namespace RDKit
 
-BOOST_PYTHON_MODULE(rdDistGeom) {
-  python::scope().attr("__doc__") =
-      "Module containing functions to compute atomic coordinates in 3D using "
-      "distance geometry";
+NB_MODULE(rdDistGeom, m) {
+  m.doc() =
+      R"DOC(Module containing functions to compute atomic coordinates in 3D using
+distance geometry)DOC";
 
-  rdkit_import_array();
-
-  // RegisterListConverter<RDKit::Atom*>();
-
-  python::def(
-      "GetExperimentalTorsions", RDKit::getExpTorsHelper,
-      (python::arg("mol"), python::arg("useExpTorsionAnglePrefs") = true,
-       python::arg("useSmallRingTorsions") = false,
-       python::arg("useMacrocycleTorsions") = true,
-       python::arg("useBasicKnowledge") = true, python::arg("ETversion") = 2,
-       python::arg("printExpTorsionAngles") = false),
+  m.def(
+      "GetExperimentalTorsions",
+      [](const RDKit::ROMol &mol, bool useExpTorsionAnglePrefs,
+         bool useSmallRingTorsions, bool useMacrocycleTorsions,
+         bool useBasicKnowledge, unsigned int ETversion,
+         bool printExpTorsionAngles) {
+        return RDKit::getExpTorsHelper(mol, useExpTorsionAnglePrefs,
+                                      useSmallRingTorsions,
+                                      useMacrocycleTorsions, useBasicKnowledge,
+                                      ETversion, printExpTorsionAngles);
+      },
+      "mol"_a, "useExpTorsionAnglePrefs"_a = true,
+      "useSmallRingTorsions"_a = false, "useMacrocycleTorsions"_a = true,
+      "useBasicKnowledge"_a = true, "ETversion"_a = 2,
+      "printExpTorsionAngles"_a = false,
       "returns information about the bonds corresponding to experimental torsions");
-  python::def(
-      "GetExperimentalTorsions", RDKit::getExpTorsHelperWithParams,
-      (python::arg("mol"), python::arg("embedParams")),
+
+  m.def(
+      "GetExperimentalTorsions",
+      [](const RDKit::ROMol &mol, const PyEmbedParameters &ps) {
+        return RDKit::getExpTorsHelper(
+            mol, ps.useExpTorsionAnglePrefs, ps.useSmallRingTorsions,
+            ps.useMacrocycleTorsions, ps.useBasicKnowledge, ps.ETversion,
+            ps.verbose);
+      },
+      "mol"_a, "embedParams"_a,
       "returns information about the bonds corresponding to experimental torsions");
 
-  std::string docString =
-      "Use distance geometry to obtain initial \n\
- coordinates for a molecule\n\n\
- \n\
- ARGUMENTS:\n\n\
-    - mol : the molecule of interest\n\
-    - maxAttempts : maximum number of embedding attempts to use for a single conformation \n\
-    - randomSeed : provide a seed for the random number generator \n\
-                   so that the same coordinates can be obtained \n\
-                   for a molecule on multiple runs. If -1, the \n\
-                   RNG will not be seeded. \n\
-    - clearConfs : clear all existing conformations on the molecule\n\
-    - useRandomCoords : Start the embedding from random coordinates instead of\n\
-                        using eigenvalues of the distance matrix.\n\
-    - boxSizeMult :  Determines the size of the box that is used for\n\
-                     random coordinates. If this is a positive number, the \n\
-                     side length will equal the largest element of the distance\n\
-                     matrix times boxSizeMult. If this is a negative number,\n\
-                     the side length will equal -boxSizeMult (i.e. independent\n\
-                     of the elements of the distance matrix).\n\
-    - randNegEig : If the embedding yields a negative eigenvalue, \n\
-                   pick coordinates that correspond \n\
-                   to this component at random \n\
-    - numZeroFail : fail embedding if we have at least this many zero eigenvalues \n\
-    - coordMap : a dictionary mapping atom IDs->coordinates. Use this to \n\
-                 require some atoms to have fixed coordinates in the resulting \n\
-                 conformation.\n\
-    - forceTol : tolerance to be used during the force-field minimization with \n\
-                 the distance geometry force field.\n\
-    - ignoreSmoothingFailures : try to embed the molecule even if triangle smoothing\n\
-                 of the bounds matrix fails.\n\
-    - enforceChirality : enforce the correct chirality if chiral centers are present.\n\
-    - useExpTorsionAnglePrefs : impose experimental torsion angle preferences\n\
-    - useBasicKnowledge : impose basic knowledge such as flat rings\n\
-    - printExpTorsionAngles : print the output from the experimental torsion angles\n\
-    - useMacrocycleTorsions : use additional torsion profiles for macrocycles\n\
-    - ETversion : version of the standard torsion definitions to use. NOTE for both\n\
-                  ETKDGv2 and ETKDGv3 this should be 2 since ETKDGv3 uses the ETKDGv2\n\
-                  definitions for standard torsions\n\
-    - useMacrocycle14config : use the 1-4 distance bounds from ETKDGv3\n\
-\n\
- RETURNS:\n\n\
-    ID of the new conformation added to the molecule or -1 if the embedding fails.\n\
-\n";
-  python::def(
-      "EmbedMolecule", RDKit::EmbedMolecule,
-      (python::arg("mol"), python::arg("maxAttempts") = 0,
-       python::arg("randomSeed") = -1, python::arg("clearConfs") = true,
-       python::arg("useRandomCoords") = false, python::arg("boxSizeMult") = 2.0,
-       python::arg("randNegEig") = true, python::arg("numZeroFail") = 1,
-       python::arg("coordMap") = python::dict(), python::arg("forceTol") = 1e-3,
-       python::arg("ignoreSmoothingFailures") = false,
-       python::arg("enforceChirality") = true,
-       python::arg("useExpTorsionAnglePrefs") = true,
-       python::arg("useBasicKnowledge") = true,
-       python::arg("printExpTorsionAngles") = false,
-       python::arg("useSmallRingTorsions") = false,
-       python::arg("useMacrocycleTorsions") = true,
-       python::arg("ETversion") = 2,
-       python::arg("useMacrocycle14config") = true),
-      docString.c_str());
+  m.def(
+      "EmbedMolecule", &RDKit::EmbedMolecule,
+      "mol"_a, "maxAttempts"_a = 0, "randomSeed"_a = -1,
+      "clearConfs"_a = true, "useRandomCoords"_a = false,
+      "boxSizeMult"_a = 2.0, "randNegEig"_a = true, "numZeroFail"_a = 1,
+      "coordMap"_a = nb::dict(), "forceTol"_a = 1e-3,
+      "ignoreSmoothingFailures"_a = false, "enforceChirality"_a = true,
+      "useExpTorsionAnglePrefs"_a = true, "useBasicKnowledge"_a = true,
+      "printExpTorsionAngles"_a = false, "useSmallRingTorsions"_a = false,
+      "useMacrocycleTorsions"_a = true, "ETversion"_a = 2,
+      "useMacrocycle14config"_a = true,
+      R"DOC(Use distance geometry to obtain initial
+coordinates for a molecule
 
-  docString =
-      "Use distance geometry to obtain multiple sets of \n\
- coordinates for a molecule\n\
- \n\
- ARGUMENTS:\n\n\
-  - mol : the molecule of interest\n\
-  - numConfs : the number of conformers to generate \n\
-  - maxAttempts : maximum number of embedding attempts to use for a single conformation \n\
-  - randomSeed : provide a seed for the random number generator \n\
-                 so that the same coordinates can be obtained \n\
-                 for a molecule on multiple runs. If -1, the \n\
-                 RNG will not be seeded. \n\
-  - clearConfs : clear all existing conformations on the molecule\n\
-  - useRandomCoords : Start the embedding from random coordinates instead of\n\
-                      using eigenvalues of the distance matrix.\n\
-  - boxSizeMult    Determines the size of the box that is used for\n\
-                   random coordinates. If this is a positive number, the \n\
-                   side length will equal the largest element of the distance\n\
-                   matrix times boxSizeMult. If this is a negative number,\n\
-                   the side length will equal -boxSizeMult (i.e. independent\n\
-                   of the elements of the distance matrix).\n\
-  - randNegEig : If the embedding yields a negative eigenvalue, \n\
-                 pick coordinates that correspond \n\
-                 to this component at random \n\
-  - numZeroFail : fail embedding if we have at least this many zero eigenvalues \n\
-  - pruneRmsThresh : Retain only the conformations out of 'numConfs' \n\
-                    after embedding that are at least \n\
-                    this far apart from each other. \n\
-                    RMSD is computed on the heavy atoms. \n\
-                    Pruning is greedy; i.e. the first embedded conformation\n\
-                    is retained and from then on only those that are at\n\
-                    least pruneRmsThresh away from all retained conformations\n\
-                    are kept. The pruning is done after embedding and \n\
-                    bounds violation minimization. No pruning by default.\n\
-  - coordMap : a dictionary mapping atom IDs->coordinates. Use this to \n\
-               require some atoms to have fixed coordinates in the resulting \n\
-               conformation.\n\
-  - forceTol : tolerance to be used during the force-field minimization with \n\
-               the distance geometry force field.\n\
-  - ignoreSmoothingFailures : try to embed the molecule even if triangle smoothing\n\
-               of the bounds matrix fails.\n\
-  - enforceChirality : enforce the correct chirality if chiral centers are present.\n\
-  - numThreads : number of threads to use while embedding. This only has an effect if the RDKit\n\
-               was built with multi-thread support.\n\
-              If set to zero, the max supported by the system will be used.\n\
-  - useExpTorsionAnglePrefs : impose experimental torsion angle preferences\n\
-  - useBasicKnowledge : impose basic knowledge such as flat rings\n\
-  - printExpTorsionAngles : print the output from the experimental torsion angles\n\
- RETURNS:\n\n\
-    Iterator which yields new conformation IDs \n\
-\n";
-  python::def(
-      "EmbedMultipleConfs", RDKit::EmbedMultipleConfs,
-      (python::arg("mol"), python::arg("numConfs") = 10,
-       python::arg("maxAttempts") = 0, python::arg("randomSeed") = -1,
-       python::arg("clearConfs") = true, python::arg("useRandomCoords") = false,
-       python::arg("boxSizeMult") = 2.0, python::arg("randNegEig") = true,
-       python::arg("numZeroFail") = 1, python::arg("pruneRmsThresh") = -1.0,
-       python::arg("coordMap") = python::dict(), python::arg("forceTol") = 1e-3,
-       python::arg("ignoreSmoothingFailures") = false,
-       python::arg("enforceChirality") = true, python::arg("numThreads") = 1,
-       python::arg("useExpTorsionAnglePrefs") = true,
-       python::arg("useBasicKnowledge") = true,
-       python::arg("printExpTorsionAngles") = false,
-       python::arg("useSmallRingTorsions") = false,
-       python::arg("useMacrocycleTorsions") = true,
-       python::arg("ETversion") = 2,
-       python::arg("useMacrocycle14config") = true),
-      docString.c_str());
+ARGUMENTS:
 
-  python::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>("EmbedFailureCauses")
+   - mol : the molecule of interest
+   - maxAttempts : maximum number of embedding attempts to use for a single conformation
+   - randomSeed : provide a seed for the random number generator
+                  so that the same coordinates can be obtained
+                  for a molecule on multiple runs. If -1, the
+                  RNG will not be seeded.
+   - clearConfs : clear all existing conformations on the molecule
+   - useRandomCoords : Start the embedding from random coordinates instead of
+                       using eigenvalues of the distance matrix.
+   - boxSizeMult :  Determines the size of the box that is used for
+                    random coordinates. If this is a positive number, the
+                    side length will equal the largest element of the distance
+                    matrix times boxSizeMult. If this is a negative number,
+                    the side length will equal -boxSizeMult (i.e. independent
+                    of the elements of the distance matrix).
+   - randNegEig : If the embedding yields a negative eigenvalue,
+                  pick coordinates that correspond
+                  to this component at random
+   - numZeroFail : fail embedding if we have at least this many zero eigenvalues
+   - coordMap : a dictionary mapping atom IDs->coordinates. Use this to
+                require some atoms to have fixed coordinates in the resulting
+                conformation.
+   - forceTol : tolerance to be used during the force-field minimization with
+                the distance geometry force field.
+   - ignoreSmoothingFailures : try to embed the molecule even if triangle smoothing
+                of the bounds matrix fails.
+   - enforceChirality : enforce the correct chirality if chiral centers are present.
+   - useExpTorsionAnglePrefs : impose experimental torsion angle preferences
+   - useBasicKnowledge : impose basic knowledge such as flat rings
+   - printExpTorsionAngles : print the output from the experimental torsion angles
+   - useMacrocycleTorsions : use additional torsion profiles for macrocycles
+   - ETversion : version of the standard torsion definitions to use. NOTE for both
+                 ETKDGv2 and ETKDGv3 this should be 2 since ETKDGv3 uses the ETKDGv2
+                 definitions for standard torsions
+   - useMacrocycle14config : use the 1-4 distance bounds from ETKDGv3
+
+RETURNS:
+
+   ID of the new conformation added to the molecule or -1 if the embedding fails.
+)DOC");
+
+  m.def(
+      "EmbedMultipleConfs", &RDKit::EmbedMultipleConfs,
+      "mol"_a, "numConfs"_a = 10, "maxAttempts"_a = 0, "randomSeed"_a = -1,
+      "clearConfs"_a = true, "useRandomCoords"_a = false,
+      "boxSizeMult"_a = 2.0, "randNegEig"_a = true, "numZeroFail"_a = 1,
+      "pruneRmsThresh"_a = -1.0, "coordMap"_a = nb::dict(),
+      "forceTol"_a = 1e-3, "ignoreSmoothingFailures"_a = false,
+      "enforceChirality"_a = true, "numThreads"_a = 1,
+      "useExpTorsionAnglePrefs"_a = true, "useBasicKnowledge"_a = true,
+      "printExpTorsionAngles"_a = false, "useSmallRingTorsions"_a = false,
+      "useMacrocycleTorsions"_a = true, "ETversion"_a = 2,
+      "useMacrocycle14config"_a = true,
+      R"DOC(Use distance geometry to obtain multiple sets of
+coordinates for a molecule
+
+ARGUMENTS:
+
+  - mol : the molecule of interest
+  - numConfs : the number of conformers to generate
+  - maxAttempts : maximum number of embedding attempts to use for a single conformation
+  - randomSeed : provide a seed for the random number generator
+                 so that the same coordinates can be obtained
+                 for a molecule on multiple runs. If -1, the
+                 RNG will not be seeded.
+  - clearConfs : clear all existing conformations on the molecule
+  - useRandomCoords : Start the embedding from random coordinates instead of
+                      using eigenvalues of the distance matrix.
+  - boxSizeMult    Determines the size of the box that is used for
+                   random coordinates. If this is a positive number, the
+                   side length will equal the largest element of the distance
+                   matrix times boxSizeMult. If this is a negative number,
+                   the side length will equal -boxSizeMult (i.e. independent
+                   of the elements of the distance matrix).
+  - randNegEig : If the embedding yields a negative eigenvalue,
+                 pick coordinates that correspond
+                 to this component at random
+  - numZeroFail : fail embedding if we have at least this many zero eigenvalues
+  - pruneRmsThresh : Retain only the conformations out of 'numConfs'
+                    after embedding that are at least
+                    this far apart from each other.
+                    RMSD is computed on the heavy atoms.
+                    Pruning is greedy; i.e. the first embedded conformation
+                    is retained and from then on only those that are at
+                    least pruneRmsThresh away from all retained conformations
+                    are kept. The pruning is done after embedding and
+                    bounds violation minimization. No pruning by default.
+  - coordMap : a dictionary mapping atom IDs->coordinates. Use this to
+               require some atoms to have fixed coordinates in the resulting
+               conformation.
+  - forceTol : tolerance to be used during the force-field minimization with
+               the distance geometry force field.
+  - ignoreSmoothingFailures : try to embed the molecule even if triangle smoothing
+               of the bounds matrix fails.
+  - enforceChirality : enforce the correct chirality if chiral centers are present.
+  - numThreads : number of threads to use while embedding. This only has an effect if the RDKit
+               was built with multi-thread support.
+              If set to zero, the max supported by the system will be used.
+  - useExpTorsionAnglePrefs : impose experimental torsion angle preferences
+  - useBasicKnowledge : impose basic knowledge such as flat rings
+  - printExpTorsionAngles : print the output from the experimental torsion angles
+
+RETURNS:
+
+   Iterator which yields new conformation IDs
+)DOC");
+
+  nb::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>(m, "EmbedFailureCauses")
       .value("INITIAL_COORDS",
              RDKit::DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS)
       .value("FIRST_MINIMIZATION",
@@ -471,8 +397,9 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
              RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_TETRAHEDRAL_CENTERS)
       .value("CHECK_CHIRAL_CENTERS",
              RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_CHIRAL_CENTERS)
-      .value("MINIMIZE_FOURTH_DIMENSION",
-             RDKit::DGeomHelpers::EmbedFailureCauses::MINIMIZE_FOURTH_DIMENSION)
+      .value(
+          "MINIMIZE_FOURTH_DIMENSION",
+          RDKit::DGeomHelpers::EmbedFailureCauses::MINIMIZE_FOURTH_DIMENSION)
       .value("ETK_MINIMIZATION",
              RDKit::DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION)
       .value("FINAL_CHIRAL_BOUNDS",
@@ -489,194 +416,193 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
              RDKit::DGeomHelpers::EmbedFailureCauses::EXCEEDED_TIMEOUT)
       .export_values();
 
-  python::class_<PyEmbedParameters, boost::noncopyable>(
-      "EmbedParameters", "Parameters controlling embedding")
-      .def_readwrite("maxIterations", &PyEmbedParameters::maxIterations,
-                     "maximum number of embedding attempts to use for a "
-                     "single conformation")
-      .def_readwrite(
+  nb::class_<PyEmbedParameters>(m, "EmbedParameters",
+                                "Parameters controlling embedding")
+      .def(nb::init<>())
+      .def_rw("maxIterations", &PyEmbedParameters::maxIterations,
+              R"DOC(maximum number of embedding attempts to use for a
+single conformation)DOC")
+      .def_rw(
           "numThreads", &PyEmbedParameters::numThreads,
           "number of threads to use when embedding multiple conformations")
-      .def_readwrite("timeout", &RDKit::DGeomHelpers::EmbedParameters::timeout,
-                     "maximum time in seconds to generate a conformer for a "
-                     "single molecule fragment. If set to 0, no timeout is set")
-      .def_readwrite("randomSeed", &PyEmbedParameters::randomSeed,
-                     "seed for the random number generator")
-      .def_readwrite("clearConfs", &PyEmbedParameters::clearConfs,
-                     "clear all existing conformations on the molecule")
-      .def_readwrite("useRandomCoords", &PyEmbedParameters::useRandomCoords,
-                     "start the embedding from random coordinates instead of "
-                     "using eigenvalues of the distance matrix")
-      .def_readwrite(
-          "boxSizeMult", &PyEmbedParameters::boxSizeMult,
-          "determines the size of the box used for random coordinates")
-      .def_readwrite("randNegEig", &PyEmbedParameters::randNegEig,
-                     "if the embedding yields a negative eigenvalue, pick "
-                     "coordinates that correspond to this component at random")
-      .def_readwrite(
+      .def_rw("timeout", &PyEmbedParameters::timeout,
+              R"DOC(maximum time in seconds to generate a conformer for a
+single molecule fragment. If set to 0, no timeout is set)DOC")
+      .def_rw("randomSeed", &PyEmbedParameters::randomSeed,
+              "seed for the random number generator")
+      .def_rw("clearConfs", &PyEmbedParameters::clearConfs,
+              "clear all existing conformations on the molecule")
+      .def_rw("useRandomCoords", &PyEmbedParameters::useRandomCoords,
+              R"DOC(start the embedding from random coordinates instead of
+using eigenvalues of the distance matrix)DOC")
+      .def_rw("boxSizeMult", &PyEmbedParameters::boxSizeMult,
+              "determines the size of the box used for random coordinates")
+      .def_rw("randNegEig", &PyEmbedParameters::randNegEig,
+              R"DOC(if the embedding yields a negative eigenvalue, pick
+coordinates that correspond to this component at random)DOC")
+      .def_rw(
           "numZeroFail", &PyEmbedParameters::numZeroFail,
           "fail embedding if we have at least this many zero eigenvalues")
-      .def_readwrite("optimizerForceTol", &PyEmbedParameters::optimizerForceTol,
-                     "the tolerance to be used during the distance-geometry "
-                     "force field minimization")
-      .def_readwrite("basinThresh", &PyEmbedParameters::basinThresh,
-                     "set the basin threshold for the DGeom force field.")
-      .def_readwrite("ignoreSmoothingFailures",
-                     &PyEmbedParameters::ignoreSmoothingFailures,
-                     "try and embed the molecule if if triangle smoothing of "
-                     "the bounds matrix fails")
-      .def_readwrite("enforceChirality", &PyEmbedParameters::enforceChirality,
-                     "enforce correct chirilaty if chiral centers are present")
-      .def_readwrite("useExpTorsionAnglePrefs",
-                     &PyEmbedParameters::useExpTorsionAnglePrefs,
-                     "impose experimental torsion angle preferences")
-      .def_readwrite("useBasicKnowledge", &PyEmbedParameters::useBasicKnowledge,
-                     "impose basic-knowledge constraints such as flat rings")
-      .def_readwrite("ETversion", &PyEmbedParameters::ETversion,
-                     "version of the experimental torsion-angle preferences")
-      .def_readwrite("verbose", &PyEmbedParameters::verbose,
-                     "be verbose about configuration")
-      .def_readwrite("pruneRmsThresh", &PyEmbedParameters::pruneRmsThresh,
-                     "used to filter multiple conformations: keep only "
-                     "conformations that are at least this far apart from each "
-                     "other")
-      .def_readwrite("onlyHeavyAtomsForRMS",
-                     &PyEmbedParameters::onlyHeavyAtomsForRMS,
-                     "Only consider heavy atoms when doing RMS filtering")
-      .def_readwrite(
+      .def_rw("optimizerForceTol", &PyEmbedParameters::optimizerForceTol,
+              R"DOC(the tolerance to be used during the distance-geometry
+force field minimization)DOC")
+      .def_rw("basinThresh", &PyEmbedParameters::basinThresh,
+              "set the basin threshold for the DGeom force field.")
+      .def_rw("ignoreSmoothingFailures",
+              &PyEmbedParameters::ignoreSmoothingFailures,
+              R"DOC(try and embed the molecule if if triangle smoothing of
+the bounds matrix fails)DOC")
+      .def_rw("enforceChirality", &PyEmbedParameters::enforceChirality,
+              "enforce correct chirilaty if chiral centers are present")
+      .def_rw("useExpTorsionAnglePrefs",
+              &PyEmbedParameters::useExpTorsionAnglePrefs,
+              "impose experimental torsion angle preferences")
+      .def_rw("useBasicKnowledge", &PyEmbedParameters::useBasicKnowledge,
+              "impose basic-knowledge constraints such as flat rings")
+      .def_rw("ETversion", &PyEmbedParameters::ETversion,
+              "version of the experimental torsion-angle preferences")
+      .def_rw("verbose", &PyEmbedParameters::verbose,
+              "be verbose about configuration")
+      .def_rw("pruneRmsThresh", &PyEmbedParameters::pruneRmsThresh,
+              R"DOC(used to filter multiple conformations: keep only
+conformations that are at least this far apart from each other)DOC")
+      .def_rw("onlyHeavyAtomsForRMS", &PyEmbedParameters::onlyHeavyAtomsForRMS,
+              "Only consider heavy atoms when doing RMS filtering")
+      .def_rw(
           "embedFragmentsSeparately",
           &PyEmbedParameters::embedFragmentsSeparately,
           "split the molecule into fragments and embed them separately")
-      .def_readwrite("useSmallRingTorsions",
-                     &PyEmbedParameters::useSmallRingTorsions,
-                     "impose small ring torsion angle preferences")
-      .def_readwrite("useMacrocycleTorsions",
-                     &PyEmbedParameters::useMacrocycleTorsions,
-                     "impose macrocycle torsion angle preferences")
-      .def_readwrite("useMacrocycle14config",
-                     &PyEmbedParameters::useMacrocycle14config,
-                     "use the 1-4 distance bounds from ETKDGv3")
-      .def_readwrite(
+      .def_rw("useSmallRingTorsions", &PyEmbedParameters::useSmallRingTorsions,
+              "impose small ring torsion angle preferences")
+      .def_rw("useMacrocycleTorsions",
+              &PyEmbedParameters::useMacrocycleTorsions,
+              "impose macrocycle torsion angle preferences")
+      .def_rw("useMacrocycle14config",
+              &PyEmbedParameters::useMacrocycle14config,
+              "use the 1-4 distance bounds from ETKDGv3")
+      .def_rw(
           "boundsMatForceScaling", &PyEmbedParameters::boundsMatForceScaling,
-          "scale the weights of the atom pair distance restraints relative to "
-          "the other types of restraints")
-      .def_readwrite(
+          R"DOC(scale the weights of the atom pair distance restraints relative to
+the other types of restraints)DOC")
+      .def_rw(
           "useSymmetryForPruning", &PyEmbedParameters::useSymmetryForPruning,
-          "use molecule symmetry when doing the RMSD pruning. Note that this "
-          "option automatically also sets onlyHeavyAtomsForRMS to true.")
+          R"DOC(use molecule symmetry when doing the RMSD pruning. Note that this
+option automatically also sets onlyHeavyAtomsForRMS to true.)DOC")
       .def("SetBoundsMat", &PyEmbedParameters::setBoundsMatrix,
-           python::args("self", "boundsMatArg"),
-           "set the distance-bounds matrix to be used (no triangle smoothing "
-           "will be done on this) from a Numpy array")
-      .def("SetCPCI", &PyEmbedParameters::setCPCI,
-           python::args("self", "CPCIdict"),
-           "set the customised pairwise Columb-like interaction to atom pairs."
-           "used during structural minimisation stage")
-      .def_readwrite("forceTransAmides", &PyEmbedParameters::forceTransAmides,
-                     "constrain amide bonds to be trans")
-      .def_readwrite(
+           "boundsMatArg"_a,
+           R"DOC(set the distance-bounds matrix to be used (no triangle smoothing
+will be done on this) from a Numpy array)DOC")
+      .def("SetCPCI", &PyEmbedParameters::setCPCI, "CPCIdict"_a,
+           R"DOC(set the customised pairwise Columb-like interaction to atom pairs.
+used during structural minimisation stage)DOC")
+      .def_rw("forceTransAmides", &PyEmbedParameters::forceTransAmides,
+              "constrain amide bonds to be trans")
+      .def_rw(
           "trackFailures", &PyEmbedParameters::trackFailures,
           "keep track of which checks during the embedding process fail")
       .def("GetFailureCounts", &PyEmbedParameters::getFailureCounts,
-           python::args("self"), "returns the counts of each failure type")
-      .def_readwrite(
+           "returns the counts of each failure type")
+      .def_rw(
           "enableSequentialRandomSeeds",
           &PyEmbedParameters::enableSequentialRandomSeeds,
           "handle random number seeds so that conformer generation can be restarted")
-      .def_readwrite(
+      .def_rw(
           "symmetrizeConjugatedTerminalGroupsForPruning",
           &PyEmbedParameters::symmetrizeConjugatedTerminalGroupsForPruning,
           "symmetrize terminal conjugated groups for RMSD pruning")
-      .def("SetCoordMap", &PyEmbedParameters::setCoordMap, python::args("self"),
+      .def("SetCoordMap", &PyEmbedParameters::setCoordMap,
            "sets the coordmap to be used")
       .def("__setattr__", &safeSetattr);
 
-  docString =
-      "Use distance geometry to obtain multiple sets of \n\
- coordinates for a molecule\n\
- \n\
- ARGUMENTS:\n\n\
-  - mol : the molecule of interest\n\
-  - numConfs : the number of conformers to generate \n\
-  - params : an EmbedParameters object \n\
- RETURNS:\n\n\
-    Iterator which yields new conformation IDs \n\
-\n";
-  python::def(
-      "EmbedMultipleConfs", RDKit::EmbedMultipleConfs2,
-      (python::arg("mol"), python::arg("numConfs"), python::arg("params")),
-      docString.c_str());
+  m.def(
+      "EmbedMultipleConfs", &RDKit::EmbedMultipleConfs2,
+      "mol"_a, "numConfs"_a, "params"_a,
+      R"DOC(Use distance geometry to obtain multiple sets of
+coordinates for a molecule
 
-  docString =
-      "Use distance geometry to obtain intial \n\
- coordinates for a molecule\n\n\
- \n\
- ARGUMENTS:\n\n\
-    - mol : the molecule of interest\n\
-    - params : an EmbedParameters object \n\
-\n\
- RETURNS:\n\n\
-    ID of the new conformation added to the molecule or -1 if the embedding fails. \n\
-\n";
-  python::def("EmbedMolecule", RDKit::EmbedMolecule2,
-              (python::arg("mol"), python::arg("params")), docString.c_str());
-  python::def(
-      "ETKDG", RDKit::getETKDG,
-      "Returns an EmbedParameters object for the ETKDG method - version 1.",
-      python::return_value_policy<python::manage_new_object>());
-  python::def(
-      "ETKDGv2", RDKit::getETKDGv2,
-      "Returns an EmbedParameters object for the ETKDG method - version 2.",
-      python::return_value_policy<python::manage_new_object>());
-  python::def("srETKDGv3", RDKit::getsrETKDGv3,
-              "Returns an EmbedParameters object for the ETKDG method - "
-              "version 3 (small rings).",
-              python::return_value_policy<python::manage_new_object>());
-  python::def("ETKDGv3", RDKit::getETKDGv3,
-              "Returns an EmbedParameters object for the ETKDG method - "
-              "version 3 (macrocycles).",
-              python::return_value_policy<python::manage_new_object>());
-  python::def("ETDG", RDKit::getETDG,
-              "Returns an EmbedParameters object for the ETDG method.",
-              python::return_value_policy<python::manage_new_object>());
-  python::def(
-      "ETDGv2", RDKit::getETDGv2,
-      "Returns an EmbedParameters object for the ETDG method - version 2.",
-      python::return_value_policy<python::manage_new_object>());
-  python::def("KDG", RDKit::getKDG,
-              "Returns an EmbedParameters object for the KDG method.",
-              python::return_value_policy<python::manage_new_object>());
+ARGUMENTS:
 
-  docString =
-      "Returns the distance bounds matrix for a molecule\n\
- \n\
- ARGUMENTS:\n\n\
-    - mol : the molecule of interest\n\
-    - set15bounds : set bounds for 1-5 atom distances based on \n\
-                    topology (otherwise stop at 1-4s)\n\
-    - scaleVDW : scale down the sum of VDW radii when setting the \n\
-                 lower bounds for atoms less than 5 bonds apart \n\
-    - doTriangleSmoothing : run triangle smoothing on the bounds \n\
-                 matrix before returning it \n\
- RETURNS:\n\n\
-    the bounds matrix as a Numeric array with lower bounds in \n\
-    the lower triangle and upper bounds in the upper triangle\n\
-\n";
-  python::def("GetMoleculeBoundsMatrix", RDKit::getMolBoundsMatrix,
-              (python::arg("mol"), python::arg("set15bounds") = true,
-               python::arg("scaleVDW") = false,
-               python::arg("doTriangleSmoothing") = true,
-               python::arg("useMacrocycle14config") = false),
-              docString.c_str());
+  - mol : the molecule of interest
+  - numConfs : the number of conformers to generate
+  - params : an EmbedParameters object
 
-  docString =
-      "Returns json string containing embedParameters attributes\n\
-  \n\
-  ARGUMENTS:\n\n\
-    - embedParameters : the Params object you want serialized\n\
-  RETURNS:\n\n\
-    The Params object as json string\n\
-  \n";
-  python::def("EmbedParametersToJSON", RDKit::embedParametersToJSONHelper,
-              (python::arg("embedParameters")), docString.c_str());
+RETURNS:
+
+   Iterator which yields new conformation IDs
+)DOC");
+
+  m.def(
+      "EmbedMolecule", &RDKit::EmbedMolecule2, "mol"_a, "params"_a,
+      R"DOC(Use distance geometry to obtain initial
+coordinates for a molecule
+
+ARGUMENTS:
+
+   - mol : the molecule of interest
+   - params : an EmbedParameters object
+
+RETURNS:
+
+   ID of the new conformation added to the molecule or -1 if the embedding fails.
+)DOC");
+
+  m.def("ETKDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDG); },
+        "Returns an EmbedParameters object for the ETKDG method - version 1.");
+  m.def("ETKDGv2",
+        []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDGv2); },
+        "Returns an EmbedParameters object for the ETKDG method - version 2.");
+  m.def("srETKDGv3",
+        []() { return PyEmbedParameters(RDKit::DGeomHelpers::srETKDGv3); },
+        R"DOC(Returns an EmbedParameters object for the ETKDG method -
+version 3 (small rings).)DOC");
+  m.def("ETKDGv3",
+        []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDGv3); },
+        R"DOC(Returns an EmbedParameters object for the ETKDG method -
+version 3 (macrocycles).)DOC");
+  m.def("ETDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETDG); },
+        "Returns an EmbedParameters object for the ETDG method.");
+  m.def("ETDGv2",
+        []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETDGv2); },
+        "Returns an EmbedParameters object for the ETDG method - version 2.");
+  m.def("KDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::KDG); },
+        "Returns an EmbedParameters object for the KDG method.");
+
+  m.def(
+      "GetMoleculeBoundsMatrix", &RDKit::getMolBoundsMatrix,
+      "mol"_a, "set15bounds"_a = true, "scaleVDW"_a = false,
+      "doTriangleSmoothing"_a = true, "useMacrocycle14config"_a = false,
+      R"DOC(Returns the distance bounds matrix for a molecule
+
+ARGUMENTS:
+
+   - mol : the molecule of interest
+   - set15bounds : set bounds for 1-5 atom distances based on
+                   topology (otherwise stop at 1-4s)
+   - scaleVDW : scale down the sum of VDW radii when setting the
+                lower bounds for atoms less than 5 bonds apart
+   - doTriangleSmoothing : run triangle smoothing on the bounds
+                matrix before returning it
+
+RETURNS:
+
+   the bounds matrix as a Numeric array with lower bounds in
+   the lower triangle and upper bounds in the upper triangle
+)DOC");
+
+  m.def(
+      "EmbedParametersToJSON",
+      [](const PyEmbedParameters &ps) {
+        return embedParametersToJSON(ps);
+      },
+      "embedParameters"_a,
+      R"DOC(Returns json string containing embedParameters attributes
+
+ARGUMENTS:
+
+  - embedParameters : the Params object you want serialized
+
+RETURNS:
+
+  The Params object as json string
+)DOC");
 }

--- a/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
@@ -185,8 +185,8 @@ static INT_VECT EmbedMultipleConfs2(ROMol &mol, unsigned int numConfs,
 }
 
 static nb::ndarray<nb::numpy, double, nb::ndim<2>> getMolBoundsMatrix(
-    const ROMol &mol, bool set15bounds, bool scaleVDW,
-    bool doTriangleSmoothing, bool useMacrocycle14config) {
+    const ROMol &mol, bool set15bounds, bool scaleVDW, bool doTriangleSmoothing,
+    bool useMacrocycle14config) {
   unsigned int nats = mol.getNumAtoms();
   DistGeom::BoundsMatPtr mat(new DistGeom::BoundsMatrix(nats));
   DGeomHelpers::initBoundsMat(mat);
@@ -244,9 +244,9 @@ distance geometry)DOC";
          bool useBasicKnowledge, unsigned int ETversion,
          bool printExpTorsionAngles) {
         return RDKit::getExpTorsHelper(mol, useExpTorsionAnglePrefs,
-                                      useSmallRingTorsions,
-                                      useMacrocycleTorsions, useBasicKnowledge,
-                                      ETversion, printExpTorsionAngles);
+                                       useSmallRingTorsions,
+                                       useMacrocycleTorsions, useBasicKnowledge,
+                                       ETversion, printExpTorsionAngles);
       },
       "mol"_a, "useExpTorsionAnglePrefs"_a = true,
       "useSmallRingTorsions"_a = false, "useMacrocycleTorsions"_a = true,
@@ -265,18 +265,16 @@ distance geometry)DOC";
       "mol"_a, "embedParams"_a,
       "returns information about the bonds corresponding to experimental torsions");
 
-  m.def(
-      "EmbedMolecule", &RDKit::EmbedMolecule,
-      "mol"_a, "maxAttempts"_a = 0, "randomSeed"_a = -1,
-      "clearConfs"_a = true, "useRandomCoords"_a = false,
-      "boxSizeMult"_a = 2.0, "randNegEig"_a = true, "numZeroFail"_a = 1,
-      "coordMap"_a = nb::dict(), "forceTol"_a = 1e-3,
-      "ignoreSmoothingFailures"_a = false, "enforceChirality"_a = true,
-      "useExpTorsionAnglePrefs"_a = true, "useBasicKnowledge"_a = true,
-      "printExpTorsionAngles"_a = false, "useSmallRingTorsions"_a = false,
-      "useMacrocycleTorsions"_a = true, "ETversion"_a = 2,
-      "useMacrocycle14config"_a = true,
-      R"DOC(Use distance geometry to obtain initial
+  m.def("EmbedMolecule", &RDKit::EmbedMolecule, "mol"_a, "maxAttempts"_a = 0,
+        "randomSeed"_a = -1, "clearConfs"_a = true, "useRandomCoords"_a = false,
+        "boxSizeMult"_a = 2.0, "randNegEig"_a = true, "numZeroFail"_a = 1,
+        "coordMap"_a = nb::dict(), "forceTol"_a = 1e-3,
+        "ignoreSmoothingFailures"_a = false, "enforceChirality"_a = true,
+        "useExpTorsionAnglePrefs"_a = true, "useBasicKnowledge"_a = true,
+        "printExpTorsionAngles"_a = false, "useSmallRingTorsions"_a = false,
+        "useMacrocycleTorsions"_a = true, "ETversion"_a = 2,
+        "useMacrocycle14config"_a = true,
+        R"DOC(Use distance geometry to obtain initial
 coordinates for a molecule
 
 ARGUMENTS:
@@ -322,19 +320,18 @@ RETURNS:
    ID of the new conformation added to the molecule or -1 if the embedding fails.
 )DOC");
 
-  m.def(
-      "EmbedMultipleConfs", &RDKit::EmbedMultipleConfs,
-      "mol"_a, "numConfs"_a = 10, "maxAttempts"_a = 0, "randomSeed"_a = -1,
-      "clearConfs"_a = true, "useRandomCoords"_a = false,
-      "boxSizeMult"_a = 2.0, "randNegEig"_a = true, "numZeroFail"_a = 1,
-      "pruneRmsThresh"_a = -1.0, "coordMap"_a = nb::dict(),
-      "forceTol"_a = 1e-3, "ignoreSmoothingFailures"_a = false,
-      "enforceChirality"_a = true, "numThreads"_a = 1,
-      "useExpTorsionAnglePrefs"_a = true, "useBasicKnowledge"_a = true,
-      "printExpTorsionAngles"_a = false, "useSmallRingTorsions"_a = false,
-      "useMacrocycleTorsions"_a = true, "ETversion"_a = 2,
-      "useMacrocycle14config"_a = true,
-      R"DOC(Use distance geometry to obtain multiple sets of
+  m.def("EmbedMultipleConfs", &RDKit::EmbedMultipleConfs, "mol"_a,
+        "numConfs"_a = 10, "maxAttempts"_a = 0, "randomSeed"_a = -1,
+        "clearConfs"_a = true, "useRandomCoords"_a = false,
+        "boxSizeMult"_a = 2.0, "randNegEig"_a = true, "numZeroFail"_a = 1,
+        "pruneRmsThresh"_a = -1.0, "coordMap"_a = nb::dict(),
+        "forceTol"_a = 1e-3, "ignoreSmoothingFailures"_a = false,
+        "enforceChirality"_a = true, "numThreads"_a = 1,
+        "useExpTorsionAnglePrefs"_a = true, "useBasicKnowledge"_a = true,
+        "printExpTorsionAngles"_a = false, "useSmallRingTorsions"_a = false,
+        "useMacrocycleTorsions"_a = true, "ETversion"_a = 2,
+        "useMacrocycle14config"_a = true,
+        R"DOC(Use distance geometry to obtain multiple sets of
 coordinates for a molecule
 
 ARGUMENTS:
@@ -388,7 +385,8 @@ RETURNS:
    Iterator which yields new conformation IDs
 )DOC");
 
-  nb::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>(m, "EmbedFailureCauses")
+  nb::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>(m, "EmbedFailureCauses",
+                                                     nb::is_arithmetic())
       .value("INITIAL_COORDS",
              RDKit::DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS)
       .value("FIRST_MINIMIZATION",
@@ -397,9 +395,8 @@ RETURNS:
              RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_TETRAHEDRAL_CENTERS)
       .value("CHECK_CHIRAL_CENTERS",
              RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_CHIRAL_CENTERS)
-      .value(
-          "MINIMIZE_FOURTH_DIMENSION",
-          RDKit::DGeomHelpers::EmbedFailureCauses::MINIMIZE_FOURTH_DIMENSION)
+      .value("MINIMIZE_FOURTH_DIMENSION",
+             RDKit::DGeomHelpers::EmbedFailureCauses::MINIMIZE_FOURTH_DIMENSION)
       .value("ETK_MINIMIZATION",
              RDKit::DGeomHelpers::EmbedFailureCauses::ETK_MINIMIZATION)
       .value("FINAL_CHIRAL_BOUNDS",
@@ -422,9 +419,8 @@ RETURNS:
       .def_rw("maxIterations", &PyEmbedParameters::maxIterations,
               R"DOC(maximum number of embedding attempts to use for a
 single conformation)DOC")
-      .def_rw(
-          "numThreads", &PyEmbedParameters::numThreads,
-          "number of threads to use when embedding multiple conformations")
+      .def_rw("numThreads", &PyEmbedParameters::numThreads,
+              "number of threads to use when embedding multiple conformations")
       .def_rw("timeout", &PyEmbedParameters::timeout,
               R"DOC(maximum time in seconds to generate a conformer for a
 single molecule fragment. If set to 0, no timeout is set)DOC")
@@ -440,9 +436,8 @@ using eigenvalues of the distance matrix)DOC")
       .def_rw("randNegEig", &PyEmbedParameters::randNegEig,
               R"DOC(if the embedding yields a negative eigenvalue, pick
 coordinates that correspond to this component at random)DOC")
-      .def_rw(
-          "numZeroFail", &PyEmbedParameters::numZeroFail,
-          "fail embedding if we have at least this many zero eigenvalues")
+      .def_rw("numZeroFail", &PyEmbedParameters::numZeroFail,
+              "fail embedding if we have at least this many zero eigenvalues")
       .def_rw("optimizerForceTol", &PyEmbedParameters::optimizerForceTol,
               R"DOC(the tolerance to be used during the distance-geometry
 force field minimization)DOC")
@@ -468,10 +463,9 @@ the bounds matrix fails)DOC")
 conformations that are at least this far apart from each other)DOC")
       .def_rw("onlyHeavyAtomsForRMS", &PyEmbedParameters::onlyHeavyAtomsForRMS,
               "Only consider heavy atoms when doing RMS filtering")
-      .def_rw(
-          "embedFragmentsSeparately",
-          &PyEmbedParameters::embedFragmentsSeparately,
-          "split the molecule into fragments and embed them separately")
+      .def_rw("embedFragmentsSeparately",
+              &PyEmbedParameters::embedFragmentsSeparately,
+              "split the molecule into fragments and embed them separately")
       .def_rw("useSmallRingTorsions", &PyEmbedParameters::useSmallRingTorsions,
               "impose small ring torsion angle preferences")
       .def_rw("useMacrocycleTorsions",
@@ -488,36 +482,34 @@ the other types of restraints)DOC")
           "useSymmetryForPruning", &PyEmbedParameters::useSymmetryForPruning,
           R"DOC(use molecule symmetry when doing the RMSD pruning. Note that this
 option automatically also sets onlyHeavyAtomsForRMS to true.)DOC")
-      .def("SetBoundsMat", &PyEmbedParameters::setBoundsMatrix,
-           "boundsMatArg"_a,
-           R"DOC(set the distance-bounds matrix to be used (no triangle smoothing
+      .def(
+          "SetBoundsMat", &PyEmbedParameters::setBoundsMatrix, "boundsMatArg"_a,
+          R"DOC(set the distance-bounds matrix to be used (no triangle smoothing
 will be done on this) from a Numpy array)DOC")
-      .def("SetCPCI", &PyEmbedParameters::setCPCI, "CPCIdict"_a,
-           R"DOC(set the customised pairwise Columb-like interaction to atom pairs.
+      .def(
+          "SetCPCI", &PyEmbedParameters::setCPCI, "CPCIdict"_a,
+          R"DOC(set the customised pairwise Columb-like interaction to atom pairs.
 used during structural minimisation stage)DOC")
       .def_rw("forceTransAmides", &PyEmbedParameters::forceTransAmides,
               "constrain amide bonds to be trans")
-      .def_rw(
-          "trackFailures", &PyEmbedParameters::trackFailures,
-          "keep track of which checks during the embedding process fail")
+      .def_rw("trackFailures", &PyEmbedParameters::trackFailures,
+              "keep track of which checks during the embedding process fail")
       .def("GetFailureCounts", &PyEmbedParameters::getFailureCounts,
            "returns the counts of each failure type")
       .def_rw(
           "enableSequentialRandomSeeds",
           &PyEmbedParameters::enableSequentialRandomSeeds,
           "handle random number seeds so that conformer generation can be restarted")
-      .def_rw(
-          "symmetrizeConjugatedTerminalGroupsForPruning",
-          &PyEmbedParameters::symmetrizeConjugatedTerminalGroupsForPruning,
-          "symmetrize terminal conjugated groups for RMSD pruning")
+      .def_rw("symmetrizeConjugatedTerminalGroupsForPruning",
+              &PyEmbedParameters::symmetrizeConjugatedTerminalGroupsForPruning,
+              "symmetrize terminal conjugated groups for RMSD pruning")
       .def("SetCoordMap", &PyEmbedParameters::setCoordMap,
            "sets the coordmap to be used")
       .def("__setattr__", &safeSetattr);
 
-  m.def(
-      "EmbedMultipleConfs", &RDKit::EmbedMultipleConfs2,
-      "mol"_a, "numConfs"_a, "params"_a,
-      R"DOC(Use distance geometry to obtain multiple sets of
+  m.def("EmbedMultipleConfs", &RDKit::EmbedMultipleConfs2, "mol"_a,
+        "numConfs"_a, "params"_a,
+        R"DOC(Use distance geometry to obtain multiple sets of
 coordinates for a molecule
 
 ARGUMENTS:
@@ -531,9 +523,8 @@ RETURNS:
    Iterator which yields new conformation IDs
 )DOC");
 
-  m.def(
-      "EmbedMolecule", &RDKit::EmbedMolecule2, "mol"_a, "params"_a,
-      R"DOC(Use distance geometry to obtain initial
+  m.def("EmbedMolecule", &RDKit::EmbedMolecule2, "mol"_a, "params"_a,
+        R"DOC(Use distance geometry to obtain initial
 coordinates for a molecule
 
 ARGUMENTS:
@@ -546,32 +537,37 @@ RETURNS:
    ID of the new conformation added to the molecule or -1 if the embedding fails.
 )DOC");
 
-  m.def("ETKDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDG); },
-        "Returns an EmbedParameters object for the ETKDG method - version 1.");
-  m.def("ETKDGv2",
-        []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDGv2); },
-        "Returns an EmbedParameters object for the ETKDG method - version 2.");
-  m.def("srETKDGv3",
-        []() { return PyEmbedParameters(RDKit::DGeomHelpers::srETKDGv3); },
-        R"DOC(Returns an EmbedParameters object for the ETKDG method -
-version 3 (small rings).)DOC");
-  m.def("ETKDGv3",
-        []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDGv3); },
-        R"DOC(Returns an EmbedParameters object for the ETKDG method -
-version 3 (macrocycles).)DOC");
-  m.def("ETDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETDG); },
-        "Returns an EmbedParameters object for the ETDG method.");
-  m.def("ETDGv2",
-        []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETDGv2); },
-        "Returns an EmbedParameters object for the ETDG method - version 2.");
-  m.def("KDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::KDG); },
-        "Returns an EmbedParameters object for the KDG method.");
-
   m.def(
-      "GetMoleculeBoundsMatrix", &RDKit::getMolBoundsMatrix,
-      "mol"_a, "set15bounds"_a = true, "scaleVDW"_a = false,
-      "doTriangleSmoothing"_a = true, "useMacrocycle14config"_a = false,
-      R"DOC(Returns the distance bounds matrix for a molecule
+      "ETKDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDG); },
+      "Returns an EmbedParameters object for the ETKDG method - version 1.");
+  m.def(
+      "ETKDGv2",
+      []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDGv2); },
+      "Returns an EmbedParameters object for the ETKDG method - version 2.");
+  m.def(
+      "srETKDGv3",
+      []() { return PyEmbedParameters(RDKit::DGeomHelpers::srETKDGv3); },
+      R"DOC(Returns an EmbedParameters object for the ETKDG method -
+version 3 (small rings).)DOC");
+  m.def(
+      "ETKDGv3",
+      []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETKDGv3); },
+      R"DOC(Returns an EmbedParameters object for the ETKDG method -
+version 3 (macrocycles).)DOC");
+  m.def(
+      "ETDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETDG); },
+      "Returns an EmbedParameters object for the ETDG method.");
+  m.def(
+      "ETDGv2", []() { return PyEmbedParameters(RDKit::DGeomHelpers::ETDGv2); },
+      "Returns an EmbedParameters object for the ETDG method - version 2.");
+  m.def(
+      "KDG", []() { return PyEmbedParameters(RDKit::DGeomHelpers::KDG); },
+      "Returns an EmbedParameters object for the KDG method.");
+
+  m.def("GetMoleculeBoundsMatrix", &RDKit::getMolBoundsMatrix, "mol"_a,
+        "set15bounds"_a = true, "scaleVDW"_a = false,
+        "doTriangleSmoothing"_a = true, "useMacrocycle14config"_a = false,
+        R"DOC(Returns the distance bounds matrix for a molecule
 
 ARGUMENTS:
 
@@ -591,9 +587,7 @@ RETURNS:
 
   m.def(
       "EmbedParametersToJSON",
-      [](const PyEmbedParameters &ps) {
-        return embedParametersToJSON(ps);
-      },
+      [](const PyEmbedParameters &ps) { return embedParametersToJSON(ps); },
       "embedParameters"_a,
       R"DOC(Returns json string containing embedParameters attributes
 


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to DistGeomHelpers.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.