### PR TITLE
pr/SHARED-12394: Implement nanobind for SimDivPickers

### DIFF
--- a/Code/SimDivPickers/CMakeLists.txt
+++ b/Code/SimDivPickers/CMakeLists.txt
@@ -17,3 +17,7 @@ rdkit_catch_test(pickersTestsCatch catch_tests.cpp
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/SimDivPickers/nbWrap/CMakeLists.txt
+++ b/Code/SimDivPickers/nbWrap/CMakeLists.txt
@@ -1,0 +1,12 @@
+remove_definitions(-DRDKIT_SIMDIVPICKERS_BUILD)
+rdkit_python_extension(rdSimDivPickers 
+                       MaxMinPicker.cpp LeaderPicker.cpp HierarchicalClusterPicker.cpp 
+                       rdSimDivPickers.cpp 
+                       DEST SimDivFilters
+                       LINK_LIBRARIES SimDivPickers DataStructs)
+
+add_pytest(pySimDivPickers ${CMAKE_CURRENT_SOURCE_DIR}/testPickers.py)
+
+
+
+

--- a/Code/SimDivPickers/nbWrap/CMakeLists.txt
+++ b/Code/SimDivPickers/nbWrap/CMakeLists.txt
@@ -1,12 +1,9 @@
 remove_definitions(-DRDKIT_SIMDIVPICKERS_BUILD)
-rdkit_python_extension(rdSimDivPickers 
-                       MaxMinPicker.cpp LeaderPicker.cpp HierarchicalClusterPicker.cpp 
-                       rdSimDivPickers.cpp 
+rdkit_nanobind_extension(rdSimDivPickers
+                       MaxMinPicker.cpp LeaderPicker.cpp HierarchicalClusterPicker.cpp
+                       rdSimDivPickers.cpp
                        DEST SimDivFilters
                        LINK_LIBRARIES SimDivPickers DataStructs)
 
-add_pytest(pySimDivPickers ${CMAKE_CURRENT_SOURCE_DIR}/testPickers.py)
-
-
-
-
+add_pytest(pySimDivPickersMaxMin ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testMaxMin.py)
+add_pytest(pySimDivPickers ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testPickers.py)

--- a/Code/SimDivPickers/nbWrap/CMakeLists.txt
+++ b/Code/SimDivPickers/nbWrap/CMakeLists.txt
@@ -5,5 +5,4 @@ rdkit_nanobind_extension(rdSimDivPickers
                        DEST SimDivFilters
                        LINK_LIBRARIES SimDivPickers DataStructs)
 
-add_pytest(pySimDivPickersMaxMin ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testMaxMin.py)
 add_pytest(pySimDivPickers ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testPickers.py)

--- a/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
@@ -1,0 +1,114 @@
+// $Id$
+//
+//  Copyright (C) 2003-2008  Greg Landrum and Rational Discovery LLC
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+
+#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
+#include <RDBoost/python.h>
+
+#include <RDBoost/boost_numpy.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+#include <RDBoost/Wrap.h>
+
+#include <SimDivPickers/DistPicker.h>
+#include <SimDivPickers/HierarchicalClusterPicker.h>
+
+namespace python = boost::python;
+namespace RDPickers {
+
+// REVIEW: the poolSize can be pulled from the numeric array
+RDKit::INT_VECT HierarchicalPicks(HierarchicalClusterPicker *picker,
+                                  python::object &distMat, int poolSize,
+                                  int pickSize) {
+  if (pickSize >= poolSize) {
+    throw ValueErrorException("pickSize must be less than poolSize");
+  }
+  if (!PyArray_Check(distMat.ptr())) {
+    throw ValueErrorException("distance mat argument must be a numpy matrix");
+  }
+
+  PyArrayObject *copy;
+  // it's painful to have to copy the input matrix, but the
+  // picker itself will step on the distance matrix, so use
+  // CopyFromObject here instead of ContiguousFromObject
+  copy =
+      (PyArrayObject *)PyArray_CopyFromObject(distMat.ptr(), NPY_DOUBLE, 1, 1);
+  auto *dMat = (double *)PyArray_DATA(copy);
+  RDKit::INT_VECT res = picker->pick(dMat, poolSize, pickSize);
+  Py_DECREF(copy);
+  return res;
+}
+
+// REVIEW: the poolSize can be pulled from the numeric array
+RDKit::VECT_INT_VECT HierarchicalClusters(HierarchicalClusterPicker *picker,
+                                          python::object &distMat, int poolSize,
+                                          int pickSize) {
+  if (!PyArray_Check(distMat.ptr())) {
+    throw ValueErrorException("distance mat argument must be a numpy matrix");
+  }
+
+  // REVIEW: check pickSize < poolSize, otherwise throw_value_error()
+  PyArrayObject *copy;
+  // it's painful to have to copy the input matrix, but the
+  // picker itself will step on the distance matrix, so use
+  // CopyFromObject here instead of ContiguousFromObject
+  copy =
+      (PyArrayObject *)PyArray_CopyFromObject(distMat.ptr(), NPY_DOUBLE, 1, 1);
+  auto *dMat = (double *)PyArray_DATA(copy);
+
+  RDKit::VECT_INT_VECT res = picker->cluster(dMat, poolSize, pickSize);
+  Py_DECREF(copy);
+  return res;
+}
+
+struct HierarchCP_wrap {
+  static void wrap() {
+    std::string docString =
+        "A class for diversity picking of items using Hierarchical "
+        "Clustering\n";
+    python::class_<HierarchicalClusterPicker>(
+        "HierarchicalClusterPicker", docString.c_str(),
+        python::init<HierarchicalClusterPicker::ClusterMethod>(
+            python::args("self", "clusterMethod")))
+        .def("Pick", HierarchicalPicks,
+             python::args("self", "distMat", "poolSize", "pickSize"),
+             "Pick a diverse subset of items from a pool of items using "
+             "hierarchical clustering\n"
+             "\n"
+             "ARGUMENTS: \n"
+             "  - distMat: 1D distance matrix (only the lower triangle "
+             "elements)\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n")
+        .def("Cluster", HierarchicalClusters,
+             python::args("self", "distMat", "poolSize", "pickSize"),
+             "Return a list of clusters of item from the pool using "
+             "hierarchical clustering\n"
+             "\n"
+             "ARGUMENTS: \n"
+             "  - distMat: 1D distance matrix (only the lower triangle "
+             "elements)\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n");
+
+    python::enum_<HierarchicalClusterPicker::ClusterMethod>("ClusterMethod")
+        .value("WARD", HierarchicalClusterPicker::WARD)
+        .value("SLINK", HierarchicalClusterPicker::SLINK)
+        .value("CLINK", HierarchicalClusterPicker::CLINK)
+        .value("UPGMA", HierarchicalClusterPicker::UPGMA)
+        .value("MCQUITTY", HierarchicalClusterPicker::MCQUITTY)
+        .value("GOWER", HierarchicalClusterPicker::GOWER)
+        .value("CENTROID", HierarchicalClusterPicker::CENTROID)
+        .export_values();
+  };
+};
+}  // namespace RDPickers
+
+void wrap_HierarchCP() { RDPickers::HierarchCP_wrap::wrap(); }

--- a/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
@@ -8,10 +8,7 @@
 //
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
-#define NO_IMPORT_ARRAY
-#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_nb_array_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
+#include <nanobind/ndarray.h>
 
 #include <SimDivPickers/DistPicker.h>
 #include <SimDivPickers/HierarchicalClusterPicker.h>
@@ -23,47 +20,24 @@ namespace RDPickers {
 
 // REVIEW: the poolSize can be pulled from the numeric array
 RDKit::INT_VECT HierarchicalPicks(HierarchicalClusterPicker *picker,
-                                  nb::object distMat, int poolSize,
-                                  int pickSize) {
+                                  nb::ndarray<nb::numpy, const double,
+                                              nb::ndim<1>, nb::c_contig> distMat,
+                                  int poolSize, int pickSize) {
   if (pickSize >= poolSize) {
     throw nb::value_error("pickSize must be less than poolSize");
   }
-  if (!PyArray_Check(distMat.ptr())) {
-    throw nb::value_error("distance mat argument must be a numpy matrix");
-  }
 
-  PyArrayObject *copy;
-  // it's painful to have to copy the input matrix, but the
-  // picker itself will step on the distance matrix, so use
-  // CopyFromObject here instead of ContiguousFromObject
-  copy =
-      (PyArrayObject *)PyArray_CopyFromObject(distMat.ptr(), NPY_DOUBLE, 1, 1);
-  auto *dMat = (double *)PyArray_DATA(copy);
-  RDKit::INT_VECT res = picker->pick(dMat, poolSize, pickSize);
-  Py_DECREF(copy);
-  return res;
+  std::vector<double> dMatCopy(distMat.data(), distMat.data() + distMat.shape(0));
+  return picker->pick(dMatCopy.data(), poolSize, pickSize);
 }
 
 // REVIEW: the poolSize can be pulled from the numeric array
 RDKit::VECT_INT_VECT HierarchicalClusters(HierarchicalClusterPicker *picker,
-                                          nb::object distMat, int poolSize,
-                                          int pickSize) {
-  if (!PyArray_Check(distMat.ptr())) {
-    throw nb::value_error("distance mat argument must be a numpy matrix");
-  }
-
-  // REVIEW: check pickSize < poolSize, otherwise throw value error
-  PyArrayObject *copy;
-  // it's painful to have to copy the input matrix, but the
-  // picker itself will step on the distance matrix, so use
-  // CopyFromObject here instead of ContiguousFromObject
-  copy =
-      (PyArrayObject *)PyArray_CopyFromObject(distMat.ptr(), NPY_DOUBLE, 1, 1);
-  auto *dMat = (double *)PyArray_DATA(copy);
-
-  RDKit::VECT_INT_VECT res = picker->cluster(dMat, poolSize, pickSize);
-  Py_DECREF(copy);
-  return res;
+                                          nb::ndarray<nb::numpy, const double,
+                                                      nb::ndim<1>, nb::c_contig> distMat,
+                                          int poolSize, int pickSize) {
+  std::vector<double> dMatCopy(distMat.data(), distMat.data() + distMat.shape(0));
+  return picker->cluster(dMatCopy.data(), poolSize, pickSize);
 }
 
 }  // namespace RDPickers

--- a/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
@@ -8,9 +8,10 @@
 //
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_nb_array_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
-#include <RDBoost/import_array.h>
 
 #include <SimDivPickers/DistPicker.h>
 #include <SimDivPickers/HierarchicalClusterPicker.h>

--- a/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/HierarchicalClusterPicker.cpp
@@ -1,37 +1,34 @@
-// $Id$
 //
-//  Copyright (C) 2003-2008  Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-
-#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
-#include <RDBoost/python.h>
-
-#include <RDBoost/boost_numpy.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
-#include <RDBoost/Wrap.h>
+#include <RDBoost/import_array.h>
 
 #include <SimDivPickers/DistPicker.h>
 #include <SimDivPickers/HierarchicalClusterPicker.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+
 namespace RDPickers {
 
 // REVIEW: the poolSize can be pulled from the numeric array
 RDKit::INT_VECT HierarchicalPicks(HierarchicalClusterPicker *picker,
-                                  python::object &distMat, int poolSize,
+                                  nb::object distMat, int poolSize,
                                   int pickSize) {
   if (pickSize >= poolSize) {
-    throw ValueErrorException("pickSize must be less than poolSize");
+    throw nb::value_error("pickSize must be less than poolSize");
   }
   if (!PyArray_Check(distMat.ptr())) {
-    throw ValueErrorException("distance mat argument must be a numpy matrix");
+    throw nb::value_error("distance mat argument must be a numpy matrix");
   }
 
   PyArrayObject *copy;
@@ -48,13 +45,13 @@ RDKit::INT_VECT HierarchicalPicks(HierarchicalClusterPicker *picker,
 
 // REVIEW: the poolSize can be pulled from the numeric array
 RDKit::VECT_INT_VECT HierarchicalClusters(HierarchicalClusterPicker *picker,
-                                          python::object &distMat, int poolSize,
+                                          nb::object distMat, int poolSize,
                                           int pickSize) {
   if (!PyArray_Check(distMat.ptr())) {
-    throw ValueErrorException("distance mat argument must be a numpy matrix");
+    throw nb::value_error("distance mat argument must be a numpy matrix");
   }
 
-  // REVIEW: check pickSize < poolSize, otherwise throw_value_error()
+  // REVIEW: check pickSize < poolSize, otherwise throw value error
   PyArrayObject *copy;
   // it's painful to have to copy the input matrix, but the
   // picker itself will step on the distance matrix, so use
@@ -68,47 +65,41 @@ RDKit::VECT_INT_VECT HierarchicalClusters(HierarchicalClusterPicker *picker,
   return res;
 }
 
-struct HierarchCP_wrap {
-  static void wrap() {
-    std::string docString =
-        "A class for diversity picking of items using Hierarchical "
-        "Clustering\n";
-    python::class_<HierarchicalClusterPicker>(
-        "HierarchicalClusterPicker", docString.c_str(),
-        python::init<HierarchicalClusterPicker::ClusterMethod>(
-            python::args("self", "clusterMethod")))
-        .def("Pick", HierarchicalPicks,
-             python::args("self", "distMat", "poolSize", "pickSize"),
-             "Pick a diverse subset of items from a pool of items using "
-             "hierarchical clustering\n"
-             "\n"
-             "ARGUMENTS: \n"
-             "  - distMat: 1D distance matrix (only the lower triangle "
-             "elements)\n"
-             "  - poolSize: number of items in the pool\n"
-             "  - pickSize: number of items to pick from the pool\n")
-        .def("Cluster", HierarchicalClusters,
-             python::args("self", "distMat", "poolSize", "pickSize"),
-             "Return a list of clusters of item from the pool using "
-             "hierarchical clustering\n"
-             "\n"
-             "ARGUMENTS: \n"
-             "  - distMat: 1D distance matrix (only the lower triangle "
-             "elements)\n"
-             "  - poolSize: number of items in the pool\n"
-             "  - pickSize: number of items to pick from the pool\n");
-
-    python::enum_<HierarchicalClusterPicker::ClusterMethod>("ClusterMethod")
-        .value("WARD", HierarchicalClusterPicker::WARD)
-        .value("SLINK", HierarchicalClusterPicker::SLINK)
-        .value("CLINK", HierarchicalClusterPicker::CLINK)
-        .value("UPGMA", HierarchicalClusterPicker::UPGMA)
-        .value("MCQUITTY", HierarchicalClusterPicker::MCQUITTY)
-        .value("GOWER", HierarchicalClusterPicker::GOWER)
-        .value("CENTROID", HierarchicalClusterPicker::CENTROID)
-        .export_values();
-  };
-};
 }  // namespace RDPickers
 
-void wrap_HierarchCP() { RDPickers::HierarchCP_wrap::wrap(); }
+void wrap_HierarchCP(nb::module_ &m) {
+  nb::class_<RDPickers::HierarchicalClusterPicker>(
+      m, "HierarchicalClusterPicker",
+      "A class for diversity picking of items using Hierarchical Clustering\n")
+      .def(nb::init<RDPickers::HierarchicalClusterPicker::ClusterMethod>(),
+           "clusterMethod"_a)
+      .def("Pick", RDPickers::HierarchicalPicks,
+           "distMat"_a, "poolSize"_a, "pickSize"_a,
+           R"DOC(Pick a diverse subset of items from a pool of items using hierarchical clustering
+
+ARGUMENTS:
+  - distMat: 1D distance matrix (only the lower triangle elements)
+  - poolSize: number of items in the pool
+  - pickSize: number of items to pick from the pool
+)DOC")
+      .def("Cluster", RDPickers::HierarchicalClusters,
+           "distMat"_a, "poolSize"_a, "pickSize"_a,
+           R"DOC(Return a list of clusters of item from the pool using hierarchical clustering
+
+ARGUMENTS:
+  - distMat: 1D distance matrix (only the lower triangle elements)
+  - poolSize: number of items in the pool
+  - pickSize: number of items to pick from the pool
+)DOC");
+
+  nb::enum_<RDPickers::HierarchicalClusterPicker::ClusterMethod>(
+      m, "ClusterMethod")
+      .value("WARD", RDPickers::HierarchicalClusterPicker::WARD)
+      .value("SLINK", RDPickers::HierarchicalClusterPicker::SLINK)
+      .value("CLINK", RDPickers::HierarchicalClusterPicker::CLINK)
+      .value("UPGMA", RDPickers::HierarchicalClusterPicker::UPGMA)
+      .value("MCQUITTY", RDPickers::HierarchicalClusterPicker::MCQUITTY)
+      .value("GOWER", RDPickers::HierarchicalClusterPicker::GOWER)
+      .value("CENTROID", RDPickers::HierarchicalClusterPicker::CENTROID)
+      .export_values();
+}

--- a/Code/SimDivPickers/nbWrap/LeaderPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/LeaderPicker.cpp
@@ -1,0 +1,103 @@
+//
+//  Copyright (C) 2019  Greg Landrum
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+
+#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
+#include <RDBoost/python.h>
+#include <RDBoost/Wrap.h>
+#include <RDBoost/boost_numpy.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+#include <map>
+
+#include "PickerHelpers.h"
+
+#include <DataStructs/BitVects.h>
+#include <DataStructs/BitOps.h>
+#include <SimDivPickers/DistPicker.h>
+#include <SimDivPickers/LeaderPicker.h>
+#include <utility>
+
+namespace python = boost::python;
+namespace RDPickers {
+namespace {
+template <typename T>
+void LazyLeaderHelper(LeaderPicker *picker, T functor, unsigned int poolSize,
+                      double &threshold, unsigned int pickSize,
+                      python::object firstPicks, RDKit::INT_VECT &res,
+                      int nThreads) {
+  RDKit::INT_VECT firstPickVect;
+  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
+    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
+  }
+  res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, threshold,
+                         nThreads);
+}
+}  // end of anonymous namespace
+
+RDKit::INT_VECT LazyVectorLeaderPicks(LeaderPicker *picker, python::object objs,
+                                      int poolSize, double threshold,
+                                      int pickSize, python::object firstPicks,
+                                      int numThreads) {
+  std::vector<const ExplicitBitVect *> bvs(poolSize);
+  for (int i = 0; i < poolSize; ++i) {
+    bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
+  }
+  pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
+  RDKit::INT_VECT res;
+  LazyLeaderHelper(picker, functor, poolSize, threshold, pickSize, firstPicks,
+                   res, numThreads);
+  return res;
+}
+
+RDKit::INT_VECT LazyLeaderPicks(LeaderPicker *picker, python::object distFunc,
+                                int poolSize, double threshold, int pickSize,
+                                python::object firstPicks, int numThreads) {
+  pyobjFunctor functor(distFunc);
+  RDKit::INT_VECT res;
+  LazyLeaderHelper(picker, functor, poolSize, threshold, pickSize, firstPicks,
+                   res, numThreads);
+  return res;
+}
+
+}  // end of namespace RDPickers
+
+struct LeaderPicker_wrap {
+  static void wrap() {
+    python::class_<RDPickers::LeaderPicker>(
+        "LeaderPicker",
+        "A class for diversity picking of items using Roger Sayle's Leader "
+        "algorithm (analogous to sphere exclusion). The algorithm is "
+        "currently unpublished, but a description is available in this "
+        "presentation from the 2019 RDKit UGM: "
+        "https://github.com/rdkit/UGM_2019/raw/master/Presentations/"
+        "Sayle_Clustering.pdf\n")
+        .def("LazyBitVectorPick", RDPickers::LazyVectorLeaderPicks,
+             (python::arg("self"), python::arg("objects"),
+              python::arg("poolSize"), python::arg("threshold"),
+              python::arg("pickSize") = 0,
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("numThreads") = 1),
+             "Pick a subset of items from a collection of bit vectors using "
+             "Tanimoto distance. The threshold value is a "
+             "*distance* (i.e. 1-similarity). Note that the numThreads "
+             "argument is currently ignored.")
+        .def("LazyPick", RDPickers::LazyLeaderPicks,
+             (python::arg("self"), python::arg("distFunc"),
+              python::arg("poolSize"), python::arg("threshold"),
+              python::arg("pickSize") = 0,
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("numThreads") = 1),
+             "Pick a subset of items from a pool of items using the "
+             "user-provided function to determine distances. Note that the "
+             "numThreads argument is currently ignored.");
+  };
+};
+
+void wrap_leaderpick() { LeaderPicker_wrap::wrap(); }

--- a/Code/SimDivPickers/nbWrap/LeaderPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/LeaderPicker.cpp
@@ -73,6 +73,7 @@ currently unpublished, but a description is available in this
 presentation from the 2019 RDKit UGM:
 https://github.com/rdkit/UGM_2019/raw/master/Presentations/Sayle_Clustering.pdf
 )DOC")
+      .def(nb::init<>())
       .def("LazyBitVectorPick", RDPickers::LazyVectorLeaderPicks,
            "objects"_a, "poolSize"_a, "threshold"_a,
            "pickSize"_a = 0, "firstPicks"_a = nb::tuple(),

--- a/Code/SimDivPickers/nbWrap/LeaderPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/LeaderPicker.cpp
@@ -1,20 +1,13 @@
 //
-//  Copyright (C) 2019  Greg Landrum
+//  Copyright (C) 2019-2026 Greg Landrum and other RDKit contributors
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-
-#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
-#include <RDBoost/python.h>
-#include <RDBoost/Wrap.h>
-#include <RDBoost/boost_numpy.h>
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
-#include <map>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
 
 #include "PickerHelpers.h"
 
@@ -24,30 +17,33 @@
 #include <SimDivPickers/LeaderPicker.h>
 #include <utility>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+
 namespace RDPickers {
 namespace {
 template <typename T>
 void LazyLeaderHelper(LeaderPicker *picker, T functor, unsigned int poolSize,
                       double &threshold, unsigned int pickSize,
-                      python::object firstPicks, RDKit::INT_VECT &res,
+                      nb::object firstPicks, RDKit::INT_VECT &res,
                       int nThreads) {
   RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
-    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
+  auto len = nb::len(firstPicks);
+  for (size_t i = 0; i < len; ++i) {
+    firstPickVect.push_back(nb::cast<int>(firstPicks[i]));
   }
   res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, threshold,
                          nThreads);
 }
 }  // end of anonymous namespace
 
-RDKit::INT_VECT LazyVectorLeaderPicks(LeaderPicker *picker, python::object objs,
+RDKit::INT_VECT LazyVectorLeaderPicks(LeaderPicker *picker, nb::object objs,
                                       int poolSize, double threshold,
-                                      int pickSize, python::object firstPicks,
+                                      int pickSize, nb::object firstPicks,
                                       int numThreads) {
   std::vector<const ExplicitBitVect *> bvs(poolSize);
   for (int i = 0; i < poolSize; ++i) {
-    bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
+    bvs[i] = nb::cast<const ExplicitBitVect *>(objs[i]);
   }
   pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
   RDKit::INT_VECT res;
@@ -56,9 +52,9 @@ RDKit::INT_VECT LazyVectorLeaderPicks(LeaderPicker *picker, python::object objs,
   return res;
 }
 
-RDKit::INT_VECT LazyLeaderPicks(LeaderPicker *picker, python::object distFunc,
+RDKit::INT_VECT LazyLeaderPicks(LeaderPicker *picker, nb::object distFunc,
                                 int poolSize, double threshold, int pickSize,
-                                python::object firstPicks, int numThreads) {
+                                nb::object firstPicks, int numThreads) {
   pyobjFunctor functor(distFunc);
   RDKit::INT_VECT res;
   LazyLeaderHelper(picker, functor, poolSize, threshold, pickSize, firstPicks,
@@ -68,36 +64,28 @@ RDKit::INT_VECT LazyLeaderPicks(LeaderPicker *picker, python::object distFunc,
 
 }  // end of namespace RDPickers
 
-struct LeaderPicker_wrap {
-  static void wrap() {
-    python::class_<RDPickers::LeaderPicker>(
-        "LeaderPicker",
-        "A class for diversity picking of items using Roger Sayle's Leader "
-        "algorithm (analogous to sphere exclusion). The algorithm is "
-        "currently unpublished, but a description is available in this "
-        "presentation from the 2019 RDKit UGM: "
-        "https://github.com/rdkit/UGM_2019/raw/master/Presentations/"
-        "Sayle_Clustering.pdf\n")
-        .def("LazyBitVectorPick", RDPickers::LazyVectorLeaderPicks,
-             (python::arg("self"), python::arg("objects"),
-              python::arg("poolSize"), python::arg("threshold"),
-              python::arg("pickSize") = 0,
-              python::arg("firstPicks") = python::tuple(),
-              python::arg("numThreads") = 1),
-             "Pick a subset of items from a collection of bit vectors using "
-             "Tanimoto distance. The threshold value is a "
-             "*distance* (i.e. 1-similarity). Note that the numThreads "
-             "argument is currently ignored.")
-        .def("LazyPick", RDPickers::LazyLeaderPicks,
-             (python::arg("self"), python::arg("distFunc"),
-              python::arg("poolSize"), python::arg("threshold"),
-              python::arg("pickSize") = 0,
-              python::arg("firstPicks") = python::tuple(),
-              python::arg("numThreads") = 1),
-             "Pick a subset of items from a pool of items using the "
-             "user-provided function to determine distances. Note that the "
-             "numThreads argument is currently ignored.");
-  };
-};
-
-void wrap_leaderpick() { LeaderPicker_wrap::wrap(); }
+void wrap_leaderpick(nb::module_ &m) {
+  nb::class_<RDPickers::LeaderPicker>(
+      m, "LeaderPicker",
+      R"DOC(A class for diversity picking of items using Roger Sayle's Leader
+algorithm (analogous to sphere exclusion). The algorithm is
+currently unpublished, but a description is available in this
+presentation from the 2019 RDKit UGM:
+https://github.com/rdkit/UGM_2019/raw/master/Presentations/Sayle_Clustering.pdf
+)DOC")
+      .def("LazyBitVectorPick", RDPickers::LazyVectorLeaderPicks,
+           "objects"_a, "poolSize"_a, "threshold"_a,
+           "pickSize"_a = 0, "firstPicks"_a = nb::tuple(),
+           "numThreads"_a = 1,
+           "Pick a subset of items from a collection of bit vectors using "
+           "Tanimoto distance. The threshold value is a "
+           "*distance* (i.e. 1-similarity). Note that the numThreads "
+           "argument is currently ignored.")
+      .def("LazyPick", RDPickers::LazyLeaderPicks,
+           "distFunc"_a, "poolSize"_a, "threshold"_a,
+           "pickSize"_a = 0, "firstPicks"_a = nb::tuple(),
+           "numThreads"_a = 1,
+           "Pick a subset of items from a pool of items using the "
+           "user-provided function to determine distances. Note that the "
+           "numThreads argument is currently ignored.");
+}

--- a/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
@@ -1,0 +1,256 @@
+//
+//  Copyright (C) 2003-2017  Greg Landrum and Rational Discovery LLC
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+
+#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
+#include <RDBoost/python.h>
+#include <RDBoost/Wrap.h>
+#include <RDBoost/boost_numpy.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+#include <map>
+
+#include "PickerHelpers.h"
+
+#include <DataStructs/BitVects.h>
+#include <DataStructs/BitOps.h>
+#include <SimDivPickers/DistPicker.h>
+#include <SimDivPickers/MaxMinPicker.h>
+#include <SimDivPickers/HierarchicalClusterPicker.h>
+#include <utility>
+
+namespace python = boost::python;
+namespace RDPickers {
+
+// REVIEW: the poolSize can be pulled from the numeric array
+RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, python::object distMat,
+                            int poolSize, int pickSize,
+                            python::object firstPicks, int seed) {
+  if (pickSize >= poolSize) {
+    throw ValueErrorException("pickSize must be less than poolSize");
+  }
+
+  if (!PyArray_Check(distMat.ptr())) {
+    throw ValueErrorException("distance mat argument must be a numpy matrix");
+  }
+
+  PyArrayObject *copy;
+  copy = (PyArrayObject *)PyArray_ContiguousFromObject(distMat.ptr(),
+                                                       NPY_DOUBLE, 1, 1);
+  auto *dMat = (double *)PyArray_DATA(copy);
+
+  RDKit::INT_VECT firstPickVect;
+  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
+    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
+  }
+  RDKit::INT_VECT res;
+  try {
+    res = picker->pick(dMat, poolSize, pickSize, firstPickVect, seed);
+  } catch (...) {
+    Py_DECREF(copy);
+    throw;
+  }
+  Py_DECREF(copy);
+  return res;
+}
+
+namespace {
+template <typename T>
+void LazyMaxMinHelper(MaxMinPicker *picker, T functor, unsigned int poolSize,
+                      unsigned int pickSize, python::object firstPicks,
+                      int seed, RDKit::INT_VECT &res, double &threshold) {
+  RDKit::INT_VECT firstPickVect;
+  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
+    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
+  }
+  res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, seed,
+                         threshold);
+}
+}  // end of anonymous namespace
+
+RDKit::INT_VECT LazyMaxMinPicks(MaxMinPicker *picker, python::object distFunc,
+                                int poolSize, int pickSize,
+                                python::object firstPicks, int seed,
+                                python::object useCache) {
+  if (useCache != python::object()) {
+    BOOST_LOG(rdWarningLog)
+        << "the useCache argument is deprecated and ignored" << std::endl;
+  }
+  pyobjFunctor functor(distFunc);
+  RDKit::INT_VECT res;
+  double threshold = -1.;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
+  return res;
+}
+python::tuple LazyMaxMinPicksWithThreshold(
+    MaxMinPicker *picker, python::object distFunc, int poolSize, int pickSize,
+    double threshold, python::object firstPicks, int seed) {
+  pyobjFunctor functor(distFunc);
+  RDKit::INT_VECT res;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
+  return python::make_tuple(res, threshold);
+}
+
+RDKit::INT_VECT LazyVectorMaxMinPicks(MaxMinPicker *picker, python::object objs,
+                                      int poolSize, int pickSize,
+                                      python::object firstPicks, int seed,
+                                      python::object useCache) {
+  if (useCache != python::object()) {
+    BOOST_LOG(rdWarningLog)
+        << "the useCache argument is deprecated and ignored" << std::endl;
+  }
+  std::vector<const ExplicitBitVect *> bvs(poolSize);
+  for (int i = 0; i < poolSize; ++i) {
+    bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
+  }
+  pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
+
+  RDKit::INT_VECT res;
+  double threshold = -1.;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
+  return res;
+}
+
+python::tuple LazyVectorMaxMinPicksWithThreshold(
+    MaxMinPicker *picker, python::object objs, int poolSize, int pickSize,
+    double threshold, python::object firstPicks, int seed) {
+  std::vector<const ExplicitBitVect *> bvs(poolSize);
+  for (int i = 0; i < poolSize; ++i) {
+    bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
+  }
+  pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
+
+  RDKit::INT_VECT res;
+  LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
+                   threshold);
+  return python::make_tuple(res, threshold);
+}
+
+}  // end of namespace RDPickers
+
+struct MaxMin_wrap {
+  static void wrap() {
+    python::class_<RDPickers::MaxMinPicker>(
+        "MaxMinPicker",
+        "A class for diversity picking of items using the MaxMin Algorithm\n")
+        .def("Pick", RDPickers::MaxMinPicks,
+             (python::arg("self"), python::arg("distMat"),
+              python::arg("poolSize"), python::arg("pickSize"),
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("seed") = -1),
+             "Pick a subset of items from a pool of items using the MaxMin "
+             "Algorithm\n"
+             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
+             "598-604 \n\n"
+             "ARGUMENTS:\n"
+             "  - distMat: 1D distance matrix (only the lower triangle "
+             "elements)\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n"
+             "  - firstPicks: (optional) the first items to be picked (seeds "
+             "the list)\n"
+             "  - seed: (optional) seed for the random number generator\n")
+
+        .def("LazyPick", RDPickers::LazyMaxMinPicks,
+             (python::arg("self"), python::arg("distFunc"),
+              python::arg("poolSize"), python::arg("pickSize"),
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("seed") = -1,
+              python::arg("useCache") = python::object()),
+             "Pick a subset of items from a pool of items using the MaxMin "
+             "Algorithm\n"
+             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
+             "598-604 \n"
+             "ARGUMENTS:\n\n"
+             "  - distFunc: a function that should take two indices and return "
+             "the\n"
+             "              distance between those two points.\n"
+             "              NOTE: the implementation caches distance values, "
+             "so the\n"
+             "              client code does not need to do so; indeed, it "
+             "should not.\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n"
+             "  - firstPicks: (optional) the first items to be picked (seeds "
+             "the list)\n"
+             "  - seed: (optional) seed for the random number generator\n"
+             "  - useCache: IGNORED\n")
+        .def("LazyBitVectorPick", RDPickers::LazyVectorMaxMinPicks,
+             (python::arg("self"), python::arg("objects"),
+              python::arg("poolSize"), python::arg("pickSize"),
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("seed") = -1,
+              python::arg("useCache") = python::object()),
+             "Pick a subset of items from a pool of bit vectors using the "
+             "MaxMin Algorithm\n"
+             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
+             "598-604 \n"
+             "ARGUMENTS:\n\n"
+             "  - vectors: a sequence of the bit vectors that should be picked "
+             "from.\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n"
+             "  - firstPicks: (optional) the first items to be picked (seeds "
+             "the list)\n"
+             "  - seed: (optional) seed for the random number generator\n"
+             "  - useCache: IGNORED.\n")
+
+        .def("LazyPickWithThreshold", RDPickers::LazyMaxMinPicksWithThreshold,
+             (python::arg("self"), python::arg("distFunc"),
+              python::arg("poolSize"), python::arg("pickSize"),
+              python::arg("threshold"),
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("seed") = -1),
+             "Pick a subset of items from a pool of items using the MaxMin "
+             "Algorithm\n"
+             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
+             "598-604 \n"
+             "ARGUMENTS:\n\n"
+             "  - distFunc: a function that should take two indices and return "
+             "the\n"
+             "              distance between those two points.\n"
+             "              NOTE: the implementation caches distance values, "
+             "so the\n"
+             "              client code does not need to do so; indeed, it "
+             "should not.\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n"
+             "  - threshold: stop picking when the distance goes below this "
+             "value\n"
+             "  - firstPicks: (optional) the first items to be picked (seeds "
+             "the list)\n"
+             "  - seed: (optional) seed for the random number generator\n")
+        .def("LazyBitVectorPickWithThreshold",
+             RDPickers::LazyVectorMaxMinPicksWithThreshold,
+             (python::arg("self"), python::arg("objects"),
+              python::arg("poolSize"), python::arg("pickSize"),
+              python::arg("threshold"),
+              python::arg("firstPicks") = python::tuple(),
+              python::arg("seed") = -1),
+             "Pick a subset of items from a pool of bit vectors using the "
+             "MaxMin Algorithm\n"
+             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
+             "598-604 \n"
+             "ARGUMENTS:\n\n"
+             "  - vectors: a sequence of the bit vectors that should be picked "
+             "from.\n"
+             "  - poolSize: number of items in the pool\n"
+             "  - pickSize: number of items to pick from the pool\n"
+             "  - threshold: stop picking when the distance goes below this "
+             "value\n"
+             "  - firstPicks: (optional) the first items to be picked (seeds "
+             "the list)\n"
+             "  - seed: (optional) seed for the random number generator\n");
+  };
+};
+
+void wrap_maxminpick() { MaxMin_wrap::wrap(); }

--- a/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
@@ -9,9 +9,10 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/stl/tuple.h>
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_nb_array_API
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
-#include <RDBoost/import_array.h>
 
 #include "PickerHelpers.h"
 

--- a/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
@@ -143,6 +143,7 @@ void wrap_maxminpick(nb::module_ &m) {
   nb::class_<RDPickers::MaxMinPicker>(
       m, "MaxMinPicker",
       "A class for diversity picking of items using the MaxMin Algorithm\n")
+      .def(nb::init<>())
       .def("Pick", RDPickers::MaxMinPicks,
            "distMat"_a, "poolSize"_a, "pickSize"_a,
            "firstPicks"_a = nb::tuple(), "seed"_a = -1,

--- a/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
@@ -1,20 +1,17 @@
 //
-//  Copyright (C) 2003-2017  Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-
-#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
-#include <RDBoost/python.h>
-#include <RDBoost/Wrap.h>
-#include <RDBoost/boost_numpy.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/tuple.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
-#include <map>
+#include <RDBoost/import_array.h>
 
 #include "PickerHelpers.h"
 
@@ -25,19 +22,21 @@
 #include <SimDivPickers/HierarchicalClusterPicker.h>
 #include <utility>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
+
 namespace RDPickers {
 
 // REVIEW: the poolSize can be pulled from the numeric array
-RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, python::object distMat,
+RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, nb::object distMat,
                             int poolSize, int pickSize,
-                            python::object firstPicks, int seed) {
+                            nb::object firstPicks, int seed) {
   if (pickSize >= poolSize) {
-    throw ValueErrorException("pickSize must be less than poolSize");
+    throw nb::value_error("pickSize must be less than poolSize");
   }
 
   if (!PyArray_Check(distMat.ptr())) {
-    throw ValueErrorException("distance mat argument must be a numpy matrix");
+    throw nb::value_error("distance mat argument must be a numpy matrix");
   }
 
   PyArrayObject *copy;
@@ -46,8 +45,9 @@ RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, python::object distMat,
   auto *dMat = (double *)PyArray_DATA(copy);
 
   RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
-    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
+  auto len = nb::len(firstPicks);
+  for (size_t i = 0; i < len; ++i) {
+    firstPickVect.push_back(nb::cast<int>(firstPicks[i]));
   }
   RDKit::INT_VECT res;
   try {
@@ -63,22 +63,23 @@ RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, python::object distMat,
 namespace {
 template <typename T>
 void LazyMaxMinHelper(MaxMinPicker *picker, T functor, unsigned int poolSize,
-                      unsigned int pickSize, python::object firstPicks,
+                      unsigned int pickSize, nb::object firstPicks,
                       int seed, RDKit::INT_VECT &res, double &threshold) {
   RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
-    firstPickVect.push_back(python::extract<int>(firstPicks[i]));
+  auto len = nb::len(firstPicks);
+  for (size_t i = 0; i < len; ++i) {
+    firstPickVect.push_back(nb::cast<int>(firstPicks[i]));
   }
   res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, seed,
                          threshold);
 }
 }  // end of anonymous namespace
 
-RDKit::INT_VECT LazyMaxMinPicks(MaxMinPicker *picker, python::object distFunc,
+RDKit::INT_VECT LazyMaxMinPicks(MaxMinPicker *picker, nb::object distFunc,
                                 int poolSize, int pickSize,
-                                python::object firstPicks, int seed,
-                                python::object useCache) {
-  if (useCache != python::object()) {
+                                nb::object firstPicks, int seed,
+                                nb::object useCache) {
+  if (!useCache.is_none()) {
     BOOST_LOG(rdWarningLog)
         << "the useCache argument is deprecated and ignored" << std::endl;
   }
@@ -89,27 +90,28 @@ RDKit::INT_VECT LazyMaxMinPicks(MaxMinPicker *picker, python::object distFunc,
                    threshold);
   return res;
 }
-python::tuple LazyMaxMinPicksWithThreshold(
-    MaxMinPicker *picker, python::object distFunc, int poolSize, int pickSize,
-    double threshold, python::object firstPicks, int seed) {
+
+std::tuple<RDKit::INT_VECT, double> LazyMaxMinPicksWithThreshold(
+    MaxMinPicker *picker, nb::object distFunc, int poolSize, int pickSize,
+    double threshold, nb::object firstPicks, int seed) {
   pyobjFunctor functor(distFunc);
   RDKit::INT_VECT res;
   LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
                    threshold);
-  return python::make_tuple(res, threshold);
+  return std::make_tuple(res, threshold);
 }
 
-RDKit::INT_VECT LazyVectorMaxMinPicks(MaxMinPicker *picker, python::object objs,
+RDKit::INT_VECT LazyVectorMaxMinPicks(MaxMinPicker *picker, nb::object objs,
                                       int poolSize, int pickSize,
-                                      python::object firstPicks, int seed,
-                                      python::object useCache) {
-  if (useCache != python::object()) {
+                                      nb::object firstPicks, int seed,
+                                      nb::object useCache) {
+  if (!useCache.is_none()) {
     BOOST_LOG(rdWarningLog)
         << "the useCache argument is deprecated and ignored" << std::endl;
   }
   std::vector<const ExplicitBitVect *> bvs(poolSize);
   for (int i = 0; i < poolSize; ++i) {
-    bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
+    bvs[i] = nb::cast<const ExplicitBitVect *>(objs[i]);
   }
   pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
 
@@ -120,137 +122,107 @@ RDKit::INT_VECT LazyVectorMaxMinPicks(MaxMinPicker *picker, python::object objs,
   return res;
 }
 
-python::tuple LazyVectorMaxMinPicksWithThreshold(
-    MaxMinPicker *picker, python::object objs, int poolSize, int pickSize,
-    double threshold, python::object firstPicks, int seed) {
+std::tuple<RDKit::INT_VECT, double> LazyVectorMaxMinPicksWithThreshold(
+    MaxMinPicker *picker, nb::object objs, int poolSize, int pickSize,
+    double threshold, nb::object firstPicks, int seed) {
   std::vector<const ExplicitBitVect *> bvs(poolSize);
   for (int i = 0; i < poolSize; ++i) {
-    bvs[i] = python::extract<const ExplicitBitVect *>(objs[i]);
+    bvs[i] = nb::cast<const ExplicitBitVect *>(objs[i]);
   }
   pyBVFunctor<ExplicitBitVect> functor(bvs, TANIMOTO);
 
   RDKit::INT_VECT res;
   LazyMaxMinHelper(picker, functor, poolSize, pickSize, firstPicks, seed, res,
                    threshold);
-  return python::make_tuple(res, threshold);
+  return std::make_tuple(res, threshold);
 }
 
 }  // end of namespace RDPickers
 
-struct MaxMin_wrap {
-  static void wrap() {
-    python::class_<RDPickers::MaxMinPicker>(
-        "MaxMinPicker",
-        "A class for diversity picking of items using the MaxMin Algorithm\n")
-        .def("Pick", RDPickers::MaxMinPicks,
-             (python::arg("self"), python::arg("distMat"),
-              python::arg("poolSize"), python::arg("pickSize"),
-              python::arg("firstPicks") = python::tuple(),
-              python::arg("seed") = -1),
-             "Pick a subset of items from a pool of items using the MaxMin "
-             "Algorithm\n"
-             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
-             "598-604 \n\n"
-             "ARGUMENTS:\n"
-             "  - distMat: 1D distance matrix (only the lower triangle "
-             "elements)\n"
-             "  - poolSize: number of items in the pool\n"
-             "  - pickSize: number of items to pick from the pool\n"
-             "  - firstPicks: (optional) the first items to be picked (seeds "
-             "the list)\n"
-             "  - seed: (optional) seed for the random number generator\n")
+void wrap_maxminpick(nb::module_ &m) {
+  nb::class_<RDPickers::MaxMinPicker>(
+      m, "MaxMinPicker",
+      "A class for diversity picking of items using the MaxMin Algorithm\n")
+      .def("Pick", RDPickers::MaxMinPicks,
+           "distMat"_a, "poolSize"_a, "pickSize"_a,
+           "firstPicks"_a = nb::tuple(), "seed"_a = -1,
+           R"DOC(Pick a subset of items from a pool of items using the MaxMin Algorithm
+Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), 598-604
 
-        .def("LazyPick", RDPickers::LazyMaxMinPicks,
-             (python::arg("self"), python::arg("distFunc"),
-              python::arg("poolSize"), python::arg("pickSize"),
-              python::arg("firstPicks") = python::tuple(),
-              python::arg("seed") = -1,
-              python::arg("useCache") = python::object()),
-             "Pick a subset of items from a pool of items using the MaxMin "
-             "Algorithm\n"
-             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
-             "598-604 \n"
-             "ARGUMENTS:\n\n"
-             "  - distFunc: a function that should take two indices and return "
-             "the\n"
-             "              distance between those two points.\n"
-             "              NOTE: the implementation caches distance values, "
-             "so the\n"
-             "              client code does not need to do so; indeed, it "
-             "should not.\n"
-             "  - poolSize: number of items in the pool\n"
-             "  - pickSize: number of items to pick from the pool\n"
-             "  - firstPicks: (optional) the first items to be picked (seeds "
-             "the list)\n"
-             "  - seed: (optional) seed for the random number generator\n"
-             "  - useCache: IGNORED\n")
-        .def("LazyBitVectorPick", RDPickers::LazyVectorMaxMinPicks,
-             (python::arg("self"), python::arg("objects"),
-              python::arg("poolSize"), python::arg("pickSize"),
-              python::arg("firstPicks") = python::tuple(),
-              python::arg("seed") = -1,
-              python::arg("useCache") = python::object()),
-             "Pick a subset of items from a pool of bit vectors using the "
-             "MaxMin Algorithm\n"
-             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
-             "598-604 \n"
-             "ARGUMENTS:\n\n"
-             "  - vectors: a sequence of the bit vectors that should be picked "
-             "from.\n"
-             "  - poolSize: number of items in the pool\n"
-             "  - pickSize: number of items to pick from the pool\n"
-             "  - firstPicks: (optional) the first items to be picked (seeds "
-             "the list)\n"
-             "  - seed: (optional) seed for the random number generator\n"
-             "  - useCache: IGNORED.\n")
+ARGUMENTS:
+  - distMat: 1D distance matrix (only the lower triangle elements)
+  - poolSize: number of items in the pool
+  - pickSize: number of items to pick from the pool
+  - firstPicks: (optional) the first items to be picked (seeds the list)
+  - seed: (optional) seed for the random number generator
+)DOC")
 
-        .def("LazyPickWithThreshold", RDPickers::LazyMaxMinPicksWithThreshold,
-             (python::arg("self"), python::arg("distFunc"),
-              python::arg("poolSize"), python::arg("pickSize"),
-              python::arg("threshold"),
-              python::arg("firstPicks") = python::tuple(),
-              python::arg("seed") = -1),
-             "Pick a subset of items from a pool of items using the MaxMin "
-             "Algorithm\n"
-             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
-             "598-604 \n"
-             "ARGUMENTS:\n\n"
-             "  - distFunc: a function that should take two indices and return "
-             "the\n"
-             "              distance between those two points.\n"
-             "              NOTE: the implementation caches distance values, "
-             "so the\n"
-             "              client code does not need to do so; indeed, it "
-             "should not.\n"
-             "  - poolSize: number of items in the pool\n"
-             "  - pickSize: number of items to pick from the pool\n"
-             "  - threshold: stop picking when the distance goes below this "
-             "value\n"
-             "  - firstPicks: (optional) the first items to be picked (seeds "
-             "the list)\n"
-             "  - seed: (optional) seed for the random number generator\n")
-        .def("LazyBitVectorPickWithThreshold",
-             RDPickers::LazyVectorMaxMinPicksWithThreshold,
-             (python::arg("self"), python::arg("objects"),
-              python::arg("poolSize"), python::arg("pickSize"),
-              python::arg("threshold"),
-              python::arg("firstPicks") = python::tuple(),
-              python::arg("seed") = -1),
-             "Pick a subset of items from a pool of bit vectors using the "
-             "MaxMin Algorithm\n"
-             "Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), "
-             "598-604 \n"
-             "ARGUMENTS:\n\n"
-             "  - vectors: a sequence of the bit vectors that should be picked "
-             "from.\n"
-             "  - poolSize: number of items in the pool\n"
-             "  - pickSize: number of items to pick from the pool\n"
-             "  - threshold: stop picking when the distance goes below this "
-             "value\n"
-             "  - firstPicks: (optional) the first items to be picked (seeds "
-             "the list)\n"
-             "  - seed: (optional) seed for the random number generator\n");
-  };
-};
+      .def("LazyPick", RDPickers::LazyMaxMinPicks,
+           "distFunc"_a, "poolSize"_a, "pickSize"_a,
+           "firstPicks"_a = nb::tuple(), "seed"_a = -1,
+           "useCache"_a = nb::none(),
+           R"DOC(Pick a subset of items from a pool of items using the MaxMin Algorithm
+Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), 598-604
+ARGUMENTS:
 
-void wrap_maxminpick() { MaxMin_wrap::wrap(); }
+  - distFunc: a function that should take two indices and return the
+              distance between those two points.
+              NOTE: the implementation caches distance values, so the
+              client code does not need to do so; indeed, it should not.
+  - poolSize: number of items in the pool
+  - pickSize: number of items to pick from the pool
+  - firstPicks: (optional) the first items to be picked (seeds the list)
+  - seed: (optional) seed for the random number generator
+  - useCache: IGNORED
+)DOC")
+      .def("LazyBitVectorPick", RDPickers::LazyVectorMaxMinPicks,
+           "objects"_a, "poolSize"_a, "pickSize"_a,
+           "firstPicks"_a = nb::tuple(), "seed"_a = -1,
+           "useCache"_a = nb::none(),
+           R"DOC(Pick a subset of items from a pool of bit vectors using the MaxMin Algorithm
+Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), 598-604
+ARGUMENTS:
+
+  - vectors: a sequence of the bit vectors that should be picked from.
+  - poolSize: number of items in the pool
+  - pickSize: number of items to pick from the pool
+  - firstPicks: (optional) the first items to be picked (seeds the list)
+  - seed: (optional) seed for the random number generator
+  - useCache: IGNORED.
+)DOC")
+
+      .def("LazyPickWithThreshold", RDPickers::LazyMaxMinPicksWithThreshold,
+           "distFunc"_a, "poolSize"_a, "pickSize"_a,
+           "threshold"_a,
+           "firstPicks"_a = nb::tuple(), "seed"_a = -1,
+           R"DOC(Pick a subset of items from a pool of items using the MaxMin Algorithm
+Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), 598-604
+ARGUMENTS:
+
+  - distFunc: a function that should take two indices and return the
+              distance between those two points.
+              NOTE: the implementation caches distance values, so the
+              client code does not need to do so; indeed, it should not.
+  - poolSize: number of items in the pool
+  - pickSize: number of items to pick from the pool
+  - threshold: stop picking when the distance goes below this value
+  - firstPicks: (optional) the first items to be picked (seeds the list)
+  - seed: (optional) seed for the random number generator
+)DOC")
+      .def("LazyBitVectorPickWithThreshold",
+           RDPickers::LazyVectorMaxMinPicksWithThreshold,
+           "objects"_a, "poolSize"_a, "pickSize"_a,
+           "threshold"_a,
+           "firstPicks"_a = nb::tuple(), "seed"_a = -1,
+           R"DOC(Pick a subset of items from a pool of bit vectors using the MaxMin Algorithm
+Ashton, M. et. al., Quant. Struct.-Act. Relat., 21 (2002), 598-604
+ARGUMENTS:
+
+  - vectors: a sequence of the bit vectors that should be picked from.
+  - poolSize: number of items in the pool
+  - pickSize: number of items to pick from the pool
+  - threshold: stop picking when the distance goes below this value
+  - firstPicks: (optional) the first items to be picked (seeds the list)
+  - seed: (optional) seed for the random number generator
+)DOC");
+}

--- a/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/nbWrap/MaxMinPicker.cpp
@@ -9,10 +9,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
 #include <nanobind/stl/tuple.h>
-#define NO_IMPORT_ARRAY
-#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_nb_array_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
+#include <nanobind/ndarray.h>
 
 #include "PickerHelpers.h"
 
@@ -29,36 +26,23 @@ using namespace nb::literals;
 namespace RDPickers {
 
 // REVIEW: the poolSize can be pulled from the numeric array
-RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, nb::object distMat,
+RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker,
+                            nb::ndarray<nb::numpy, double, nb::ndim<1>,
+                                        nb::c_contig> distMat,
                             int poolSize, int pickSize,
                             nb::object firstPicks, int seed) {
   if (pickSize >= poolSize) {
     throw nb::value_error("pickSize must be less than poolSize");
   }
 
-  if (!PyArray_Check(distMat.ptr())) {
-    throw nb::value_error("distance mat argument must be a numpy matrix");
-  }
-
-  PyArrayObject *copy;
-  copy = (PyArrayObject *)PyArray_ContiguousFromObject(distMat.ptr(),
-                                                       NPY_DOUBLE, 1, 1);
-  auto *dMat = (double *)PyArray_DATA(copy);
+  auto *dMat = distMat.data();
 
   RDKit::INT_VECT firstPickVect;
   auto len = nb::len(firstPicks);
   for (size_t i = 0; i < len; ++i) {
     firstPickVect.push_back(nb::cast<int>(firstPicks[i]));
   }
-  RDKit::INT_VECT res;
-  try {
-    res = picker->pick(dMat, poolSize, pickSize, firstPickVect, seed);
-  } catch (...) {
-    Py_DECREF(copy);
-    throw;
-  }
-  Py_DECREF(copy);
-  return res;
+  return picker->pick(dMat, poolSize, pickSize, firstPickVect, seed);
 }
 
 namespace {

--- a/Code/SimDivPickers/nbWrap/PickerHelpers.h
+++ b/Code/SimDivPickers/nbWrap/PickerHelpers.h
@@ -1,0 +1,59 @@
+//
+//  Copyright (C) 2019  Greg Landrum
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#ifndef RDKIT_PICKERHELPERS_H
+#define RDKIT_PICKERHELPERS_H
+
+#include <vector>
+#include <DataStructs/BitOps.h>
+
+// NOTE: TANIMOTO and DICE provably return the same results for the diversity
+// picking this is still here just in case we ever later want to support other
+//    methods.
+typedef enum { TANIMOTO = 1, DICE } DistanceMethod;
+
+template <typename BV>
+class pyBVFunctor {
+ public:
+  pyBVFunctor(const std::vector<const BV *> &obj, DistanceMethod method)
+      : d_obj(obj), d_method(method) {}
+  ~pyBVFunctor() = default;
+  double operator()(unsigned int i, unsigned int j) {
+    double res = 0.0;
+    switch (d_method) {
+      case TANIMOTO:
+        res = 1. - TanimotoSimilarity(*d_obj[i], *d_obj[j]);
+        break;
+      case DICE:
+        res = 1. - DiceSimilarity(*d_obj[i], *d_obj[j]);
+        break;
+      default:
+        throw_value_error("unsupported similarity value");
+    }
+    return res;
+  }
+
+ private:
+  const std::vector<const BV *> &d_obj;
+  DistanceMethod d_method;
+};
+
+class pyobjFunctor {
+ public:
+  pyobjFunctor(python::object obj) : dp_obj(std::move(obj)) {}
+  ~pyobjFunctor() = default;
+  double operator()(unsigned int i, unsigned int j) {
+    return python::extract<double>(dp_obj(i, j));
+  }
+
+ private:
+  python::object dp_obj;
+};
+
+#endif  // RDKIT_PICKERHELPERS_H

--- a/Code/SimDivPickers/nbWrap/PickerHelpers.h
+++ b/Code/SimDivPickers/nbWrap/PickerHelpers.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2019  Greg Landrum
+//  Copyright (C) 2019-2026 Greg Landrum and other RDKit contributors
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -12,6 +12,9 @@
 
 #include <vector>
 #include <DataStructs/BitOps.h>
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
 
 // NOTE: TANIMOTO and DICE provably return the same results for the diversity
 // picking this is still here just in case we ever later want to support other
@@ -34,7 +37,7 @@ class pyBVFunctor {
         res = 1. - DiceSimilarity(*d_obj[i], *d_obj[j]);
         break;
       default:
-        throw_value_error("unsupported similarity value");
+        throw nb::value_error("unsupported similarity value");
     }
     return res;
   }
@@ -46,14 +49,14 @@ class pyBVFunctor {
 
 class pyobjFunctor {
  public:
-  pyobjFunctor(python::object obj) : dp_obj(std::move(obj)) {}
+  pyobjFunctor(nb::object obj) : dp_obj(std::move(obj)) {}
   ~pyobjFunctor() = default;
   double operator()(unsigned int i, unsigned int j) {
-    return python::extract<double>(dp_obj(i, j));
+    return nb::cast<double>(dp_obj(i, j));
   }
 
  private:
-  python::object dp_obj;
+  nb::object dp_obj;
 };
 
 #endif  // RDKIT_PICKERHELPERS_H

--- a/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
+++ b/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
@@ -1,0 +1,30 @@
+//
+//  Copyright (C) 2003-2006 Rational Discovery LLC
+//  Copyright (C) 2019 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
+#include <RDBoost/Wrap.h>
+#include <RDBoost/import_array.h>
+
+namespace python = boost::python;
+
+void wrap_maxminpick();
+void wrap_leaderpick();
+void wrap_HierarchCP();
+
+BOOST_PYTHON_MODULE(rdSimDivPickers) {
+  python::scope().attr("__doc__") =
+      "Module containing the diversity and similarity pickers";
+
+  rdkit_import_array();
+
+  wrap_maxminpick();
+  wrap_leaderpick();
+  wrap_HierarchCP();
+}

--- a/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
+++ b/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
@@ -1,6 +1,5 @@
 //
-//  Copyright (C) 2003-2006 Rational Discovery LLC
-//  Copyright (C) 2019 Greg Landrum
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,23 +7,19 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_array_API
-#include <RDBoost/Wrap.h>
-#include <RDBoost/import_array.h>
+#include <nanobind/nanobind.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
-void wrap_maxminpick();
-void wrap_leaderpick();
-void wrap_HierarchCP();
+void wrap_maxminpick(nb::module_ &m);
+void wrap_leaderpick(nb::module_ &m);
+void wrap_HierarchCP(nb::module_ &m);
 
-BOOST_PYTHON_MODULE(rdSimDivPickers) {
-  python::scope().attr("__doc__") =
-      "Module containing the diversity and similarity pickers";
+NB_MODULE(rdSimDivPickers, m) {
+  m.doc() = "Module containing the diversity and similarity pickers";
 
-  rdkit_import_array();
-
-  wrap_maxminpick();
-  wrap_leaderpick();
-  wrap_HierarchCP();
+  wrap_maxminpick(m);
+  wrap_leaderpick(m);
+  wrap_HierarchCP(m);
 }

--- a/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
+++ b/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
@@ -8,9 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <nanobind/nanobind.h>
-#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_nb_array_API
-#include <RDBoost/import_array.h>
-
 namespace nb = nanobind;
 using namespace nb::literals;
 
@@ -20,8 +17,6 @@ void wrap_HierarchCP(nb::module_ &m);
 
 NB_MODULE(rdSimDivPickers, m) {
   m.doc() = "Module containing the diversity and similarity pickers";
-
-  rdkit_import_array();
 
   wrap_maxminpick(m);
   wrap_leaderpick(m);

--- a/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
+++ b/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 #include <nanobind/nanobind.h>
+#include <RDBoost/import_array.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -18,6 +19,8 @@ void wrap_HierarchCP(nb::module_ &m);
 
 NB_MODULE(rdSimDivPickers, m) {
   m.doc() = "Module containing the diversity and similarity pickers";
+
+  rdkit_import_array();
 
   wrap_maxminpick(m);
   wrap_leaderpick(m);

--- a/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
+++ b/Code/SimDivPickers/nbWrap/rdSimDivPickers.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 #include <nanobind/nanobind.h>
+#define PY_ARRAY_UNIQUE_SYMBOL rdpicker_nb_array_API
 #include <RDBoost/import_array.h>
 
 namespace nb = nanobind;


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to SimDivPickers.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.