### PR TITLE
pr/SHARED-12390: Implement nanobind for MolStandardize

### DIFF
--- a/Code/GraphMol/MolStandardize/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/CMakeLists.txt
@@ -61,6 +61,10 @@ if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
 
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()
+
 rdkit_test(molStandardizeTest test1.cpp LINK_LIBRARIES MolStandardize )
 rdkit_test(molNormalizeTest testNormalize.cpp LINK_LIBRARIES MolStandardize )
 rdkit_test(molValidateTest testValidate.cpp LINK_LIBRARIES MolStandardize )

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -10,7 +10,12 @@ from datetime import datetime, timedelta
 
 from rdkit import Chem, DataStructs, RDConfig
 from rdkit.Chem.MolStandardize import rdMolStandardize
-from rdkit.Chem import inchi, rdCIPLabeler
+try:
+  from rdkit.Chem import inchi
+  haveInchi = True
+except ImportError:
+  haveInchi = False
+from rdkit.Chem import rdCIPLabeler
 from rdkit.Chem.rdchem import Atom
 from rdkit.Geometry import rdGeometry as geom
 
@@ -1904,7 +1909,7 @@ M  END
       ctaut = enumerator.Canonicalize(m2, score_func2)
       self.assertEqual(Chem.MolToSmiles(ctaut), Chem.CanonSmiles("C1(=CCCCC1)O"))
 
-  @unittest.skipUnless(inchi.INCHI_AVAILABLE, 'Inchi required')
+  @unittest.skipUnless(haveInchi, 'Inchi required')
   def testTautomerCanonicalizeNoInchiBondStereoFrom2DCoords(self):
 
     molblock = """

--- a/Code/GraphMol/MolStandardize/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/nbWrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+remove_definitions(-DRDKIT_MOLSTANDARDIZE_BUILD)
+rdkit_python_extension(rdMolStandardize rdMolStandardize.cpp Validate.cpp
+	Charge.cpp Fragment.cpp Normalize.cpp Metal.cpp Tautomer.cpp Pipeline.cpp
+                       DEST Chem/MolStandardize
+                       LINK_LIBRARIES
+LINK_LIBRARIES MolStandardize )
+
+add_pytest(pyMolStandardize ${CMAKE_CURRENT_SOURCE_DIR}/testMolStandardize.py)

--- a/Code/GraphMol/MolStandardize/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolStandardize/nbWrap/CMakeLists.txt
@@ -1,8 +1,7 @@
 remove_definitions(-DRDKIT_MOLSTANDARDIZE_BUILD)
-rdkit_python_extension(rdMolStandardize rdMolStandardize.cpp Validate.cpp
+rdkit_nanobind_extension(rdMolStandardize rdMolStandardize.cpp Validate.cpp
 	Charge.cpp Fragment.cpp Normalize.cpp Metal.cpp Tautomer.cpp Pipeline.cpp
                        DEST Chem/MolStandardize
-                       LINK_LIBRARIES
-LINK_LIBRARIES MolStandardize )
+                       LINK_LIBRARIES MolStandardize)
 
-add_pytest(pyMolStandardize ${CMAKE_CURRENT_SOURCE_DIR}/testMolStandardize.py)
+add_pytest(pyMolStandardize ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testMolStandardize.py)

--- a/Code/GraphMol/MolStandardize/nbWrap/Charge.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Charge.cpp
@@ -1,0 +1,103 @@
+//
+//  Copyright (C) 2018 Susan H. Leung
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/Charge.h>
+
+namespace python = boost::python;
+using namespace RDKit;
+
+namespace {
+
+std::vector<MolStandardize::ChargeCorrection> defaultChargeCorrections() {
+  return MolStandardize::CHARGE_CORRECTIONS;
+}
+
+ROMol *reionizeHelper(MolStandardize::Reionizer &self, const ROMol &mol) {
+  return self.reionize(mol);
+}
+
+void reionizeInPlaceHelper(MolStandardize::Reionizer &self, ROMol &mol) {
+  self.reionizeInPlace(static_cast<RWMol &>(mol));
+}
+MolStandardize::Reionizer *reionizerFromData(const std::string &data,
+                                             python::object chargeCorrections) {
+  std::istringstream sstr(data);
+  auto corrections =
+      pythonObjectToVect<MolStandardize::ChargeCorrection>(chargeCorrections);
+  MolStandardize::Reionizer *res;
+  if (corrections) {
+    res = new MolStandardize::Reionizer(sstr, *corrections);
+  } else {
+    res = new MolStandardize::Reionizer(
+        sstr, std::vector<MolStandardize::ChargeCorrection>());
+  }
+  return res;
+}
+
+void unchargeInPlaceHelper(MolStandardize::Uncharger &self, ROMol &mol) {
+  self.unchargeInPlace(static_cast<RWMol &>(mol));
+}
+
+}  // namespace
+
+struct charge_wrapper {
+  static void wrap() {
+    python::scope().attr("__doc__") =
+        "Module containing functions for charge corrections";
+
+    std::string docString = "";
+
+    python::class_<MolStandardize::ChargeCorrection, boost::noncopyable>(
+        "ChargeCorrection",
+        python::init<std::string, std::string, int>(
+            python::args("self", "name", "smarts", "charge")))
+        .def_readwrite("Name", &MolStandardize::ChargeCorrection::Name)
+        .def_readwrite("Smarts", &MolStandardize::ChargeCorrection::Smarts)
+        .def_readwrite("Charge", &MolStandardize::ChargeCorrection::Charge);
+
+    python::def("CHARGE_CORRECTIONS", defaultChargeCorrections);
+
+    python::class_<MolStandardize::Reionizer, boost::noncopyable>(
+        "Reionizer", python::init<>(python::args("self")))
+        .def(python::init<std::string>(python::args("self", "acidbaseFile")))
+        .def(python::init<std::string,
+                          std::vector<MolStandardize::ChargeCorrection>>(
+            python::args("self", "acidbaseFile", "ccs")))
+        .def("reionize", &reionizeHelper,
+             (python::arg("self"), python::arg("mol")), "",
+             python::return_value_policy<python::manage_new_object>())
+        .def("reionizeInPlace", reionizeInPlaceHelper,
+             (python::arg("self"), python::arg("mol")),
+             "modifies the input molecule");
+
+    python::def("ReionizerFromData", &reionizerFromData,
+                (python::arg("paramData"),
+                 python::arg("chargeCorrections") = python::list()),
+                "creates a reionizer from a string containing parameter data "
+                "and a list of charge corrections",
+                python::return_value_policy<python::manage_new_object>());
+    python::class_<MolStandardize::Uncharger, boost::noncopyable>(
+        "Uncharger",
+        python::init<bool, bool, bool>(
+            (python::arg("self"), python::arg("canonicalOrder") = true,
+             python::arg("force") = false,
+             python::arg("protonationOnly") = false)))
+        .def("uncharge", &MolStandardize::Uncharger::uncharge,
+             (python::arg("self"), python::arg("mol")), "",
+             python::return_value_policy<python::manage_new_object>())
+        .def("unchargeInPlace", unchargeInPlaceHelper,
+             (python::arg("self"), python::arg("mol")),
+             "modifies the input molecule");
+  }
+};
+
+void wrap_charge() { charge_wrapper::wrap(); }

--- a/Code/GraphMol/MolStandardize/nbWrap/Charge.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Charge.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Susan H. Leung
+//  Copyright (C) 2018-2026 Susan H. Leung and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,12 +7,17 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/Charge.h>
 
-namespace python = boost::python;
+#include <sstream>
+
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 
 namespace {
@@ -28,19 +33,17 @@ ROMol *reionizeHelper(MolStandardize::Reionizer &self, const ROMol &mol) {
 void reionizeInPlaceHelper(MolStandardize::Reionizer &self, ROMol &mol) {
   self.reionizeInPlace(static_cast<RWMol &>(mol));
 }
+
 MolStandardize::Reionizer *reionizerFromData(const std::string &data,
-                                             python::object chargeCorrections) {
+                                             nb::object chargeCorrections) {
   std::istringstream sstr(data);
-  auto corrections =
-      pythonObjectToVect<MolStandardize::ChargeCorrection>(chargeCorrections);
-  MolStandardize::Reionizer *res;
-  if (corrections) {
-    res = new MolStandardize::Reionizer(sstr, *corrections);
-  } else {
-    res = new MolStandardize::Reionizer(
-        sstr, std::vector<MolStandardize::ChargeCorrection>());
+  std::vector<MolStandardize::ChargeCorrection> corrections;
+  if (!chargeCorrections.is_none()) {
+    for (nb::handle h : chargeCorrections) {
+      corrections.push_back(nb::cast<MolStandardize::ChargeCorrection>(h));
+    }
   }
-  return res;
+  return new MolStandardize::Reionizer(sstr, corrections);
 }
 
 void unchargeInPlaceHelper(MolStandardize::Uncharger &self, ROMol &mol) {
@@ -49,55 +52,38 @@ void unchargeInPlaceHelper(MolStandardize::Uncharger &self, ROMol &mol) {
 
 }  // namespace
 
-struct charge_wrapper {
-  static void wrap() {
-    python::scope().attr("__doc__") =
-        "Module containing functions for charge corrections";
+void wrap_charge(nb::module_ &m) {
+  nb::class_<MolStandardize::ChargeCorrection>(m, "ChargeCorrection")
+      .def(nb::init<std::string, std::string, int>(), "name"_a, "smarts"_a,
+           "charge"_a)
+      .def_rw("Name", &MolStandardize::ChargeCorrection::Name)
+      .def_rw("Smarts", &MolStandardize::ChargeCorrection::Smarts)
+      .def_rw("Charge", &MolStandardize::ChargeCorrection::Charge);
 
-    std::string docString = "";
+  m.def("CHARGE_CORRECTIONS", defaultChargeCorrections);
 
-    python::class_<MolStandardize::ChargeCorrection, boost::noncopyable>(
-        "ChargeCorrection",
-        python::init<std::string, std::string, int>(
-            python::args("self", "name", "smarts", "charge")))
-        .def_readwrite("Name", &MolStandardize::ChargeCorrection::Name)
-        .def_readwrite("Smarts", &MolStandardize::ChargeCorrection::Smarts)
-        .def_readwrite("Charge", &MolStandardize::ChargeCorrection::Charge);
+  nb::class_<MolStandardize::Reionizer>(m, "Reionizer")
+      .def(nb::init<>())
+      .def(nb::init<std::string>(), "acidbaseFile"_a)
+      .def(nb::init<std::string,
+                    std::vector<MolStandardize::ChargeCorrection>>(),
+           "acidbaseFile"_a, "ccs"_a)
+      .def("reionize", &reionizeHelper, "mol"_a, "",
+           nb::rv_policy::take_ownership)
+      .def("reionizeInPlace", reionizeInPlaceHelper, "mol"_a,
+           "modifies the input molecule");
 
-    python::def("CHARGE_CORRECTIONS", defaultChargeCorrections);
+  m.def("ReionizerFromData", &reionizerFromData, "paramData"_a,
+        "chargeCorrections"_a = nb::none(),
+        "creates a reionizer from a string containing parameter data "
+        "and a list of charge corrections",
+        nb::rv_policy::take_ownership);
 
-    python::class_<MolStandardize::Reionizer, boost::noncopyable>(
-        "Reionizer", python::init<>(python::args("self")))
-        .def(python::init<std::string>(python::args("self", "acidbaseFile")))
-        .def(python::init<std::string,
-                          std::vector<MolStandardize::ChargeCorrection>>(
-            python::args("self", "acidbaseFile", "ccs")))
-        .def("reionize", &reionizeHelper,
-             (python::arg("self"), python::arg("mol")), "",
-             python::return_value_policy<python::manage_new_object>())
-        .def("reionizeInPlace", reionizeInPlaceHelper,
-             (python::arg("self"), python::arg("mol")),
-             "modifies the input molecule");
-
-    python::def("ReionizerFromData", &reionizerFromData,
-                (python::arg("paramData"),
-                 python::arg("chargeCorrections") = python::list()),
-                "creates a reionizer from a string containing parameter data "
-                "and a list of charge corrections",
-                python::return_value_policy<python::manage_new_object>());
-    python::class_<MolStandardize::Uncharger, boost::noncopyable>(
-        "Uncharger",
-        python::init<bool, bool, bool>(
-            (python::arg("self"), python::arg("canonicalOrder") = true,
-             python::arg("force") = false,
-             python::arg("protonationOnly") = false)))
-        .def("uncharge", &MolStandardize::Uncharger::uncharge,
-             (python::arg("self"), python::arg("mol")), "",
-             python::return_value_policy<python::manage_new_object>())
-        .def("unchargeInPlace", unchargeInPlaceHelper,
-             (python::arg("self"), python::arg("mol")),
-             "modifies the input molecule");
-  }
-};
-
-void wrap_charge() { charge_wrapper::wrap(); }
+  nb::class_<MolStandardize::Uncharger>(m, "Uncharger")
+      .def(nb::init<bool, bool, bool>(), "canonicalOrder"_a = true,
+           "force"_a = false, "protonationOnly"_a = false)
+      .def("uncharge", &MolStandardize::Uncharger::uncharge, "mol"_a, "",
+           nb::rv_policy::take_ownership)
+      .def("unchargeInPlace", unchargeInPlaceHelper, "mol"_a,
+           "modifies the input molecule");
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Fragment.cpp
@@ -1,0 +1,90 @@
+//
+//  Copyright (C) 2018 Susan H. Leung
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/Fragment.h>
+
+namespace python = boost::python;
+using namespace RDKit;
+
+namespace {
+
+ROMol *removeHelper(MolStandardize::FragmentRemover &self, const ROMol &mol) {
+  return self.remove(mol);
+}
+
+void removeInPlaceHelper(MolStandardize::FragmentRemover &self, ROMol &mol) {
+  self.removeInPlace(static_cast<RWMol &>(mol));
+}
+
+ROMol *chooseHelper(MolStandardize::LargestFragmentChooser &self,
+                    const ROMol &mol) {
+  return self.choose(mol);
+}
+
+void chooseInPlaceHelper(MolStandardize::LargestFragmentChooser &self,
+                         ROMol &mol) {
+  self.chooseInPlace(static_cast<RWMol &>(mol));
+}
+
+MolStandardize::FragmentRemover *removerFromParams(const std::string &data,
+                                                   bool leave_last,
+                                                   bool skip_if_all_match) {
+  std::istringstream sstr(data);
+  return new MolStandardize::FragmentRemover(sstr, leave_last,
+                                             skip_if_all_match);
+}
+
+}  // namespace
+
+struct fragment_wrapper {
+  static void wrap() {
+    python::scope().attr("__doc__") =
+        "Module containing tools for dealing with molecules with more than \
+					one covalently bonded unit";
+
+    std::string docString = "";
+
+    python::class_<MolStandardize::FragmentRemover, boost::noncopyable>(
+        "FragmentRemover", python::init<>(python::args("self")))
+        .def(python::init<std::string, bool, bool>(
+            (python::arg("self"), python::arg("fragmentFilename") = "",
+             python::arg("leave_last") = true,
+             python::arg("skip_if_all_match") = false)))
+        .def("remove", &removeHelper, (python::arg("self"), python::arg("mol")),
+             "", python::return_value_policy<python::manage_new_object>())
+        .def("removeInPlace", &removeInPlaceHelper,
+             (python::arg("self"), python::arg("mol")),
+             "modifies the molecule in place");
+
+    python::def(
+        "FragmentRemoverFromData", &removerFromParams,
+        (python::arg("fragmentData"), python::arg("leave_last") = true,
+         python::arg("skip_if_all_match") = false),
+        "creates a FragmentRemover from a string containing parameter data",
+        python::return_value_policy<python::manage_new_object>());
+
+    python::class_<MolStandardize::LargestFragmentChooser, boost::noncopyable>(
+        "LargestFragmentChooser",
+        python::init<bool>(
+            (python::arg("self"), python::arg("preferOrganic") = false)))
+        .def(python::init<const MolStandardize::CleanupParameters &>(
+            (python::arg("self"), python::arg("params"))))
+        .def("choose", &chooseHelper, (python::arg("self"), python::arg("mol")),
+             "", python::return_value_policy<python::manage_new_object>())
+        .def("chooseInPlace", &chooseInPlaceHelper,
+             (python::arg("self"), python::arg("mol")), "",
+             python::return_value_policy<python::manage_new_object>());
+    ;
+  }
+};
+
+void wrap_fragment() { fragment_wrapper::wrap(); }

--- a/Code/GraphMol/MolStandardize/nbWrap/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Fragment.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Susan H. Leung
+//  Copyright (C) 2018-2026 Susan H. Leung and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,12 +7,16 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/Fragment.h>
 
-namespace python = boost::python;
+#include <sstream>
+
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 
 namespace {
@@ -45,46 +49,27 @@ MolStandardize::FragmentRemover *removerFromParams(const std::string &data,
 
 }  // namespace
 
-struct fragment_wrapper {
-  static void wrap() {
-    python::scope().attr("__doc__") =
-        "Module containing tools for dealing with molecules with more than \
-					one covalently bonded unit";
+void wrap_fragment(nb::module_ &m) {
+  nb::class_<MolStandardize::FragmentRemover>(m, "FragmentRemover")
+      .def(nb::init<>())
+      .def(nb::init<std::string, bool, bool>(), "fragmentFilename"_a = "",
+           "leave_last"_a = true, "skip_if_all_match"_a = false)
+      .def("remove", &removeHelper, "mol"_a, "",
+           nb::rv_policy::take_ownership)
+      .def("removeInPlace", &removeInPlaceHelper, "mol"_a,
+           "modifies the molecule in place");
 
-    std::string docString = "";
-
-    python::class_<MolStandardize::FragmentRemover, boost::noncopyable>(
-        "FragmentRemover", python::init<>(python::args("self")))
-        .def(python::init<std::string, bool, bool>(
-            (python::arg("self"), python::arg("fragmentFilename") = "",
-             python::arg("leave_last") = true,
-             python::arg("skip_if_all_match") = false)))
-        .def("remove", &removeHelper, (python::arg("self"), python::arg("mol")),
-             "", python::return_value_policy<python::manage_new_object>())
-        .def("removeInPlace", &removeInPlaceHelper,
-             (python::arg("self"), python::arg("mol")),
-             "modifies the molecule in place");
-
-    python::def(
-        "FragmentRemoverFromData", &removerFromParams,
-        (python::arg("fragmentData"), python::arg("leave_last") = true,
-         python::arg("skip_if_all_match") = false),
+  m.def("FragmentRemoverFromData", &removerFromParams, "fragmentData"_a,
+        "leave_last"_a = true, "skip_if_all_match"_a = false,
         "creates a FragmentRemover from a string containing parameter data",
-        python::return_value_policy<python::manage_new_object>());
+        nb::rv_policy::take_ownership);
 
-    python::class_<MolStandardize::LargestFragmentChooser, boost::noncopyable>(
-        "LargestFragmentChooser",
-        python::init<bool>(
-            (python::arg("self"), python::arg("preferOrganic") = false)))
-        .def(python::init<const MolStandardize::CleanupParameters &>(
-            (python::arg("self"), python::arg("params"))))
-        .def("choose", &chooseHelper, (python::arg("self"), python::arg("mol")),
-             "", python::return_value_policy<python::manage_new_object>())
-        .def("chooseInPlace", &chooseInPlaceHelper,
-             (python::arg("self"), python::arg("mol")), "",
-             python::return_value_policy<python::manage_new_object>());
-    ;
-  }
-};
-
-void wrap_fragment() { fragment_wrapper::wrap(); }
+  nb::class_<MolStandardize::LargestFragmentChooser>(m,
+                                                      "LargestFragmentChooser")
+      .def(nb::init<bool>(), "preferOrganic"_a = false)
+      .def(nb::init<const MolStandardize::CleanupParameters &>(), "params"_a)
+      .def("choose", &chooseHelper, "mol"_a, "",
+           nb::rv_policy::take_ownership)
+      .def("chooseInPlace", &chooseInPlaceHelper, "mol"_a,
+           "modifies the molecule in place");
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/Metal.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Metal.cpp
@@ -1,0 +1,134 @@
+//
+//  Copyright (C) 2018 Susan H. Leung
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/SmilesParse/SmartsWrite.h>
+#include <GraphMol/MolStandardize/Metal.h>
+
+namespace python = boost::python;
+
+namespace {
+
+class MetalDisconnectorWrap {
+ public:
+  MetalDisconnectorWrap(python::object options = python::object()) {
+    if (options.is_none()) {
+      md_.reset(new RDKit::MolStandardize::MetalDisconnector());
+    } else {
+      RDKit::MolStandardize::MetalDisconnectorOptions md_opts;
+      md_opts.splitGrignards =
+          python::extract<bool>(options.attr("splitGrignards"));
+      md_opts.splitAromaticC =
+          python::extract<bool>(options.attr("splitAromaticC"));
+      md_opts.adjustCharges =
+          python::extract<bool>(options.attr("adjustCharges"));
+      md_opts.removeHapticDummies =
+          python::extract<bool>(options.attr("removeHapticDummies"));
+      md_.reset(new RDKit::MolStandardize::MetalDisconnector(md_opts));
+    }
+  }
+
+  RDKit::ROMol *getMetalNof() { return md_->getMetalNof(); }
+  RDKit::ROMol *getMetalNon() { return md_->getMetalNon(); }
+  void setMetalNof(const RDKit::ROMol &mol) { md_->setMetalNof(mol); }
+  void setMetalNon(const RDKit::ROMol &mol) { md_->setMetalNon(mol); }
+
+  RDKit::ROMol *disconnect(const RDKit::ROMol &mol) {
+    return md_->disconnect(mol);
+  }
+  void disconnectInPlace(RDKit::ROMol &mol) {
+    return md_->disconnectInPlace(static_cast<RDKit::RWMol &>(mol));
+  }
+
+ private:
+  std::unique_ptr<RDKit::MolStandardize::MetalDisconnector> md_;
+};
+
+std::string getMetalNofHelper(MetalDisconnectorWrap &self) {
+  return RDKit::MolToSmarts(*(self.getMetalNof()));
+}
+
+std::string getMetalNonHelper(MetalDisconnectorWrap &self) {
+  return RDKit::MolToSmarts(*(self.getMetalNon()));
+}
+
+void setMetalNonHelper(MetalDisconnectorWrap &self, const RDKit::ROMol &mol) {
+  self.setMetalNon(mol);
+}
+
+void setMetalNofHelper(MetalDisconnectorWrap &self, const RDKit::ROMol &mol) {
+  self.setMetalNof(mol);
+}
+}  // namespace
+
+struct metal_wrapper {
+  static void wrap() {
+    python::scope().attr("__doc__") =
+        "Module containing functions for molecular standardization";
+
+    std::string docString = "Metal Disconnector Options";
+    python::class_<RDKit::MolStandardize::MetalDisconnectorOptions>(
+        "MetalDisconnectorOptions", docString.c_str(),
+        python::init<>(python::args("self")))
+        .def_readwrite(
+            "splitGrignards",
+            &RDKit::MolStandardize::MetalDisconnectorOptions::splitGrignards,
+            "Whether to split Grignard-type complexes. Default false.")
+        .def_readwrite(
+            "splitAromaticC",
+            &RDKit::MolStandardize::MetalDisconnectorOptions::splitAromaticC,
+            "Whether to split metal-aromatic C bonds.  Default false.")
+        .def_readwrite(
+            "adjustCharges",
+            &RDKit::MolStandardize::MetalDisconnectorOptions::adjustCharges,
+            "Whether to adjust charges on ligand atoms.  Default true.")
+        .def_readwrite("removeHapticDummies",
+                       &RDKit::MolStandardize::MetalDisconnectorOptions::
+                           removeHapticDummies,
+                       "Whether to remove the dummy atoms representing haptic"
+                       " bonds.  Such dummies are bonded to the metal with a"
+                       " bond that has the MolFileBondEndPts prop set."
+                       "  Default false.");
+
+    docString =
+        "a class to disconnect metals that are defined as covalently bonded to"
+        " non-metals";
+    python::class_<MetalDisconnectorWrap, boost::noncopyable>(
+        "MetalDisconnector", docString.c_str(),
+        python::init<python::optional<python::object>>(
+            (python::arg("self"), python::arg("options") = python::object())))
+        .add_property("MetalNof", &getMetalNofHelper,
+                      "SMARTS defining the metals to disconnect if attached to "
+                      "Nitrogen, Oxygen or Fluorine")
+        .add_property(
+            "MetalNon", &getMetalNonHelper,
+            "SMARTS defining the metals to disconnect other inorganic elements")
+        .def(
+            "SetMetalNon", &setMetalNonHelper,
+            (python::arg("self"), python::arg("mol")),
+            "Set the query molecule defining the metals to disconnect from other"
+            " inorganic elements.")
+        .def(
+            "SetMetalNof", &setMetalNofHelper,
+            (python::arg("self"), python::arg("mol")),
+            "Set the query molecule defining the metals to disconnect if attached"
+            " to Nitrogen, Oxygen or Fluorine.")
+        .def("Disconnect", &MetalDisconnectorWrap::disconnect,
+             (python::arg("self"), python::arg("mol")),
+             "performs the disconnection",
+             python::return_value_policy<python::manage_new_object>())
+        .def("DisconnectInPlace", &MetalDisconnectorWrap::disconnectInPlace,
+             (python::arg("self"), python::arg("mol")),
+             "performs the disconnection, modifies the input molecule");
+  }
+};
+
+void wrap_metal() { metal_wrapper::wrap(); }

--- a/Code/GraphMol/MolStandardize/nbWrap/Metal.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Metal.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Susan H. Leung
+//  Copyright (C) 2018-2026 Susan H. Leung and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,31 +7,33 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/MolStandardize/Metal.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace {
 
 class MetalDisconnectorWrap {
  public:
-  MetalDisconnectorWrap(python::object options = python::object()) {
+  MetalDisconnectorWrap(nb::object options = nb::none()) {
     if (options.is_none()) {
       md_.reset(new RDKit::MolStandardize::MetalDisconnector());
     } else {
       RDKit::MolStandardize::MetalDisconnectorOptions md_opts;
       md_opts.splitGrignards =
-          python::extract<bool>(options.attr("splitGrignards"));
+          nb::cast<bool>(options.attr("splitGrignards"));
       md_opts.splitAromaticC =
-          python::extract<bool>(options.attr("splitAromaticC"));
+          nb::cast<bool>(options.attr("splitAromaticC"));
       md_opts.adjustCharges =
-          python::extract<bool>(options.attr("adjustCharges"));
+          nb::cast<bool>(options.attr("adjustCharges"));
       md_opts.removeHapticDummies =
-          python::extract<bool>(options.attr("removeHapticDummies"));
+          nb::cast<bool>(options.attr("removeHapticDummies"));
       md_.reset(new RDKit::MolStandardize::MetalDisconnector(md_opts));
     }
   }
@@ -69,66 +71,46 @@ void setMetalNofHelper(MetalDisconnectorWrap &self, const RDKit::ROMol &mol) {
 }
 }  // namespace
 
-struct metal_wrapper {
-  static void wrap() {
-    python::scope().attr("__doc__") =
-        "Module containing functions for molecular standardization";
+void wrap_metal(nb::module_ &m) {
+  nb::class_<RDKit::MolStandardize::MetalDisconnectorOptions>(
+      m, "MetalDisconnectorOptions", "Metal Disconnector Options")
+      .def(nb::init<>())
+      .def_rw("splitGrignards",
+               &RDKit::MolStandardize::MetalDisconnectorOptions::splitGrignards,
+               "Whether to split Grignard-type complexes. Default false.")
+      .def_rw("splitAromaticC",
+               &RDKit::MolStandardize::MetalDisconnectorOptions::splitAromaticC,
+               "Whether to split metal-aromatic C bonds.  Default false.")
+      .def_rw("adjustCharges",
+               &RDKit::MolStandardize::MetalDisconnectorOptions::adjustCharges,
+               "Whether to adjust charges on ligand atoms.  Default true.")
+      .def_rw("removeHapticDummies",
+               &RDKit::MolStandardize::MetalDisconnectorOptions::
+                   removeHapticDummies,
+               "Whether to remove the dummy atoms representing haptic"
+               " bonds.  Such dummies are bonded to the metal with a"
+               " bond that has the MolFileBondEndPts prop set."
+               "  Default false.");
 
-    std::string docString = "Metal Disconnector Options";
-    python::class_<RDKit::MolStandardize::MetalDisconnectorOptions>(
-        "MetalDisconnectorOptions", docString.c_str(),
-        python::init<>(python::args("self")))
-        .def_readwrite(
-            "splitGrignards",
-            &RDKit::MolStandardize::MetalDisconnectorOptions::splitGrignards,
-            "Whether to split Grignard-type complexes. Default false.")
-        .def_readwrite(
-            "splitAromaticC",
-            &RDKit::MolStandardize::MetalDisconnectorOptions::splitAromaticC,
-            "Whether to split metal-aromatic C bonds.  Default false.")
-        .def_readwrite(
-            "adjustCharges",
-            &RDKit::MolStandardize::MetalDisconnectorOptions::adjustCharges,
-            "Whether to adjust charges on ligand atoms.  Default true.")
-        .def_readwrite("removeHapticDummies",
-                       &RDKit::MolStandardize::MetalDisconnectorOptions::
-                           removeHapticDummies,
-                       "Whether to remove the dummy atoms representing haptic"
-                       " bonds.  Such dummies are bonded to the metal with a"
-                       " bond that has the MolFileBondEndPts prop set."
-                       "  Default false.");
-
-    docString =
-        "a class to disconnect metals that are defined as covalently bonded to"
-        " non-metals";
-    python::class_<MetalDisconnectorWrap, boost::noncopyable>(
-        "MetalDisconnector", docString.c_str(),
-        python::init<python::optional<python::object>>(
-            (python::arg("self"), python::arg("options") = python::object())))
-        .add_property("MetalNof", &getMetalNofHelper,
-                      "SMARTS defining the metals to disconnect if attached to "
-                      "Nitrogen, Oxygen or Fluorine")
-        .add_property(
-            "MetalNon", &getMetalNonHelper,
-            "SMARTS defining the metals to disconnect other inorganic elements")
-        .def(
-            "SetMetalNon", &setMetalNonHelper,
-            (python::arg("self"), python::arg("mol")),
-            "Set the query molecule defining the metals to disconnect from other"
-            " inorganic elements.")
-        .def(
-            "SetMetalNof", &setMetalNofHelper,
-            (python::arg("self"), python::arg("mol")),
-            "Set the query molecule defining the metals to disconnect if attached"
-            " to Nitrogen, Oxygen or Fluorine.")
-        .def("Disconnect", &MetalDisconnectorWrap::disconnect,
-             (python::arg("self"), python::arg("mol")),
-             "performs the disconnection",
-             python::return_value_policy<python::manage_new_object>())
-        .def("DisconnectInPlace", &MetalDisconnectorWrap::disconnectInPlace,
-             (python::arg("self"), python::arg("mol")),
-             "performs the disconnection, modifies the input molecule");
-  }
-};
-
-void wrap_metal() { metal_wrapper::wrap(); }
+  nb::class_<MetalDisconnectorWrap>(
+      m, "MetalDisconnector",
+      "a class to disconnect metals that are defined as covalently bonded to"
+      " non-metals")
+      .def(nb::init<nb::object>(), "options"_a = nb::none())
+      .def_prop_ro("MetalNof", &getMetalNofHelper,
+                   "SMARTS defining the metals to disconnect if attached to "
+                   "Nitrogen, Oxygen or Fluorine")
+      .def_prop_ro(
+          "MetalNon", &getMetalNonHelper,
+          "SMARTS defining the metals to disconnect other inorganic elements")
+      .def("SetMetalNon", &setMetalNonHelper, "mol"_a,
+           "Set the query molecule defining the metals to disconnect from other"
+           " inorganic elements.")
+      .def("SetMetalNof", &setMetalNofHelper, "mol"_a,
+           "Set the query molecule defining the metals to disconnect if "
+           "attached to Nitrogen, Oxygen or Fluorine.")
+      .def("Disconnect", &MetalDisconnectorWrap::disconnect, "mol"_a,
+           "performs the disconnection", nb::rv_policy::take_ownership)
+      .def("DisconnectInPlace", &MetalDisconnectorWrap::disconnectInPlace,
+           "mol"_a, "performs the disconnection, modifies the input molecule");
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Normalize.cpp
@@ -1,0 +1,67 @@
+//
+//  Copyright (C) 2018 Susan H. Leung
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/Normalize.h>
+#include <sstream>
+
+namespace python = boost::python;
+using namespace RDKit;
+
+namespace {
+
+ROMol *normalizeHelper(MolStandardize::Normalizer &self, const ROMol &mol) {
+  return self.normalize(mol);
+}
+
+void normalizeInPlaceHelper(MolStandardize::Normalizer &self, ROMol &mol) {
+  self.normalizeInPlace(static_cast<RWMol &>(mol));
+}
+
+MolStandardize::Normalizer *normalizerFromDataAndParams(
+    const std::string &data, const MolStandardize::CleanupParameters &params) {
+  std::istringstream sstr(data);
+  return new MolStandardize::Normalizer(sstr, params.maxRestarts);
+}
+
+}  // namespace
+
+struct normalize_wrapper {
+  static void wrap() {
+    python::scope().attr("__doc__") =
+        "Module containing tools for normalizing molecules defined by SMARTS "
+        "patterns";
+
+    std::string docString = "";
+
+    python::class_<MolStandardize::Normalizer, boost::noncopyable>(
+        "Normalizer", python::init<>(python::args("self")))
+        .def(python::init<std::string, unsigned int>(
+            python::args("self", "normalizeFilename", "maxRestarts")))
+        .def("normalize", &normalizeHelper,
+             (python::arg("self"), python::arg("mol")), "",
+             python::return_value_policy<python::manage_new_object>())
+        .def("normalizeInPlace", &normalizeInPlaceHelper,
+             (python::arg("self"), python::arg("mol")),
+             "modifies the input molecule");
+    python::def(
+        "NormalizerFromData", &normalizerFromDataAndParams,
+        (python::arg("paramData"), python::arg("params")),
+        "creates a Normalizer from a string containing normalization SMARTS",
+        python::return_value_policy<python::manage_new_object>());
+    python::def("NormalizerFromParams", &MolStandardize::normalizerFromParams,
+                (python::arg("params")),
+                "creates a Normalizer from CleanupParameters",
+                python::return_value_policy<python::manage_new_object>());
+  }
+};
+
+void wrap_normalize() { normalize_wrapper::wrap(); }

--- a/Code/GraphMol/MolStandardize/nbWrap/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Normalize.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Susan H. Leung
+//  Copyright (C) 2018-2026 Susan H. Leung and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,13 +7,15 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/Normalize.h>
 #include <sstream>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 
 namespace {
@@ -34,34 +36,22 @@ MolStandardize::Normalizer *normalizerFromDataAndParams(
 
 }  // namespace
 
-struct normalize_wrapper {
-  static void wrap() {
-    python::scope().attr("__doc__") =
-        "Module containing tools for normalizing molecules defined by SMARTS "
-        "patterns";
+void wrap_normalize(nb::module_ &m) {
+  nb::class_<MolStandardize::Normalizer>(m, "Normalizer")
+      .def(nb::init<>())
+      .def(nb::init<std::string, unsigned int>(), "normalizeFilename"_a,
+           "maxRestarts"_a)
+      .def("normalize", &normalizeHelper, "mol"_a, "",
+           nb::rv_policy::take_ownership)
+      .def("normalizeInPlace", &normalizeInPlaceHelper, "mol"_a,
+           "modifies the input molecule");
 
-    std::string docString = "";
-
-    python::class_<MolStandardize::Normalizer, boost::noncopyable>(
-        "Normalizer", python::init<>(python::args("self")))
-        .def(python::init<std::string, unsigned int>(
-            python::args("self", "normalizeFilename", "maxRestarts")))
-        .def("normalize", &normalizeHelper,
-             (python::arg("self"), python::arg("mol")), "",
-             python::return_value_policy<python::manage_new_object>())
-        .def("normalizeInPlace", &normalizeInPlaceHelper,
-             (python::arg("self"), python::arg("mol")),
-             "modifies the input molecule");
-    python::def(
-        "NormalizerFromData", &normalizerFromDataAndParams,
-        (python::arg("paramData"), python::arg("params")),
+  m.def("NormalizerFromData", &normalizerFromDataAndParams, "paramData"_a,
+        "params"_a,
         "creates a Normalizer from a string containing normalization SMARTS",
-        python::return_value_policy<python::manage_new_object>());
-    python::def("NormalizerFromParams", &MolStandardize::normalizerFromParams,
-                (python::arg("params")),
-                "creates a Normalizer from CleanupParameters",
-                python::return_value_policy<python::manage_new_object>());
-  }
-};
+        nb::rv_policy::take_ownership);
 
-void wrap_normalize() { normalize_wrapper::wrap(); }
+  m.def("NormalizerFromParams", &MolStandardize::normalizerFromParams,
+        "params"_a, "creates a Normalizer from CleanupParameters",
+        nb::rv_policy::take_ownership);
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/Pipeline.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Pipeline.cpp
@@ -1,0 +1,143 @@
+//
+//  Copyright (C) 2023 Novartis Biomedical Research
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/Pipeline.h>
+
+namespace RDKit {
+namespace MolStandardize {
+
+bool operator==(const PipelineLogEntry &lhs, const PipelineLogEntry &rhs) {
+  return (lhs.status == rhs.status) && (lhs.detail == rhs.detail);
+}
+
+}  // namespace MolStandardize
+}  // namespace RDKit
+
+namespace python = boost::python;
+using namespace RDKit;
+
+void wrap_pipeline() {
+  python::class_<MolStandardize::PipelineOptions>("PipelineOptions")
+      .def_readwrite("strictParsing",
+                     &MolStandardize::PipelineOptions::strictParsing)
+      .def_readwrite("reportAllFailures",
+                     &MolStandardize::PipelineOptions::reportAllFailures)
+      .def_readwrite("allowEmptyMolecules",
+                     &MolStandardize::PipelineOptions::allowEmptyMolecules)
+      .def_readwrite("allowEnhancedStereo",
+                     &MolStandardize::PipelineOptions::allowEnhancedStereo)
+      .def_readwrite("allowAromaticBondType",
+                     &MolStandardize::PipelineOptions::allowAromaticBondType)
+      .def_readwrite("allowDativeBondType",
+                     &MolStandardize::PipelineOptions::allowDativeBondType)
+      .def_readwrite("is2DZeroThreshold",
+                     &MolStandardize::PipelineOptions::is2DZeroThreshold)
+      .def_readwrite("atomClashLimit",
+                     &MolStandardize::PipelineOptions::atomClashLimit)
+      .def_readwrite("minMedianBondLength",
+                     &MolStandardize::PipelineOptions::minMedianBondLength)
+      .def_readwrite("bondLengthLimit",
+                     &MolStandardize::PipelineOptions::bondLengthLimit)
+      .def_readwrite("allowLongBondsInRings",
+                     &MolStandardize::PipelineOptions::allowLongBondsInRings)
+      .def_readwrite(
+          "allowAtomBondClashExemption",
+          &MolStandardize::PipelineOptions::allowAtomBondClashExemption)
+      .def_readwrite("metalNof", &MolStandardize::PipelineOptions::metalNof)
+      .def_readwrite("metalNon", &MolStandardize::PipelineOptions::metalNon)
+      .def_readwrite("normalizerData",
+                     &MolStandardize::PipelineOptions::normalizerData)
+      .def_readwrite("normalizerMaxRestarts",
+                     &MolStandardize::PipelineOptions::normalizerMaxRestarts)
+      .def_readwrite("scaledMedianBondLength",
+                     &MolStandardize::PipelineOptions::scaledMedianBondLength)
+      .def_readwrite("outputV2000",
+                     &MolStandardize::PipelineOptions::outputV2000);
+
+  python::enum_<MolStandardize::PipelineStatus>("PipelineStatus")
+      .value("NO_EVENT", MolStandardize::PipelineStatus::NO_EVENT)
+      .value("INPUT_ERROR", MolStandardize::PipelineStatus::INPUT_ERROR)
+      .value("PREPARE_FOR_VALIDATION_ERROR",
+             MolStandardize::PipelineStatus::PREPARE_FOR_VALIDATION_ERROR)
+      .value("FEATURES_VALIDATION_ERROR",
+             MolStandardize::PipelineStatus::FEATURES_VALIDATION_ERROR)
+      .value("BASIC_VALIDATION_ERROR",
+             MolStandardize::PipelineStatus::BASIC_VALIDATION_ERROR)
+      .value("IS2D_VALIDATION_ERROR",
+             MolStandardize::PipelineStatus::IS2D_VALIDATION_ERROR)
+      .value("LAYOUT2D_VALIDATION_ERROR",
+             MolStandardize::PipelineStatus::LAYOUT2D_VALIDATION_ERROR)
+      .value("STEREO_VALIDATION_ERROR",
+             MolStandardize::PipelineStatus::STEREO_VALIDATION_ERROR)
+      .value("VALIDATION_ERROR",
+             MolStandardize::PipelineStatus::VALIDATION_ERROR)
+      .value("PREPARE_FOR_STANDARDIZATION_ERROR",
+             MolStandardize::PipelineStatus::PREPARE_FOR_STANDARDIZATION_ERROR)
+      .value("METAL_STANDARDIZATION_ERROR",
+             MolStandardize::PipelineStatus::METAL_STANDARDIZATION_ERROR)
+      .value("NORMALIZER_STANDARDIZATION_ERROR",
+             MolStandardize::PipelineStatus::NORMALIZER_STANDARDIZATION_ERROR)
+      .value("FRAGMENT_STANDARDIZATION_ERROR",
+             MolStandardize::PipelineStatus::FRAGMENT_STANDARDIZATION_ERROR)
+      .value("CHARGE_STANDARDIZATION_ERROR",
+             MolStandardize::PipelineStatus::CHARGE_STANDARDIZATION_ERROR)
+      .value("STANDARDIZATION_ERROR",
+             MolStandardize::PipelineStatus::STANDARDIZATION_ERROR)
+      .value("OUTPUT_ERROR", MolStandardize::PipelineStatus::OUTPUT_ERROR)
+      .value("PIPELINE_ERROR", MolStandardize::PipelineStatus::PIPELINE_ERROR)
+      .value("METALS_DISCONNECTED",
+             MolStandardize::PipelineStatus::METALS_DISCONNECTED)
+      .value("NORMALIZATION_APPLIED",
+             MolStandardize::PipelineStatus::NORMALIZATION_APPLIED)
+      .value("FRAGMENTS_REMOVED",
+             MolStandardize::PipelineStatus::FRAGMENTS_REMOVED)
+      .value("PROTONATION_CHANGED",
+             MolStandardize::PipelineStatus::PROTONATION_CHANGED)
+      .value("STRUCTURE_MODIFICATION",
+             MolStandardize::PipelineStatus::STRUCTURE_MODIFICATION);
+
+  python::enum_<MolStandardize::PipelineStage>("PipelineStage")
+      .value("PARSING_INPUT", MolStandardize::PipelineStage::PARSING_INPUT)
+      .value("PREPARE_FOR_VALIDATION",
+             MolStandardize::PipelineStage::PREPARE_FOR_VALIDATION)
+      .value("VALIDATION", MolStandardize::PipelineStage::VALIDATION)
+      .value("PREPARE_FOR_STANDARDIZATION",
+             MolStandardize::PipelineStage::PREPARE_FOR_STANDARDIZATION)
+      .value("STANDARDIZATION", MolStandardize::PipelineStage::STANDARDIZATION)
+      .value("SERIALIZING_OUTPUT",
+             MolStandardize::PipelineStage::SERIALIZING_OUTPUT)
+      .value("COMPLETED", MolStandardize::PipelineStage::COMPLETED);
+
+  python::class_<MolStandardize::PipelineLogEntry>("PipelineLogEntry",
+                                                   python::no_init)
+      .def_readonly("status", &MolStandardize::PipelineLogEntry::status)
+      .def_readonly("detail", &MolStandardize::PipelineLogEntry::detail);
+
+  python::class_<MolStandardize::PipelineLog>("PipelineLog", python::no_init)
+      .def(python::vector_indexing_suite<MolStandardize::PipelineLog>());
+
+  python::class_<MolStandardize::PipelineResult>("PipelineResult",
+                                                 python::no_init)
+      .def_readonly("status", &MolStandardize::PipelineResult::status)
+      .def_readonly("stage", &MolStandardize::PipelineResult::stage)
+      .def_readonly("log", &MolStandardize::PipelineResult::log)
+      .def_readonly("inputMolData",
+                    &MolStandardize::PipelineResult::inputMolData)
+      .def_readonly("outputMolData",
+                    &MolStandardize::PipelineResult::outputMolData)
+      .def_readonly("parentMolData",
+                    &MolStandardize::PipelineResult::parentMolData);
+
+  python::class_<MolStandardize::Pipeline>("Pipeline")
+      .def(python::init<const MolStandardize::PipelineOptions &>())
+      .def("run", &MolStandardize::Pipeline::run);
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/Pipeline.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Pipeline.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2023 Novartis Biomedical Research
+//  Copyright (C) 2023-2026 Novartis Biomedical Research and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,7 +7,9 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/bind_vector.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/Pipeline.h>
@@ -22,48 +24,49 @@ bool operator==(const PipelineLogEntry &lhs, const PipelineLogEntry &rhs) {
 }  // namespace MolStandardize
 }  // namespace RDKit
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 
-void wrap_pipeline() {
-  python::class_<MolStandardize::PipelineOptions>("PipelineOptions")
-      .def_readwrite("strictParsing",
-                     &MolStandardize::PipelineOptions::strictParsing)
-      .def_readwrite("reportAllFailures",
-                     &MolStandardize::PipelineOptions::reportAllFailures)
-      .def_readwrite("allowEmptyMolecules",
-                     &MolStandardize::PipelineOptions::allowEmptyMolecules)
-      .def_readwrite("allowEnhancedStereo",
-                     &MolStandardize::PipelineOptions::allowEnhancedStereo)
-      .def_readwrite("allowAromaticBondType",
-                     &MolStandardize::PipelineOptions::allowAromaticBondType)
-      .def_readwrite("allowDativeBondType",
-                     &MolStandardize::PipelineOptions::allowDativeBondType)
-      .def_readwrite("is2DZeroThreshold",
-                     &MolStandardize::PipelineOptions::is2DZeroThreshold)
-      .def_readwrite("atomClashLimit",
-                     &MolStandardize::PipelineOptions::atomClashLimit)
-      .def_readwrite("minMedianBondLength",
-                     &MolStandardize::PipelineOptions::minMedianBondLength)
-      .def_readwrite("bondLengthLimit",
-                     &MolStandardize::PipelineOptions::bondLengthLimit)
-      .def_readwrite("allowLongBondsInRings",
-                     &MolStandardize::PipelineOptions::allowLongBondsInRings)
-      .def_readwrite(
-          "allowAtomBondClashExemption",
-          &MolStandardize::PipelineOptions::allowAtomBondClashExemption)
-      .def_readwrite("metalNof", &MolStandardize::PipelineOptions::metalNof)
-      .def_readwrite("metalNon", &MolStandardize::PipelineOptions::metalNon)
-      .def_readwrite("normalizerData",
-                     &MolStandardize::PipelineOptions::normalizerData)
-      .def_readwrite("normalizerMaxRestarts",
-                     &MolStandardize::PipelineOptions::normalizerMaxRestarts)
-      .def_readwrite("scaledMedianBondLength",
-                     &MolStandardize::PipelineOptions::scaledMedianBondLength)
-      .def_readwrite("outputV2000",
-                     &MolStandardize::PipelineOptions::outputV2000);
+void wrap_pipeline(nb::module_ &m) {
+  nb::class_<MolStandardize::PipelineOptions>(m, "PipelineOptions")
+      .def(nb::init<>())
+      .def_rw("strictParsing",
+               &MolStandardize::PipelineOptions::strictParsing)
+      .def_rw("reportAllFailures",
+               &MolStandardize::PipelineOptions::reportAllFailures)
+      .def_rw("allowEmptyMolecules",
+               &MolStandardize::PipelineOptions::allowEmptyMolecules)
+      .def_rw("allowEnhancedStereo",
+               &MolStandardize::PipelineOptions::allowEnhancedStereo)
+      .def_rw("allowAromaticBondType",
+               &MolStandardize::PipelineOptions::allowAromaticBondType)
+      .def_rw("allowDativeBondType",
+               &MolStandardize::PipelineOptions::allowDativeBondType)
+      .def_rw("is2DZeroThreshold",
+               &MolStandardize::PipelineOptions::is2DZeroThreshold)
+      .def_rw("atomClashLimit",
+               &MolStandardize::PipelineOptions::atomClashLimit)
+      .def_rw("minMedianBondLength",
+               &MolStandardize::PipelineOptions::minMedianBondLength)
+      .def_rw("bondLengthLimit",
+               &MolStandardize::PipelineOptions::bondLengthLimit)
+      .def_rw("allowLongBondsInRings",
+               &MolStandardize::PipelineOptions::allowLongBondsInRings)
+      .def_rw("allowAtomBondClashExemption",
+               &MolStandardize::PipelineOptions::allowAtomBondClashExemption)
+      .def_rw("metalNof", &MolStandardize::PipelineOptions::metalNof)
+      .def_rw("metalNon", &MolStandardize::PipelineOptions::metalNon)
+      .def_rw("normalizerData",
+               &MolStandardize::PipelineOptions::normalizerData)
+      .def_rw("normalizerMaxRestarts",
+               &MolStandardize::PipelineOptions::normalizerMaxRestarts)
+      .def_rw("scaledMedianBondLength",
+               &MolStandardize::PipelineOptions::scaledMedianBondLength)
+      .def_rw("outputV2000", &MolStandardize::PipelineOptions::outputV2000);
 
-  python::enum_<MolStandardize::PipelineStatus>("PipelineStatus")
+  nb::enum_<MolStandardize::PipelineStatus>(m, "PipelineStatus",
+                                             nb::is_arithmetic(), nb::is_flag())
       .value("NO_EVENT", MolStandardize::PipelineStatus::NO_EVENT)
       .value("INPUT_ERROR", MolStandardize::PipelineStatus::INPUT_ERROR)
       .value("PREPARE_FOR_VALIDATION_ERROR",
@@ -84,8 +87,9 @@ void wrap_pipeline() {
              MolStandardize::PipelineStatus::PREPARE_FOR_STANDARDIZATION_ERROR)
       .value("METAL_STANDARDIZATION_ERROR",
              MolStandardize::PipelineStatus::METAL_STANDARDIZATION_ERROR)
-      .value("NORMALIZER_STANDARDIZATION_ERROR",
-             MolStandardize::PipelineStatus::NORMALIZER_STANDARDIZATION_ERROR)
+      .value(
+          "NORMALIZER_STANDARDIZATION_ERROR",
+          MolStandardize::PipelineStatus::NORMALIZER_STANDARDIZATION_ERROR)
       .value("FRAGMENT_STANDARDIZATION_ERROR",
              MolStandardize::PipelineStatus::FRAGMENT_STANDARDIZATION_ERROR)
       .value("CHARGE_STANDARDIZATION_ERROR",
@@ -103,41 +107,44 @@ void wrap_pipeline() {
       .value("PROTONATION_CHANGED",
              MolStandardize::PipelineStatus::PROTONATION_CHANGED)
       .value("STRUCTURE_MODIFICATION",
-             MolStandardize::PipelineStatus::STRUCTURE_MODIFICATION);
+             MolStandardize::PipelineStatus::STRUCTURE_MODIFICATION)
+;
 
-  python::enum_<MolStandardize::PipelineStage>("PipelineStage")
+  nb::enum_<MolStandardize::PipelineStage>(m, "PipelineStage")
       .value("PARSING_INPUT", MolStandardize::PipelineStage::PARSING_INPUT)
       .value("PREPARE_FOR_VALIDATION",
              MolStandardize::PipelineStage::PREPARE_FOR_VALIDATION)
       .value("VALIDATION", MolStandardize::PipelineStage::VALIDATION)
       .value("PREPARE_FOR_STANDARDIZATION",
              MolStandardize::PipelineStage::PREPARE_FOR_STANDARDIZATION)
-      .value("STANDARDIZATION", MolStandardize::PipelineStage::STANDARDIZATION)
+      .value("STANDARDIZATION",
+             MolStandardize::PipelineStage::STANDARDIZATION)
       .value("SERIALIZING_OUTPUT",
              MolStandardize::PipelineStage::SERIALIZING_OUTPUT)
       .value("COMPLETED", MolStandardize::PipelineStage::COMPLETED);
 
-  python::class_<MolStandardize::PipelineLogEntry>("PipelineLogEntry",
-                                                   python::no_init)
-      .def_readonly("status", &MolStandardize::PipelineLogEntry::status)
-      .def_readonly("detail", &MolStandardize::PipelineLogEntry::detail);
+  nb::class_<MolStandardize::PipelineLogEntry>(m, "PipelineLogEntry")
+      .def_ro("status", &MolStandardize::PipelineLogEntry::status)
+      .def_ro("detail", &MolStandardize::PipelineLogEntry::detail);
 
-  python::class_<MolStandardize::PipelineLog>("PipelineLog", python::no_init)
-      .def(python::vector_indexing_suite<MolStandardize::PipelineLog>());
+  nb::bind_vector<MolStandardize::PipelineLog>(m, "PipelineLog");
 
-  python::class_<MolStandardize::PipelineResult>("PipelineResult",
-                                                 python::no_init)
-      .def_readonly("status", &MolStandardize::PipelineResult::status)
-      .def_readonly("stage", &MolStandardize::PipelineResult::stage)
-      .def_readonly("log", &MolStandardize::PipelineResult::log)
-      .def_readonly("inputMolData",
-                    &MolStandardize::PipelineResult::inputMolData)
-      .def_readonly("outputMolData",
-                    &MolStandardize::PipelineResult::outputMolData)
-      .def_readonly("parentMolData",
-                    &MolStandardize::PipelineResult::parentMolData);
+  nb::class_<MolStandardize::PipelineResult>(m, "PipelineResult")
+      .def_ro("status", &MolStandardize::PipelineResult::status)
+      .def_prop_ro("stage",
+                   [](const MolStandardize::PipelineResult &self) {
+                     return static_cast<MolStandardize::PipelineStage>(
+                         self.stage);
+                   })
+      .def_ro("log", &MolStandardize::PipelineResult::log)
+      .def_ro("inputMolData", &MolStandardize::PipelineResult::inputMolData)
+      .def_ro("outputMolData",
+               &MolStandardize::PipelineResult::outputMolData)
+      .def_ro("parentMolData",
+               &MolStandardize::PipelineResult::parentMolData);
 
-  python::class_<MolStandardize::Pipeline>("Pipeline")
-      .def(python::init<const MolStandardize::PipelineOptions &>())
-      .def("run", &MolStandardize::Pipeline::run);
+  nb::class_<MolStandardize::Pipeline>(m, "Pipeline")
+      .def(nb::init<>())
+      .def(nb::init<const MolStandardize::PipelineOptions &>(), "options"_a)
+      .def("run", &MolStandardize::Pipeline::run, "molData"_a);
 }

--- a/Code/GraphMol/MolStandardize/nbWrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Tautomer.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2020 Greg Landrum
+//  Copyright (C) 2020-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,25 +7,38 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#define NO_IMPORT_ARRAY
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/bind_vector.h>
+#include <nanobind/trampoline.h>
+#include <nanobind/make_iterator.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/MolStandardize.h>
 #include <GraphMol/MolStandardize/Tautomer.h>
 #include <sstream>
 
-namespace python = boost::python;
+NB_MAKE_OPAQUE(std::vector<RDKit::MolStandardize::TautomerScoringFunctions::SubstructTerm>);
+
+#include <nanobind/stl/vector.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 
 namespace {
+
+std::shared_ptr<RDKit::ROMol> toStd(const RDKit::ROMOL_SPTR &bptr) {
+  return {bptr.get(), [b = bptr](RDKit::ROMol *) {}};
+}
+
 class PyTautomerEnumeratorResult {
  public:
   PyTautomerEnumeratorResult(const MolStandardize::TautomerEnumeratorResult &tr)
       : d_tr(new MolStandardize::TautomerEnumeratorResult(std::move(tr))) {
-    python::list atList;
-    python::list bndList;
+    nb::list atList;
+    nb::list bndList;
     for (unsigned int i = 0; i < d_tr->modifiedAtoms().size(); ++i) {
       if (d_tr->modifiedAtoms().test(i)) {
         atList.append(i);
@@ -36,14 +49,18 @@ class PyTautomerEnumeratorResult {
         bndList.append(i);
       }
     }
-    d_atTuple = python::tuple(atList);
-    d_bndTuple = python::tuple(bndList);
+    d_atTuple = nb::tuple(atList);
+    d_bndTuple = nb::tuple(bndList);
   }
-  inline const std::vector<ROMOL_SPTR> *tautomers() const {
-    return new std::vector<ROMOL_SPTR>(d_tr->tautomers());
+  inline std::vector<std::shared_ptr<RDKit::ROMol>> tautomers() const {
+    std::vector<std::shared_ptr<RDKit::ROMol>> out;
+    for (const auto &sptr : d_tr->tautomers()) {
+      out.push_back(toStd(sptr));
+    }
+    return out;
   }
-  inline const std::vector<std::string> *smiles() const {
-    return new std::vector<std::string>(d_tr->smiles());
+  inline std::vector<std::string> smiles() const {
+    return std::vector<std::string>(d_tr->smiles());
   }
   inline const MolStandardize::SmilesTautomerMap &smilesTautomerMap() const {
     return d_tr->smilesTautomerMap();
@@ -51,8 +68,8 @@ class PyTautomerEnumeratorResult {
   inline MolStandardize::TautomerEnumeratorStatus status() const {
     return d_tr->status();
   }
-  inline python::tuple modifiedAtoms() const { return d_atTuple; }
-  inline python::tuple modifiedBonds() const { return d_bndTuple; }
+  inline nb::tuple modifiedAtoms() const { return d_atTuple; }
+  inline nb::tuple modifiedBonds() const { return d_bndTuple; }
   inline const MolStandardize::TautomerEnumeratorResult::const_iterator begin()
       const {
     return d_tr->begin();
@@ -68,158 +85,131 @@ class PyTautomerEnumeratorResult {
     }
     if (pos < 0 || pos >= size()) {
       PyErr_SetString(PyExc_IndexError, "index out of bounds");
-      python::throw_error_already_set();
-      return nullptr;
+      throw nb::python_error();
     }
     return new RDKit::ROMol(*d_tr->at(pos));
   }
   const MolStandardize::TautomerEnumeratorResult *get() { return d_tr.get(); }
 
  private:
-  boost::shared_ptr<MolStandardize::TautomerEnumeratorResult> d_tr;
-  python::tuple d_atTuple;
-  python::tuple d_bndTuple;
+  std::shared_ptr<MolStandardize::TautomerEnumeratorResult> d_tr;
+  nb::tuple d_atTuple;
+  nb::tuple d_bndTuple;
 };
 
-class PyTautomerEnumeratorCallback
-    : public MolStandardize::TautomerEnumeratorCallback,
-      public python::wrapper<MolStandardize::TautomerEnumeratorCallback> {
- public:
-  PyTautomerEnumeratorCallback() {}
-  PyTautomerEnumeratorCallback(const python::object &pyCallbackObject) {
-    PyTautomerEnumeratorCallback *pyCallback =
-        python::extract<PyTautomerEnumeratorCallback *>(pyCallbackObject);
-    *this = *pyCallback;
-    d_pyCallbackObject = pyCallbackObject;
-    pyCallback->d_cppCallback = this;
-  }
-  inline python::object getCallbackOverride() const {
-    return get_override("__call__");
-  }
-  bool operator()(
-      const ROMol &mol,
-      const MolStandardize::TautomerEnumeratorResult &res) override {
-    PyTautomerEnumeratorResult pyRes(res);
-    return getCallbackOverride()(boost::ref(mol), boost::ref(pyRes));
-  }
-  python::object getPyCallbackObject() { return d_pyCallbackObject; }
+struct TautomerEnumeratorCallbackTrampoline
+    : MolStandardize::TautomerEnumeratorCallback {
+  NB_TRAMPOLINE(MolStandardize::TautomerEnumeratorCallback, 1);
 
- private:
-  PyTautomerEnumeratorCallback *d_cppCallback;
-  python::object d_pyCallbackObject;
+  bool operator()(const ROMol &mol,
+                  const MolStandardize::TautomerEnumeratorResult &res) override {
+    nb::gil_scoped_acquire guard;
+    nb::object self = nb::find(this);
+    auto *pyRes = new PyTautomerEnumeratorResult(res);
+    nb::object pyResObj = nb::cast(pyRes, nb::rv_policy::take_ownership);
+    return nb::cast<bool>(self.attr("__call__")(mol, pyResObj));
+  }
 };
 
-typedef boost::shared_ptr<MolStandardize::Tautomer> TAUT_SPTR;
+// Wrapper to hold a Python callback object without needing to copy trampolines
+struct PyCallbackWrapper : MolStandardize::TautomerEnumeratorCallback {
+  nb::object d_pyObj;
+  explicit PyCallbackWrapper(nb::object obj) : d_pyObj(std::move(obj)) {}
+  bool operator()(const ROMol &mol,
+                  const MolStandardize::TautomerEnumeratorResult &res) override {
+    nb::gil_scoped_acquire guard;
+    auto *pyRes = new PyTautomerEnumeratorResult(res);
+    nb::object pyResObj = nb::cast(pyRes, nb::rv_policy::take_ownership);
+    return nb::cast<bool>(d_pyObj(mol, pyResObj));
+  }
+};
 
-ROMol *getTautomerHelper(const TAUT_SPTR &self) {
-  return new ROMol(*self->tautomer);
-}
-
-ROMol *getKekulizedHelper(const TAUT_SPTR &self) {
-  return new ROMol(*self->getKekulized());
-}
-
-python::tuple smilesTautomerMapKeysHelper(
+nb::tuple smilesTautomerMapKeysHelper(
     const MolStandardize::SmilesTautomerMap &self) {
-  python::list keys;
+  nb::list keys;
   for (const auto &pair : self) {
     keys.append(pair.first);
   }
-  return python::tuple(keys);
+  return nb::tuple(keys);
 }
 
-python::tuple smilesTautomerMapValuesHelper(
+nb::tuple smilesTautomerMapValuesHelper(
     const MolStandardize::SmilesTautomerMap &self) {
-  python::list values;
+  nb::list values;
   for (const auto &pair : self) {
-    values.append(TAUT_SPTR(new MolStandardize::Tautomer(pair.second)));
+    auto *t = new MolStandardize::Tautomer(pair.second);
+    values.append(nb::cast(t, nb::rv_policy::take_ownership));
   }
-  return python::tuple(values);
+  return nb::tuple(values);
 }
 
-python::tuple smilesTautomerMapItemsHelper(
+nb::tuple smilesTautomerMapItemsHelper(
     const MolStandardize::SmilesTautomerMap &self) {
-  python::list items;
+  nb::list items;
   for (const auto &pair : self) {
-    items.append(python::make_tuple(
-        pair.first, TAUT_SPTR(new MolStandardize::Tautomer(pair.second))));
+    auto *t = new MolStandardize::Tautomer(pair.second);
+    items.append(nb::make_tuple(
+        pair.first, nb::cast(t, nb::rv_policy::take_ownership)));
   }
-  return python::tuple(items);
+  return nb::tuple(items);
 }
 
-python::object getCallbackHelper(const MolStandardize::TautomerEnumerator &te) {
-  PyTautomerEnumeratorCallback *cppCallback =
-      dynamic_cast<PyTautomerEnumeratorCallback *>(te.getCallback());
-  python::object res;
+nb::object getCallbackHelper(const MolStandardize::TautomerEnumerator &te) {
+  PyCallbackWrapper *cppCallback =
+      dynamic_cast<PyCallbackWrapper *>(te.getCallback());
   if (cppCallback) {
-    res = cppCallback->getPyCallbackObject();
+    return cppCallback->d_pyObj;
   }
-  return res;
-};
+  return nb::none();
+}
 
 void setCallbackHelper(MolStandardize::TautomerEnumerator &te,
-                       PyObject *callback) {
-  PRECONDITION(callback, "callback must not be NULL");
-  if (callback == Py_None) {
+                       nb::object callback) {
+  if (callback.is_none()) {
     te.setCallback(nullptr);
     return;
   }
-  python::object callbackObject(python::handle<>(python::borrowed(callback)));
-  python::extract<PyTautomerEnumeratorCallback *> extractCallback(
-      callbackObject);
-  if (extractCallback.check()) {
-    if (!PyCallable_Check(extractCallback()->getCallbackOverride().ptr())) {
-      PyErr_SetString(PyExc_AttributeError,
-                      "The __call__ attribute in the "
-                      "rdMolStandardize.TautomerEnumeratorCallback subclass "
-                      "must exist and be a callable method");
-      python::throw_error_already_set();
-    } else {
-      te.setCallback(new PyTautomerEnumeratorCallback(callbackObject));
-    }
-  } else {
-    PyErr_SetString(PyExc_TypeError,
-                    "Expected an instance of a "
-                    "rdMolStandardize.TautomerEnumeratorCallback subclass");
-    python::throw_error_already_set();
+  if (!nb::isinstance(
+          callback,
+          nb::type<MolStandardize::TautomerEnumeratorCallback>())) {
+    throw nb::type_error(
+        "Expected an instance of a "
+        "rdMolStandardize.TautomerEnumeratorCallback subclass");
   }
-}
-
-std::string tautomerEnumeratorCallbackClassDoc =
-    R"DOC(Create a derived class from this abstract base class and
-    implement the __call__() method.
-    The __call__() method is called in the innermost loop of the
-    algorithm, and provides a mechanism to monitor or stop
-    its progress.
-
-    To have your callback called, pass an instance of your
-    derived class to TautomerEnumerator.SetCallback())DOC";
-
-MolStandardize::TautomerEnumerator *EnumeratorFromParams(
-    const MolStandardize::CleanupParameters &params) {
-  return new MolStandardize::TautomerEnumerator(params);
-}
-
-MolStandardize::TautomerEnumerator *createDefaultEnumerator() {
-  MolStandardize::CleanupParameters ps;
-  return EnumeratorFromParams(ps);
-}
-
-MolStandardize::TautomerEnumerator *copyEnumerator(
-    const MolStandardize::TautomerEnumerator &other) {
-  return new MolStandardize::TautomerEnumerator(other);
+  // Verify that the Python subclass has a properly overridden __call__:
+  // - it must be defined in the immediate class dict (not just inherited)
+  // - it must be callable
+  nb::object cls_dict =
+      nb::borrow<nb::object>(PyObject_Type(callback.ptr())).attr("__dict__");
+  if (!nb::cast<bool>(cls_dict.attr("__contains__")("__call__"))) {
+    throw nb::attribute_error(
+        "TautomerEnumeratorCallback subclass must override __call__");
+  }
+  nb::object call_attr = cls_dict.attr("__getitem__")("__call__");
+  nb::object builtins = nb::module_::import_("builtins");
+  if (!nb::cast<bool>(builtins.attr("callable")(call_attr))) {
+    throw nb::attribute_error(
+        "TautomerEnumeratorCallback.__call__ must be callable");
+  }
+  te.setCallback(new PyCallbackWrapper(callback));
 }
 
 class pyobjFunctor {
  public:
-  pyobjFunctor(python::object obj) : dp_obj(std::move(obj)) {}
+  pyobjFunctor(nb::object obj) : dp_obj(std::move(obj)) {}
   ~pyobjFunctor() = default;
   int operator()(const ROMol &m) {
-    return python::extract<int>(dp_obj(boost::ref(m)));
+    nb::object result = dp_obj(m);
+    try {
+      return nb::cast<int>(result);
+    } catch (const nb::cast_error &) {
+      throw nb::type_error(
+          "scoring function must return a numeric value");
+    }
   }
 
  private:
-  python::object dp_obj;
+  nb::object dp_obj;
 };
 
 ROMol *canonicalizeHelper(const MolStandardize::TautomerEnumerator &self,
@@ -228,39 +218,52 @@ ROMol *canonicalizeHelper(const MolStandardize::TautomerEnumerator &self,
 }
 
 ROMol *canonicalizeHelper2(const MolStandardize::TautomerEnumerator &self,
-                           const ROMol &mol, python::object scoreFunc) {
+                           const ROMol &mol, nb::object scoreFunc) {
   pyobjFunctor ftor(scoreFunc);
   return self.canonicalize(mol, ftor);
 }
 
-inline std::vector<ROMOL_SPTR> extractPythonIterable(const python::object &o) {
-  if (!PyObject_HasAttrString(o.ptr(), "__iter__")) {
-    PyErr_SetString(PyExc_TypeError,
-                    "the passed object should be an iterable of Mol objects");
-    python::throw_error_already_set();
-    return std::vector<ROMOL_SPTR>();
+inline std::vector<ROMOL_SPTR> extractPythonIterable(const nb::object &o) {
+  if (!nb::hasattr(o, "__iter__")) {
+    throw nb::type_error(
+        "the passed object should be an iterable of Mol objects");
   }
-  return std::vector<ROMOL_SPTR>(python::stl_input_iterator<ROMOL_SPTR>(o),
-                                 python::stl_input_iterator<ROMOL_SPTR>());
+  std::vector<ROMOL_SPTR> result;
+  for (nb::handle h : o) {
+    RDKit::ROMol *molPtr = nullptr;
+    try {
+      molPtr = nb::cast<RDKit::ROMol *>(h);
+    } catch (const nb::cast_error &) {
+      throw nb::type_error(
+          "the passed object should be an iterable of Mol objects");
+    }
+    // Copy the molecule so the vector owns its lifetime independently of Python
+    result.push_back(ROMOL_SPTR(new RDKit::ROMol(*molPtr)));
+  }
+  return result;
 }
 
 ROMol *pickCanonicalHelper(const MolStandardize::TautomerEnumerator &self,
-                           const python::object &o) {
-  python::extract<PyTautomerEnumeratorResult *> e(o);
-  if (e.check()) {
-    return self.pickCanonical(*e()->get());
+                           const nb::object &o) {
+  try {
+    PyTautomerEnumeratorResult *e =
+        nb::cast<PyTautomerEnumeratorResult *>(o);
+    return self.pickCanonical(*e->get());
+  } catch (const nb::cast_error &) {
+    return self.pickCanonical(extractPythonIterable(o));
   }
-  return self.pickCanonical(extractPythonIterable(o));
 }
 
 ROMol *pickCanonicalHelper2(const MolStandardize::TautomerEnumerator &self,
-                            const python::object &o, python::object scoreFunc) {
+                            const nb::object &o, nb::object scoreFunc) {
   pyobjFunctor ftor(scoreFunc);
-  python::extract<PyTautomerEnumeratorResult *> e(o);
-  if (e.check()) {
-    return self.pickCanonical(*e()->get(), ftor);
+  try {
+    PyTautomerEnumeratorResult *e =
+        nb::cast<PyTautomerEnumeratorResult *>(o);
+    return self.pickCanonical(*e->get(), ftor);
+  } catch (const nb::cast_error &) {
+    return self.pickCanonical(extractPythonIterable(o), ftor);
   }
-  return self.pickCanonical(extractPythonIterable(o), ftor);
 }
 
 PyTautomerEnumeratorResult *enumerateHelper(
@@ -277,286 +280,269 @@ GetDefaultTautomerSubstructsHelper() {
   }
   return terms;
 }
-  
 
 }  // namespace
 
-// This indicates that the scoreSubstructs takes a minimum of 1 argument and a maximum of 2
-// so we can call it ScoreSubstructs(mol) or ScoreSubstructs(mol, terms)
-BOOST_PYTHON_FUNCTION_OVERLOADS(scoreSubstructs_overloads,
-				RDKit::MolStandardize::TautomerScoringFunctions::scoreSubstructs, 1, 2)
+void wrap_tautomer(nb::module_ &m) {
+  nb::enum_<MolStandardize::TautomerEnumeratorStatus>(
+      m, "TautomerEnumeratorStatus")
+      .value("Completed",
+             MolStandardize::TautomerEnumeratorStatus::Completed)
+      .value("MaxTautomersReached",
+             MolStandardize::TautomerEnumeratorStatus::MaxTautomersReached)
+      .value("MaxTransformsReached",
+             MolStandardize::TautomerEnumeratorStatus::MaxTransformsReached)
+      .value("Canceled",
+             MolStandardize::TautomerEnumeratorStatus::Canceled);
 
-struct tautomer_wrapper {
-  static void wrap() {
-    python::enum_<MolStandardize::TautomerEnumeratorStatus>(
-        "TautomerEnumeratorStatus")
-        .value("Completed", MolStandardize::TautomerEnumeratorStatus::Completed)
-        .value("MaxTautomersReached",
-               MolStandardize::TautomerEnumeratorStatus::MaxTautomersReached)
-        .value("MaxTransformsReached",
-               MolStandardize::TautomerEnumeratorStatus::MaxTransformsReached)
-        .value("Canceled", MolStandardize::TautomerEnumeratorStatus::Canceled);
+  nb::class_<MolStandardize::TautomerEnumeratorCallback,
+             TautomerEnumeratorCallbackTrampoline>(
+      m, "TautomerEnumeratorCallback",
+      R"DOC(Create a derived class from this abstract base class and
+implement the __call__() method.
+The __call__() method is called in the innermost loop of the
+algorithm, and provides a mechanism to monitor or stop
+its progress.
 
-    python::class_<PyTautomerEnumeratorCallback, boost::noncopyable>(
-        "TautomerEnumeratorCallback",
-        tautomerEnumeratorCallbackClassDoc.c_str(),
-        python::init<>(python::args("self")))
-        .def("__call__",
-             python::pure_virtual(&PyTautomerEnumeratorCallback::operator()),
-             python::args("self", "mol", "res"),
-             "This must be implemented in the derived class. "
-             "Return True if the tautomer enumeration should continue; "
-             "False if the tautomer enumeration should stop.\n");
+To have your callback called, pass an instance of your
+derived class to TautomerEnumerator.SetCallback())DOC")
+      .def(nb::init<>())
+      .def("__call__",
+           &MolStandardize::TautomerEnumeratorCallback::operator(), "mol"_a,
+           "res"_a,
+           "This must be implemented in the derived class. "
+           "Return True if the tautomer enumeration should continue; "
+           "False if the tautomer enumeration should stop.\n");
 
-    python::class_<MolStandardize::Tautomer, TAUT_SPTR>(
-        "Tautomer",
-        "used to hold the aromatic and kekulized versions "
-        "of each tautomer",
-        python::no_init)
-        .add_property(
-            "tautomer",
-            python::make_function(
-                &getTautomerHelper,
-                python::return_value_policy<python::manage_new_object>()),
-            "aromatic version of the tautomer")
-        .add_property(
-            "kekulized",
-            python::make_function(
-                &getKekulizedHelper,
-                python::return_value_policy<python::manage_new_object>()),
-            "kekulized version of the tautomer");
+  nb::class_<MolStandardize::Tautomer>(
+      m, "Tautomer",
+      "used to hold the aromatic and kekulized versions of each tautomer")
+      .def_prop_ro("tautomer",
+                   [](const MolStandardize::Tautomer &self) {
+                     return new ROMol(*self.tautomer);
+                   },
+                   nb::rv_policy::take_ownership,
+                   "aromatic version of the tautomer")
+      .def_prop_ro("kekulized",
+                   [](const MolStandardize::Tautomer &self) {
+                     return new ROMol(*self.getKekulized());
+                   },
+                   nb::rv_policy::take_ownership,
+                   "kekulized version of the tautomer");
 
-    python::class_<MolStandardize::SmilesTautomerMap, boost::noncopyable>(
-        "SmilesTautomerMap",
-        "maps SMILES strings to the respective Tautomer objects",
-        python::no_init)
-        .def(python::map_indexing_suite<MolStandardize::SmilesTautomerMap,
-                                        true>())
-        .def("keys", &smilesTautomerMapKeysHelper, python::args("self"))
-        .def("values", &smilesTautomerMapValuesHelper, python::args("self"))
-        .def("items", &smilesTautomerMapItemsHelper, python::args("self"));
+  nb::class_<MolStandardize::SmilesTautomerMap>(
+      m, "SmilesTautomerMap",
+      "maps SMILES strings to the respective Tautomer objects")
+      .def("keys", &smilesTautomerMapKeysHelper)
+      .def("values", &smilesTautomerMapValuesHelper)
+      .def("items", &smilesTautomerMapItemsHelper)
+      .def("__len__",
+           [](const MolStandardize::SmilesTautomerMap &self) {
+             return self.size();
+           });
 
-    python::class_<PyTautomerEnumeratorResult, boost::noncopyable>(
-        "TautomerEnumeratorResult",
-        "used to return tautomer enumeration results", python::no_init)
-        .add_property(
-            "tautomers",
-            python::make_function(
-                &PyTautomerEnumeratorResult::tautomers,
-                python::return_value_policy<python::manage_new_object>()),
-            "tautomers generated by the enumerator")
-        .add_property(
-            "smiles",
-            python::make_function(
-                &PyTautomerEnumeratorResult::smiles,
-                python::return_value_policy<python::manage_new_object>()),
-            "SMILES of tautomers generated by the enumerator")
-        .add_property("smilesTautomerMap",
-                      python::make_function(
-                          &PyTautomerEnumeratorResult::smilesTautomerMap,
-                          python::return_value_policy<
-                              python::reference_existing_object>()),
-                      "dictionary mapping SMILES strings to the respective "
-                      "Tautomer objects")
-        .add_property("status", &PyTautomerEnumeratorResult::status,
-                      "whether the enumeration completed or not; see "
-                      "TautomerEnumeratorStatus for possible values")
-        .add_property(
-            "modifiedAtoms",
-            python::make_function(&PyTautomerEnumeratorResult::modifiedAtoms),
-            "tuple of atom indices modified by the transforms")
-        .add_property(
-            "modifiedBonds",
-            python::make_function(&PyTautomerEnumeratorResult::modifiedBonds),
-            "tuple of bond indices modified by the transforms")
-        .def("__call__", &PyTautomerEnumeratorResult::tautomers,
-             python::return_value_policy<python::manage_new_object>(),
-             python::args("self"), "tautomers generated by the enumerator")
-        .def("__iter__", python::range(&PyTautomerEnumeratorResult::begin,
-                                       &PyTautomerEnumeratorResult::end))
-        .def("__getitem__", &PyTautomerEnumeratorResult::at,
-             python::return_value_policy<python::manage_new_object>(),
-             python::args("self", "pos"))
-        .def("__len__", &PyTautomerEnumeratorResult::size,
-             python::args("self"));
+  nb::class_<PyTautomerEnumeratorResult>(
+      m, "TautomerEnumeratorResult",
+      "used to return tautomer enumeration results")
+      .def_prop_ro("tautomers", &PyTautomerEnumeratorResult::tautomers,
+                   "tautomers generated by the enumerator")
+      .def_prop_ro("smiles", &PyTautomerEnumeratorResult::smiles,
+                   "SMILES of tautomers generated by the enumerator")
+      .def_prop_ro(
+          "smilesTautomerMap",
+          &PyTautomerEnumeratorResult::smilesTautomerMap,
+          nb::rv_policy::reference_internal,
+          "dictionary mapping SMILES strings to the respective Tautomer objects")
+      .def_prop_ro("status", &PyTautomerEnumeratorResult::status,
+                   "whether the enumeration completed or not; see "
+                   "TautomerEnumeratorStatus for possible values")
+      .def_prop_ro("modifiedAtoms", &PyTautomerEnumeratorResult::modifiedAtoms,
+                   "tuple of atom indices modified by the transforms")
+      .def_prop_ro("modifiedBonds", &PyTautomerEnumeratorResult::modifiedBonds,
+                   "tuple of bond indices modified by the transforms")
+      .def("__call__",
+           [](PyTautomerEnumeratorResult &self) { return self.tautomers(); },
+           "tautomers generated by the enumerator")
+      .def("__iter__",
+           [](PyTautomerEnumeratorResult &self) {
+             auto taus = self.tautomers();
+             nb::list result;
+             for (const auto &mol : taus) {
+               result.append(nb::cast(mol));
+             }
+             return result.attr("__iter__")();
+           })
+      .def("__getitem__",
+           [](PyTautomerEnumeratorResult &self, int pos) {
+             return self.at(pos);
+           },
+           "pos"_a, nb::rv_policy::take_ownership)
+      .def("__len__", &PyTautomerEnumeratorResult::size);
 
-    python::class_<MolStandardize::TautomerEnumerator, boost::noncopyable>(
-        "TautomerEnumerator", python::no_init)
-        .def("__init__", python::make_constructor(createDefaultEnumerator))
-        .def("__init__", python::make_constructor(EnumeratorFromParams))
-        .def("__init__", python::make_constructor(copyEnumerator))
-        .def("Enumerate", &enumerateHelper,
-             (python::arg("self"), python::arg("mol")),
-             python::return_value_policy<python::manage_new_object>(),
-             R"DOC(Generates the tautomers for a molecule.
-             
-  The enumeration rules are inspired by the publication:
-  M. Sitzmann et al., “Tautomerism in Large Databases.”, JCAMD 24:521 (2010)
-  https://doi.org/10.1007/s10822-010-9346-4
-  
-  Note: the definitions used here are that the atoms modified during
-  tautomerization are the atoms at the beginning and end of each tautomer
-  transform (the H "donor" and H "acceptor" in the transform) and the bonds
-  modified during transformation are any bonds whose order is changed during
-  the tautomer transform (these are the bonds between the "donor" and the
-  "acceptor").)DOC")
-        .def("Canonicalize", &canonicalizeHelper,
-             (python::arg("self"), python::arg("mol")),
-             python::return_value_policy<python::manage_new_object>(),
-             R"DOC(Returns the canonical tautomer for a molecule.
+  nb::class_<MolStandardize::TautomerEnumerator>(m, "TautomerEnumerator")
+      .def(nb::init<>())
+      .def(nb::init<const MolStandardize::CleanupParameters &>(), "params"_a)
+      .def(nb::init<const MolStandardize::TautomerEnumerator &>(), "other"_a)
+      .def("Enumerate", &enumerateHelper, "mol"_a,
+           nb::rv_policy::take_ownership,
+           R"DOC(Generates the tautomers for a molecule.
 
-  The default scoring scheme is inspired by the publication:
-  M. Sitzmann et al., “Tautomerism in Large Databases.”, JCAMD 24:521 (2010)
-  https://doi.org/10.1007/s10822-010-9346-4
+The enumeration rules are inspired by the publication:
+M. Sitzmann et al., "Tautomerism in Large Databases.", JCAMD 24:521 (2010)
+https://doi.org/10.1007/s10822-010-9346-4
 
-  Note that the canonical tautomer is very likely not the most stable tautomer
-  for any given conditions. The default scoring rules are designed to produce
-  "reasonable" tautomers, but the primary concern is that the results are
-  canonical: you always get the same canonical tautomer for a molecule
-  regardless of what the input tautomer or atom ordering were.)DOC")
-        .def(
-            "Canonicalize", &canonicalizeHelper2,
-            (python::arg("self"), python::arg("mol"), python::arg("scoreFunc")),
-            python::return_value_policy<python::manage_new_object>(),
-            "picks the canonical tautomer from an iterable of molecules "
-            "using a custom scoring function")
-        .def("PickCanonical", &pickCanonicalHelper,
-             (python::arg("self"), python::arg("iterable")),
-             python::return_value_policy<python::manage_new_object>(),
-             "picks the canonical tautomer from an iterable of molecules")
-        .def("PickCanonical", &pickCanonicalHelper2,
-             (python::arg("self"), python::arg("iterable"),
-              python::arg("scoreFunc")),
-             python::return_value_policy<python::manage_new_object>(),
-             "returns the canonical tautomer for a molecule using a custom "
-             "scoring function")
-        .def("ScoreTautomer",
-             &MolStandardize::TautomerScoringFunctions::scoreTautomer,
-             (python::arg("mol")),
-             "returns the score for a tautomer using the default scoring "
-             "scheme.")
-        .staticmethod("ScoreTautomer")
-        .def("SetMaxTautomers",
-             &MolStandardize::TautomerEnumerator::setMaxTautomers,
-             (python::arg("self"), python::arg("maxTautomers")),
-             "set the maximum number of tautomers to be generated.")
-        .def("GetMaxTautomers",
-             &MolStandardize::TautomerEnumerator::getMaxTautomers,
-             (python::arg("self")),
-             "returns the maximum number of tautomers to be generated.")
-        .def("SetMaxTransforms",
-             &MolStandardize::TautomerEnumerator::setMaxTransforms,
-             (python::arg("self"), python::arg("maxTransforms")),
-             "set the maximum number of transformations to be applied. "
-             "This limit is usually hit earlier than the maxTautomers limit "
-             "and leads to a more linear scaling of CPU time with increasing "
-             "number of tautomeric centers (see Sitzmann et al.).")
-        .def("GetMaxTransforms",
-             &MolStandardize::TautomerEnumerator::getMaxTransforms,
-             (python::arg("self")),
-             "returns the maximum number of transformations to be applied.")
-        .def("SetRemoveSp3Stereo",
-             &MolStandardize::TautomerEnumerator::setRemoveSp3Stereo,
-             (python::arg("self"), python::arg("removeSp3Stereo")),
-             "set to True if you wish stereochemistry information "
-             "to be removed from sp3 atoms involved in tautomerism. "
-             "This means that S-aminoacids will lose their stereochemistry "
-             "after going through tautomer enumeration because of the "
-             "amido-imidol tautomerism. This defaults to True in RDKit, "
-             "and to False in the workflow described by Sitzmann et al.")
-        .def("GetRemoveSp3Stereo",
-             &MolStandardize::TautomerEnumerator::getRemoveSp3Stereo,
-             (python::arg("self")),
-             "returns whether stereochemistry information will be removed from "
-             "sp3 atoms involved in tautomerism.")
-        .def("SetRemoveBondStereo",
-             &MolStandardize::TautomerEnumerator::setRemoveBondStereo,
-             (python::arg("self"), python::arg("removeBondStereo")),
-             "set to True if you wish stereochemistry information "
-             "to be removed from double bonds involved in tautomerism. "
-             "This means that enols will lose their E/Z stereochemistry "
-             "after going through tautomer enumeration because of the "
-             "keto-enolic tautomerism. This defaults to True in the "
-             "RDKit and also in the workflow described by Sitzmann et al.")
-        .def("GetRemoveBondStereo",
-             &MolStandardize::TautomerEnumerator::getRemoveBondStereo,
-             (python::arg("self")),
-             "returns whether stereochemistry information "
-             "will be removed from double bonds involved in tautomerism.")
-        .def("SetReassignStereo",
-             &MolStandardize::TautomerEnumerator::setReassignStereo,
-             (python::arg("self"), python::arg("reassignStereo")),
-             "set to True if you wish AssignStereochemistry to be called "
-             "on each tautomer generated by the Enumerate() method. "
-             "This defaults to True.")
-        .def("GetReassignStereo",
-             &MolStandardize::TautomerEnumerator::getReassignStereo,
-             (python::arg("self")),
-             "returns whether AssignStereochemistry will be called "
-             "on each tautomer generated by the Enumerate() method.")
-        .def("SetCallback", &setCallbackHelper,
-             python::args("self", "callback"),
-             "Pass an instance of a class derived from\n"
-             "TautomerEnumeratorCallback, which must implement the\n"
-             "__call__() method.")
-        .def("GetCallback", &getCallbackHelper, python::args("self"),
-             "Get the TautomerEnumeratorCallback subclass instance,\n"
-             "or None if none was set.")
-        .def_readonly(
-            "tautomerScoreVersion",
-            MolStandardize::TautomerScoringFunctions::tautomerScoringVersion);
-    python::def("GetV1TautomerEnumerator",
-                MolStandardize::getV1TautomerEnumerator,
-                "return a TautomerEnumerator using v1 of the enumeration rules",
-                python::return_value_policy<python::manage_new_object>());
+Note: the definitions used here are that the atoms modified during
+tautomerization are the atoms at the beginning and end of each tautomer
+transform (the H "donor" and H "acceptor" in the transform) and the bonds
+modified during transformation are any bonds whose order is changed during
+the tautomer transform (these are the bonds between the "donor" and the
+"acceptor").)DOC")
+      .def("Canonicalize", &canonicalizeHelper, "mol"_a,
+           nb::rv_policy::take_ownership,
+           R"DOC(Returns the canonical tautomer for a molecule.
 
-    std::string docString =
+The default scoring scheme is inspired by the publication:
+M. Sitzmann et al., "Tautomerism in Large Databases.", JCAMD 24:521 (2010)
+https://doi.org/10.1007/s10822-010-9346-4
+
+Note that the canonical tautomer is very likely not the most stable tautomer
+for any given conditions. The default scoring rules are designed to produce
+"reasonable" tautomers, but the primary concern is that the results are
+canonical: you always get the same canonical tautomer for a molecule
+regardless of what the input tautomer or atom ordering were.)DOC")
+      .def("Canonicalize", &canonicalizeHelper2, "mol"_a, "scoreFunc"_a,
+           nb::rv_policy::take_ownership,
+           "picks the canonical tautomer from an iterable of molecules "
+           "using a custom scoring function")
+      .def("PickCanonical", &pickCanonicalHelper, "iterable"_a,
+           nb::rv_policy::take_ownership,
+           "picks the canonical tautomer from an iterable of molecules")
+      .def("PickCanonical", &pickCanonicalHelper2, "iterable"_a,
+           "scoreFunc"_a, nb::rv_policy::take_ownership,
+           "returns the canonical tautomer for a molecule using a custom "
+           "scoring function")
+      .def_static(
+          "ScoreTautomer",
+          &MolStandardize::TautomerScoringFunctions::scoreTautomer, "mol"_a,
+          "returns the score for a tautomer using the default scoring scheme.")
+      .def("SetMaxTautomers",
+           &MolStandardize::TautomerEnumerator::setMaxTautomers,
+           "maxTautomers"_a,
+           "set the maximum number of tautomers to be generated.")
+      .def("GetMaxTautomers",
+           &MolStandardize::TautomerEnumerator::getMaxTautomers,
+           "returns the maximum number of tautomers to be generated.")
+      .def("SetMaxTransforms",
+           &MolStandardize::TautomerEnumerator::setMaxTransforms,
+           "maxTransforms"_a,
+           "set the maximum number of transformations to be applied. "
+           "This limit is usually hit earlier than the maxTautomers limit "
+           "and leads to a more linear scaling of CPU time with increasing "
+           "number of tautomeric centers (see Sitzmann et al.).")
+      .def("GetMaxTransforms",
+           &MolStandardize::TautomerEnumerator::getMaxTransforms,
+           "returns the maximum number of transformations to be applied.")
+      .def("SetRemoveSp3Stereo",
+           &MolStandardize::TautomerEnumerator::setRemoveSp3Stereo,
+           "removeSp3Stereo"_a,
+           "set to True if you wish stereochemistry information "
+           "to be removed from sp3 atoms involved in tautomerism. "
+           "This means that S-aminoacids will lose their stereochemistry "
+           "after going through tautomer enumeration because of the "
+           "amido-imidol tautomerism. This defaults to True in RDKit, "
+           "and to False in the workflow described by Sitzmann et al.")
+      .def("GetRemoveSp3Stereo",
+           &MolStandardize::TautomerEnumerator::getRemoveSp3Stereo,
+           "returns whether stereochemistry information will be removed from "
+           "sp3 atoms involved in tautomerism.")
+      .def("SetRemoveBondStereo",
+           &MolStandardize::TautomerEnumerator::setRemoveBondStereo,
+           "removeBondStereo"_a,
+           "set to True if you wish stereochemistry information "
+           "to be removed from double bonds involved in tautomerism. "
+           "This means that enols will lose their E/Z stereochemistry "
+           "after going through tautomer enumeration because of the "
+           "keto-enolic tautomerism. This defaults to True in the "
+           "RDKit and also in the workflow described by Sitzmann et al.")
+      .def("GetRemoveBondStereo",
+           &MolStandardize::TautomerEnumerator::getRemoveBondStereo,
+           "returns whether stereochemistry information "
+           "will be removed from double bonds involved in tautomerism.")
+      .def("SetReassignStereo",
+           &MolStandardize::TautomerEnumerator::setReassignStereo,
+           "reassignStereo"_a,
+           "set to True if you wish AssignStereochemistry to be called "
+           "on each tautomer generated by the Enumerate() method. "
+           "This defaults to True.")
+      .def("GetReassignStereo",
+           &MolStandardize::TautomerEnumerator::getReassignStereo,
+           "returns whether AssignStereochemistry will be called "
+           "on each tautomer generated by the Enumerate() method.")
+      .def("SetCallback", &setCallbackHelper, "callback"_a,
+           "Pass an instance of a class derived from\n"
+           "TautomerEnumeratorCallback, which must implement the\n"
+           "__call__() method.")
+      .def("GetCallback", &getCallbackHelper,
+           "Get the TautomerEnumeratorCallback subclass instance,\n"
+           "or None if none was set.")
+      .def_prop_ro_static(
+          "tautomerScoreVersion",
+          [](nb::handle) {
+            return MolStandardize::TautomerScoringFunctions::
+                tautomerScoringVersion;
+          });
+
+  m.def("GetV1TautomerEnumerator", MolStandardize::getV1TautomerEnumerator,
+        "return a TautomerEnumerator using v1 of the enumeration rules",
+        nb::rv_policy::take_ownership);
+
+  m.def("ScoreRings",
+        MolStandardize::TautomerScoringFunctions::scoreRings, "mol"_a,
         "scores the ring system of the tautomer for canonicalization\n"
-        "Aromatic rings score 100, all carbon aromatic rings score 250";
-    python::def("ScoreRings",
-                MolStandardize::TautomerScoringFunctions::scoreRings,
-                python::arg("mol"), docString.c_str());
+        "Aromatic rings score 100, all carbon aromatic rings score 250");
 
-    docString =
+  m.def("ScoreHeteroHs",
+        MolStandardize::TautomerScoringFunctions::scoreHeteroHs, "mol"_a,
         "scores the number of heteroHs of the tautomer for canonicalization\n"
-        "This gives a negative penalty to hydrogens attached to S,P, Se and Te";
-    python::def("ScoreHeteroHs",
-                MolStandardize::TautomerScoringFunctions::scoreHeteroHs,
-                python::arg("mol"), docString.c_str());
+        "This gives a negative penalty to hydrogens attached to S,P, Se and Te");
 
-    python::class_<MolStandardize::TautomerScoringFunctions::SubstructTerm>(
-        "SubstructTerm",
-        "Sets the score of this particular tautomer substructure, higher scores are more preferable\n"
-        "Aromatic rings score 100, all carbon aromatic rings score 250",
-        python::init<std::string, std::string, int>(
-            python::args("self", "name", "smarts", "score")))
-        .def_readonly(
-            "name",
-            &MolStandardize::TautomerScoringFunctions::SubstructTerm::name)
-        .def_readonly(
-            "smarts",
-            &MolStandardize::TautomerScoringFunctions::SubstructTerm::smarts)
-        .def_readonly(
-            "score",
-            &MolStandardize::TautomerScoringFunctions::SubstructTerm::score);
+  nb::class_<MolStandardize::TautomerScoringFunctions::SubstructTerm>(
+      m, "SubstructTerm",
+      "Sets the score of this particular tautomer substructure, higher scores "
+      "are more preferable\n"
+      "Aromatic rings score 100, all carbon aromatic rings score 250")
+      .def(nb::init<std::string, std::string, int>(), "name"_a, "smarts"_a,
+           "score"_a)
+      .def_ro(
+          "name",
+          &MolStandardize::TautomerScoringFunctions::SubstructTerm::name)
+      .def_ro(
+          "smarts",
+          &MolStandardize::TautomerScoringFunctions::SubstructTerm::smarts)
+      .def_ro(
+          "score",
+          &MolStandardize::TautomerScoringFunctions::SubstructTerm::score);
 
-    python::class_<
-        std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>(
-        "SubstructTermVector")
-        .def(python::vector_indexing_suite<std::vector<
-                 MolStandardize::TautomerScoringFunctions::SubstructTerm>>());
-    
-    docString = "scores the tautomer substructures";
-    python::def("ScoreSubstructs", &MolStandardize::TautomerScoringFunctions::scoreSubstructs,
-		scoreSubstructs_overloads((python::arg("mol"), python::arg("terms")),
-					  docString.c_str())
-		);
+  nb::bind_vector<
+      std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>(
+      m, "SubstructTermVector");
 
+  m.def(
+      "ScoreSubstructs",
+      [](const ROMol &mol,
+         nb::object terms) -> int {
+        if (terms.is_none()) {
+          return MolStandardize::TautomerScoringFunctions::scoreSubstructs(mol);
+        }
+        return MolStandardize::TautomerScoringFunctions::scoreSubstructs(
+            mol,
+            nb::cast<std::vector<
+                MolStandardize::TautomerScoringFunctions::SubstructTerm> &>(
+                terms));
+      },
+      "mol"_a, "terms"_a = nb::none(), "scores the tautomer substructures");
 
-    python::def("GetDefaultTautomerScoreSubstructs",
-                GetDefaultTautomerSubstructsHelper,
-                "Return the default tautomer substructure scoring terms");
-  }
-};
-
-void wrap_tautomer() { tautomer_wrapper::wrap(); }
+  m.def("GetDefaultTautomerScoreSubstructs",
+        GetDefaultTautomerSubstructsHelper,
+        "Return the default tautomer substructure scoring terms");
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Tautomer.cpp
@@ -1,0 +1,562 @@
+//
+//  Copyright (C) 2020 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#define NO_IMPORT_ARRAY
+#include <boost/python/suite/indexing/map_indexing_suite.hpp>
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/MolStandardize.h>
+#include <GraphMol/MolStandardize/Tautomer.h>
+#include <sstream>
+
+namespace python = boost::python;
+using namespace RDKit;
+
+namespace {
+class PyTautomerEnumeratorResult {
+ public:
+  PyTautomerEnumeratorResult(const MolStandardize::TautomerEnumeratorResult &tr)
+      : d_tr(new MolStandardize::TautomerEnumeratorResult(std::move(tr))) {
+    python::list atList;
+    python::list bndList;
+    for (unsigned int i = 0; i < d_tr->modifiedAtoms().size(); ++i) {
+      if (d_tr->modifiedAtoms().test(i)) {
+        atList.append(i);
+      }
+    }
+    for (unsigned int i = 0; i < d_tr->modifiedBonds().size(); ++i) {
+      if (d_tr->modifiedBonds().test(i)) {
+        bndList.append(i);
+      }
+    }
+    d_atTuple = python::tuple(atList);
+    d_bndTuple = python::tuple(bndList);
+  }
+  inline const std::vector<ROMOL_SPTR> *tautomers() const {
+    return new std::vector<ROMOL_SPTR>(d_tr->tautomers());
+  }
+  inline const std::vector<std::string> *smiles() const {
+    return new std::vector<std::string>(d_tr->smiles());
+  }
+  inline const MolStandardize::SmilesTautomerMap &smilesTautomerMap() const {
+    return d_tr->smilesTautomerMap();
+  }
+  inline MolStandardize::TautomerEnumeratorStatus status() const {
+    return d_tr->status();
+  }
+  inline python::tuple modifiedAtoms() const { return d_atTuple; }
+  inline python::tuple modifiedBonds() const { return d_bndTuple; }
+  inline const MolStandardize::TautomerEnumeratorResult::const_iterator begin()
+      const {
+    return d_tr->begin();
+  }
+  inline const MolStandardize::TautomerEnumeratorResult::const_iterator end()
+      const {
+    return d_tr->end();
+  }
+  inline int size() const { return d_tr->size(); }
+  RDKit::ROMol *at(int pos) const {
+    if (pos < 0) {
+      pos += size();
+    }
+    if (pos < 0 || pos >= size()) {
+      PyErr_SetString(PyExc_IndexError, "index out of bounds");
+      python::throw_error_already_set();
+      return nullptr;
+    }
+    return new RDKit::ROMol(*d_tr->at(pos));
+  }
+  const MolStandardize::TautomerEnumeratorResult *get() { return d_tr.get(); }
+
+ private:
+  boost::shared_ptr<MolStandardize::TautomerEnumeratorResult> d_tr;
+  python::tuple d_atTuple;
+  python::tuple d_bndTuple;
+};
+
+class PyTautomerEnumeratorCallback
+    : public MolStandardize::TautomerEnumeratorCallback,
+      public python::wrapper<MolStandardize::TautomerEnumeratorCallback> {
+ public:
+  PyTautomerEnumeratorCallback() {}
+  PyTautomerEnumeratorCallback(const python::object &pyCallbackObject) {
+    PyTautomerEnumeratorCallback *pyCallback =
+        python::extract<PyTautomerEnumeratorCallback *>(pyCallbackObject);
+    *this = *pyCallback;
+    d_pyCallbackObject = pyCallbackObject;
+    pyCallback->d_cppCallback = this;
+  }
+  inline python::object getCallbackOverride() const {
+    return get_override("__call__");
+  }
+  bool operator()(
+      const ROMol &mol,
+      const MolStandardize::TautomerEnumeratorResult &res) override {
+    PyTautomerEnumeratorResult pyRes(res);
+    return getCallbackOverride()(boost::ref(mol), boost::ref(pyRes));
+  }
+  python::object getPyCallbackObject() { return d_pyCallbackObject; }
+
+ private:
+  PyTautomerEnumeratorCallback *d_cppCallback;
+  python::object d_pyCallbackObject;
+};
+
+typedef boost::shared_ptr<MolStandardize::Tautomer> TAUT_SPTR;
+
+ROMol *getTautomerHelper(const TAUT_SPTR &self) {
+  return new ROMol(*self->tautomer);
+}
+
+ROMol *getKekulizedHelper(const TAUT_SPTR &self) {
+  return new ROMol(*self->getKekulized());
+}
+
+python::tuple smilesTautomerMapKeysHelper(
+    const MolStandardize::SmilesTautomerMap &self) {
+  python::list keys;
+  for (const auto &pair : self) {
+    keys.append(pair.first);
+  }
+  return python::tuple(keys);
+}
+
+python::tuple smilesTautomerMapValuesHelper(
+    const MolStandardize::SmilesTautomerMap &self) {
+  python::list values;
+  for (const auto &pair : self) {
+    values.append(TAUT_SPTR(new MolStandardize::Tautomer(pair.second)));
+  }
+  return python::tuple(values);
+}
+
+python::tuple smilesTautomerMapItemsHelper(
+    const MolStandardize::SmilesTautomerMap &self) {
+  python::list items;
+  for (const auto &pair : self) {
+    items.append(python::make_tuple(
+        pair.first, TAUT_SPTR(new MolStandardize::Tautomer(pair.second))));
+  }
+  return python::tuple(items);
+}
+
+python::object getCallbackHelper(const MolStandardize::TautomerEnumerator &te) {
+  PyTautomerEnumeratorCallback *cppCallback =
+      dynamic_cast<PyTautomerEnumeratorCallback *>(te.getCallback());
+  python::object res;
+  if (cppCallback) {
+    res = cppCallback->getPyCallbackObject();
+  }
+  return res;
+};
+
+void setCallbackHelper(MolStandardize::TautomerEnumerator &te,
+                       PyObject *callback) {
+  PRECONDITION(callback, "callback must not be NULL");
+  if (callback == Py_None) {
+    te.setCallback(nullptr);
+    return;
+  }
+  python::object callbackObject(python::handle<>(python::borrowed(callback)));
+  python::extract<PyTautomerEnumeratorCallback *> extractCallback(
+      callbackObject);
+  if (extractCallback.check()) {
+    if (!PyCallable_Check(extractCallback()->getCallbackOverride().ptr())) {
+      PyErr_SetString(PyExc_AttributeError,
+                      "The __call__ attribute in the "
+                      "rdMolStandardize.TautomerEnumeratorCallback subclass "
+                      "must exist and be a callable method");
+      python::throw_error_already_set();
+    } else {
+      te.setCallback(new PyTautomerEnumeratorCallback(callbackObject));
+    }
+  } else {
+    PyErr_SetString(PyExc_TypeError,
+                    "Expected an instance of a "
+                    "rdMolStandardize.TautomerEnumeratorCallback subclass");
+    python::throw_error_already_set();
+  }
+}
+
+std::string tautomerEnumeratorCallbackClassDoc =
+    R"DOC(Create a derived class from this abstract base class and
+    implement the __call__() method.
+    The __call__() method is called in the innermost loop of the
+    algorithm, and provides a mechanism to monitor or stop
+    its progress.
+
+    To have your callback called, pass an instance of your
+    derived class to TautomerEnumerator.SetCallback())DOC";
+
+MolStandardize::TautomerEnumerator *EnumeratorFromParams(
+    const MolStandardize::CleanupParameters &params) {
+  return new MolStandardize::TautomerEnumerator(params);
+}
+
+MolStandardize::TautomerEnumerator *createDefaultEnumerator() {
+  MolStandardize::CleanupParameters ps;
+  return EnumeratorFromParams(ps);
+}
+
+MolStandardize::TautomerEnumerator *copyEnumerator(
+    const MolStandardize::TautomerEnumerator &other) {
+  return new MolStandardize::TautomerEnumerator(other);
+}
+
+class pyobjFunctor {
+ public:
+  pyobjFunctor(python::object obj) : dp_obj(std::move(obj)) {}
+  ~pyobjFunctor() = default;
+  int operator()(const ROMol &m) {
+    return python::extract<int>(dp_obj(boost::ref(m)));
+  }
+
+ private:
+  python::object dp_obj;
+};
+
+ROMol *canonicalizeHelper(const MolStandardize::TautomerEnumerator &self,
+                          const ROMol &mol) {
+  return self.canonicalize(mol);
+}
+
+ROMol *canonicalizeHelper2(const MolStandardize::TautomerEnumerator &self,
+                           const ROMol &mol, python::object scoreFunc) {
+  pyobjFunctor ftor(scoreFunc);
+  return self.canonicalize(mol, ftor);
+}
+
+inline std::vector<ROMOL_SPTR> extractPythonIterable(const python::object &o) {
+  if (!PyObject_HasAttrString(o.ptr(), "__iter__")) {
+    PyErr_SetString(PyExc_TypeError,
+                    "the passed object should be an iterable of Mol objects");
+    python::throw_error_already_set();
+    return std::vector<ROMOL_SPTR>();
+  }
+  return std::vector<ROMOL_SPTR>(python::stl_input_iterator<ROMOL_SPTR>(o),
+                                 python::stl_input_iterator<ROMOL_SPTR>());
+}
+
+ROMol *pickCanonicalHelper(const MolStandardize::TautomerEnumerator &self,
+                           const python::object &o) {
+  python::extract<PyTautomerEnumeratorResult *> e(o);
+  if (e.check()) {
+    return self.pickCanonical(*e()->get());
+  }
+  return self.pickCanonical(extractPythonIterable(o));
+}
+
+ROMol *pickCanonicalHelper2(const MolStandardize::TautomerEnumerator &self,
+                            const python::object &o, python::object scoreFunc) {
+  pyobjFunctor ftor(scoreFunc);
+  python::extract<PyTautomerEnumeratorResult *> e(o);
+  if (e.check()) {
+    return self.pickCanonical(*e()->get(), ftor);
+  }
+  return self.pickCanonical(extractPythonIterable(o), ftor);
+}
+
+PyTautomerEnumeratorResult *enumerateHelper(
+    const MolStandardize::TautomerEnumerator &self, const ROMol &mol) {
+  return new PyTautomerEnumeratorResult(self.enumerate(mol));
+}
+
+std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>
+GetDefaultTautomerSubstructsHelper() {
+  std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms;
+  for (auto term : MolStandardize::TautomerScoringFunctions::
+           getDefaultTautomerScoreSubstructs()) {
+    terms.emplace_back(term);
+  }
+  return terms;
+}
+  
+
+}  // namespace
+
+// This indicates that the scoreSubstructs takes a minimum of 1 argument and a maximum of 2
+// so we can call it ScoreSubstructs(mol) or ScoreSubstructs(mol, terms)
+BOOST_PYTHON_FUNCTION_OVERLOADS(scoreSubstructs_overloads,
+				RDKit::MolStandardize::TautomerScoringFunctions::scoreSubstructs, 1, 2)
+
+struct tautomer_wrapper {
+  static void wrap() {
+    python::enum_<MolStandardize::TautomerEnumeratorStatus>(
+        "TautomerEnumeratorStatus")
+        .value("Completed", MolStandardize::TautomerEnumeratorStatus::Completed)
+        .value("MaxTautomersReached",
+               MolStandardize::TautomerEnumeratorStatus::MaxTautomersReached)
+        .value("MaxTransformsReached",
+               MolStandardize::TautomerEnumeratorStatus::MaxTransformsReached)
+        .value("Canceled", MolStandardize::TautomerEnumeratorStatus::Canceled);
+
+    python::class_<PyTautomerEnumeratorCallback, boost::noncopyable>(
+        "TautomerEnumeratorCallback",
+        tautomerEnumeratorCallbackClassDoc.c_str(),
+        python::init<>(python::args("self")))
+        .def("__call__",
+             python::pure_virtual(&PyTautomerEnumeratorCallback::operator()),
+             python::args("self", "mol", "res"),
+             "This must be implemented in the derived class. "
+             "Return True if the tautomer enumeration should continue; "
+             "False if the tautomer enumeration should stop.\n");
+
+    python::class_<MolStandardize::Tautomer, TAUT_SPTR>(
+        "Tautomer",
+        "used to hold the aromatic and kekulized versions "
+        "of each tautomer",
+        python::no_init)
+        .add_property(
+            "tautomer",
+            python::make_function(
+                &getTautomerHelper,
+                python::return_value_policy<python::manage_new_object>()),
+            "aromatic version of the tautomer")
+        .add_property(
+            "kekulized",
+            python::make_function(
+                &getKekulizedHelper,
+                python::return_value_policy<python::manage_new_object>()),
+            "kekulized version of the tautomer");
+
+    python::class_<MolStandardize::SmilesTautomerMap, boost::noncopyable>(
+        "SmilesTautomerMap",
+        "maps SMILES strings to the respective Tautomer objects",
+        python::no_init)
+        .def(python::map_indexing_suite<MolStandardize::SmilesTautomerMap,
+                                        true>())
+        .def("keys", &smilesTautomerMapKeysHelper, python::args("self"))
+        .def("values", &smilesTautomerMapValuesHelper, python::args("self"))
+        .def("items", &smilesTautomerMapItemsHelper, python::args("self"));
+
+    python::class_<PyTautomerEnumeratorResult, boost::noncopyable>(
+        "TautomerEnumeratorResult",
+        "used to return tautomer enumeration results", python::no_init)
+        .add_property(
+            "tautomers",
+            python::make_function(
+                &PyTautomerEnumeratorResult::tautomers,
+                python::return_value_policy<python::manage_new_object>()),
+            "tautomers generated by the enumerator")
+        .add_property(
+            "smiles",
+            python::make_function(
+                &PyTautomerEnumeratorResult::smiles,
+                python::return_value_policy<python::manage_new_object>()),
+            "SMILES of tautomers generated by the enumerator")
+        .add_property("smilesTautomerMap",
+                      python::make_function(
+                          &PyTautomerEnumeratorResult::smilesTautomerMap,
+                          python::return_value_policy<
+                              python::reference_existing_object>()),
+                      "dictionary mapping SMILES strings to the respective "
+                      "Tautomer objects")
+        .add_property("status", &PyTautomerEnumeratorResult::status,
+                      "whether the enumeration completed or not; see "
+                      "TautomerEnumeratorStatus for possible values")
+        .add_property(
+            "modifiedAtoms",
+            python::make_function(&PyTautomerEnumeratorResult::modifiedAtoms),
+            "tuple of atom indices modified by the transforms")
+        .add_property(
+            "modifiedBonds",
+            python::make_function(&PyTautomerEnumeratorResult::modifiedBonds),
+            "tuple of bond indices modified by the transforms")
+        .def("__call__", &PyTautomerEnumeratorResult::tautomers,
+             python::return_value_policy<python::manage_new_object>(),
+             python::args("self"), "tautomers generated by the enumerator")
+        .def("__iter__", python::range(&PyTautomerEnumeratorResult::begin,
+                                       &PyTautomerEnumeratorResult::end))
+        .def("__getitem__", &PyTautomerEnumeratorResult::at,
+             python::return_value_policy<python::manage_new_object>(),
+             python::args("self", "pos"))
+        .def("__len__", &PyTautomerEnumeratorResult::size,
+             python::args("self"));
+
+    python::class_<MolStandardize::TautomerEnumerator, boost::noncopyable>(
+        "TautomerEnumerator", python::no_init)
+        .def("__init__", python::make_constructor(createDefaultEnumerator))
+        .def("__init__", python::make_constructor(EnumeratorFromParams))
+        .def("__init__", python::make_constructor(copyEnumerator))
+        .def("Enumerate", &enumerateHelper,
+             (python::arg("self"), python::arg("mol")),
+             python::return_value_policy<python::manage_new_object>(),
+             R"DOC(Generates the tautomers for a molecule.
+             
+  The enumeration rules are inspired by the publication:
+  M. Sitzmann et al., “Tautomerism in Large Databases.”, JCAMD 24:521 (2010)
+  https://doi.org/10.1007/s10822-010-9346-4
+  
+  Note: the definitions used here are that the atoms modified during
+  tautomerization are the atoms at the beginning and end of each tautomer
+  transform (the H "donor" and H "acceptor" in the transform) and the bonds
+  modified during transformation are any bonds whose order is changed during
+  the tautomer transform (these are the bonds between the "donor" and the
+  "acceptor").)DOC")
+        .def("Canonicalize", &canonicalizeHelper,
+             (python::arg("self"), python::arg("mol")),
+             python::return_value_policy<python::manage_new_object>(),
+             R"DOC(Returns the canonical tautomer for a molecule.
+
+  The default scoring scheme is inspired by the publication:
+  M. Sitzmann et al., “Tautomerism in Large Databases.”, JCAMD 24:521 (2010)
+  https://doi.org/10.1007/s10822-010-9346-4
+
+  Note that the canonical tautomer is very likely not the most stable tautomer
+  for any given conditions. The default scoring rules are designed to produce
+  "reasonable" tautomers, but the primary concern is that the results are
+  canonical: you always get the same canonical tautomer for a molecule
+  regardless of what the input tautomer or atom ordering were.)DOC")
+        .def(
+            "Canonicalize", &canonicalizeHelper2,
+            (python::arg("self"), python::arg("mol"), python::arg("scoreFunc")),
+            python::return_value_policy<python::manage_new_object>(),
+            "picks the canonical tautomer from an iterable of molecules "
+            "using a custom scoring function")
+        .def("PickCanonical", &pickCanonicalHelper,
+             (python::arg("self"), python::arg("iterable")),
+             python::return_value_policy<python::manage_new_object>(),
+             "picks the canonical tautomer from an iterable of molecules")
+        .def("PickCanonical", &pickCanonicalHelper2,
+             (python::arg("self"), python::arg("iterable"),
+              python::arg("scoreFunc")),
+             python::return_value_policy<python::manage_new_object>(),
+             "returns the canonical tautomer for a molecule using a custom "
+             "scoring function")
+        .def("ScoreTautomer",
+             &MolStandardize::TautomerScoringFunctions::scoreTautomer,
+             (python::arg("mol")),
+             "returns the score for a tautomer using the default scoring "
+             "scheme.")
+        .staticmethod("ScoreTautomer")
+        .def("SetMaxTautomers",
+             &MolStandardize::TautomerEnumerator::setMaxTautomers,
+             (python::arg("self"), python::arg("maxTautomers")),
+             "set the maximum number of tautomers to be generated.")
+        .def("GetMaxTautomers",
+             &MolStandardize::TautomerEnumerator::getMaxTautomers,
+             (python::arg("self")),
+             "returns the maximum number of tautomers to be generated.")
+        .def("SetMaxTransforms",
+             &MolStandardize::TautomerEnumerator::setMaxTransforms,
+             (python::arg("self"), python::arg("maxTransforms")),
+             "set the maximum number of transformations to be applied. "
+             "This limit is usually hit earlier than the maxTautomers limit "
+             "and leads to a more linear scaling of CPU time with increasing "
+             "number of tautomeric centers (see Sitzmann et al.).")
+        .def("GetMaxTransforms",
+             &MolStandardize::TautomerEnumerator::getMaxTransforms,
+             (python::arg("self")),
+             "returns the maximum number of transformations to be applied.")
+        .def("SetRemoveSp3Stereo",
+             &MolStandardize::TautomerEnumerator::setRemoveSp3Stereo,
+             (python::arg("self"), python::arg("removeSp3Stereo")),
+             "set to True if you wish stereochemistry information "
+             "to be removed from sp3 atoms involved in tautomerism. "
+             "This means that S-aminoacids will lose their stereochemistry "
+             "after going through tautomer enumeration because of the "
+             "amido-imidol tautomerism. This defaults to True in RDKit, "
+             "and to False in the workflow described by Sitzmann et al.")
+        .def("GetRemoveSp3Stereo",
+             &MolStandardize::TautomerEnumerator::getRemoveSp3Stereo,
+             (python::arg("self")),
+             "returns whether stereochemistry information will be removed from "
+             "sp3 atoms involved in tautomerism.")
+        .def("SetRemoveBondStereo",
+             &MolStandardize::TautomerEnumerator::setRemoveBondStereo,
+             (python::arg("self"), python::arg("removeBondStereo")),
+             "set to True if you wish stereochemistry information "
+             "to be removed from double bonds involved in tautomerism. "
+             "This means that enols will lose their E/Z stereochemistry "
+             "after going through tautomer enumeration because of the "
+             "keto-enolic tautomerism. This defaults to True in the "
+             "RDKit and also in the workflow described by Sitzmann et al.")
+        .def("GetRemoveBondStereo",
+             &MolStandardize::TautomerEnumerator::getRemoveBondStereo,
+             (python::arg("self")),
+             "returns whether stereochemistry information "
+             "will be removed from double bonds involved in tautomerism.")
+        .def("SetReassignStereo",
+             &MolStandardize::TautomerEnumerator::setReassignStereo,
+             (python::arg("self"), python::arg("reassignStereo")),
+             "set to True if you wish AssignStereochemistry to be called "
+             "on each tautomer generated by the Enumerate() method. "
+             "This defaults to True.")
+        .def("GetReassignStereo",
+             &MolStandardize::TautomerEnumerator::getReassignStereo,
+             (python::arg("self")),
+             "returns whether AssignStereochemistry will be called "
+             "on each tautomer generated by the Enumerate() method.")
+        .def("SetCallback", &setCallbackHelper,
+             python::args("self", "callback"),
+             "Pass an instance of a class derived from\n"
+             "TautomerEnumeratorCallback, which must implement the\n"
+             "__call__() method.")
+        .def("GetCallback", &getCallbackHelper, python::args("self"),
+             "Get the TautomerEnumeratorCallback subclass instance,\n"
+             "or None if none was set.")
+        .def_readonly(
+            "tautomerScoreVersion",
+            MolStandardize::TautomerScoringFunctions::tautomerScoringVersion);
+    python::def("GetV1TautomerEnumerator",
+                MolStandardize::getV1TautomerEnumerator,
+                "return a TautomerEnumerator using v1 of the enumeration rules",
+                python::return_value_policy<python::manage_new_object>());
+
+    std::string docString =
+        "scores the ring system of the tautomer for canonicalization\n"
+        "Aromatic rings score 100, all carbon aromatic rings score 250";
+    python::def("ScoreRings",
+                MolStandardize::TautomerScoringFunctions::scoreRings,
+                python::arg("mol"), docString.c_str());
+
+    docString =
+        "scores the number of heteroHs of the tautomer for canonicalization\n"
+        "This gives a negative penalty to hydrogens attached to S,P, Se and Te";
+    python::def("ScoreHeteroHs",
+                MolStandardize::TautomerScoringFunctions::scoreHeteroHs,
+                python::arg("mol"), docString.c_str());
+
+    python::class_<MolStandardize::TautomerScoringFunctions::SubstructTerm>(
+        "SubstructTerm",
+        "Sets the score of this particular tautomer substructure, higher scores are more preferable\n"
+        "Aromatic rings score 100, all carbon aromatic rings score 250",
+        python::init<std::string, std::string, int>(
+            python::args("self", "name", "smarts", "score")))
+        .def_readonly(
+            "name",
+            &MolStandardize::TautomerScoringFunctions::SubstructTerm::name)
+        .def_readonly(
+            "smarts",
+            &MolStandardize::TautomerScoringFunctions::SubstructTerm::smarts)
+        .def_readonly(
+            "score",
+            &MolStandardize::TautomerScoringFunctions::SubstructTerm::score);
+
+    python::class_<
+        std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>(
+        "SubstructTermVector")
+        .def(python::vector_indexing_suite<std::vector<
+                 MolStandardize::TautomerScoringFunctions::SubstructTerm>>());
+    
+    docString = "scores the tautomer substructures";
+    python::def("ScoreSubstructs", &MolStandardize::TautomerScoringFunctions::scoreSubstructs,
+		scoreSubstructs_overloads((python::arg("mol"), python::arg("terms")),
+					  docString.c_str())
+		);
+
+
+    python::def("GetDefaultTautomerScoreSubstructs",
+                GetDefaultTautomerSubstructsHelper,
+                "Return the default tautomer substructure scoring terms");
+  }
+};
+
+void wrap_tautomer() { tautomer_wrapper::wrap(); }

--- a/Code/GraphMol/MolStandardize/nbWrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Validate.cpp
@@ -1,0 +1,219 @@
+//
+//  Copyright (C) 2018 Susan H. Leung
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/Validate.h>
+
+namespace python = boost::python;
+using namespace RDKit;
+
+namespace {
+
+struct ValidationMethodWrap
+    : MolStandardize::ValidationMethod,
+      python::wrapper<MolStandardize::ValidationMethod> {
+  std::vector<MolStandardize::ValidationErrorInfo> validate(
+      const ROMol &mol, bool reportAllFailures) const override {
+    return this->get_override("validate")(mol, reportAllFailures);
+  }
+
+  std::shared_ptr<MolStandardize::ValidationMethod> copy() const override {
+    return this->get_override("copy")();
+  }
+};
+
+// Wrap ValidationMethod::validate and convert the returned
+// vector into a python list of strings
+python::list pythonValidateMethod(const MolStandardize::ValidationMethod &self,
+                                  const ROMol &mol, bool reportAllFailures) {
+  python::list res;
+  std::vector<MolStandardize::ValidationErrorInfo> errout =
+      self.validate(mol, reportAllFailures);
+  for (const auto &msg : errout) {
+    res.append(msg);
+  }
+  return res;
+}
+
+MolStandardize::MolVSValidation *getMolVSValidation(
+    python::object validations) {
+  std::vector<std::shared_ptr<MolStandardize::ValidationMethod>> vs;
+
+  auto pvect =
+      pythonObjectToVect<std::shared_ptr<MolStandardize::ValidationMethod>>(
+          validations);
+  if (!pvect) {
+    throw_value_error("validations argument must be non-empty");
+  }
+  for (auto v : *pvect) {
+    vs.push_back(v->copy());
+  }
+  return new MolStandardize::MolVSValidation(vs);
+}
+
+MolStandardize::AllowedAtomsValidation *getAllowedAtomsValidation(
+    python::object atoms) {
+  auto p_atomList = pythonObjectToVect<Atom *>(atoms);
+  if (!p_atomList) {
+    throw_value_error("allowedAtoms argument must be non-empty");
+  }
+  std::vector<std::shared_ptr<Atom>> satoms;
+  for (auto ap : *p_atomList) {
+    satoms.push_back(std::shared_ptr<Atom>(ap->copy()));
+  }
+  return new MolStandardize::AllowedAtomsValidation(satoms);
+}
+
+MolStandardize::DisallowedAtomsValidation *getDisallowedAtomsValidation(
+    python::object atoms) {
+  auto p_atomList = pythonObjectToVect<Atom *>(atoms);
+  if (!p_atomList) {
+    throw_value_error("disallowedAtoms must be non-empty");
+  }
+  std::vector<std::shared_ptr<Atom>> satoms;
+  for (auto ap : *p_atomList) {
+    satoms.push_back(std::shared_ptr<Atom>(ap->copy()));
+  }
+  return new MolStandardize::DisallowedAtomsValidation(satoms);
+}
+
+python::list standardizeSmilesHelper(const std::string &smiles) {
+  python::list res;
+  std::vector<MolStandardize::ValidationErrorInfo> errout =
+      MolStandardize::validateSmiles(smiles);
+  for (const auto &msg : errout) {
+    res.append(msg);
+  }
+  return res;
+}
+
+}  // namespace
+
+struct validate_wrapper {
+  static void wrap() {
+    std::string docString = "";
+
+    python::class_<ValidationMethodWrap, boost::noncopyable>("ValidationMethod")
+        .def("validate", pythonValidateMethod,
+             (python::arg("self"), python::arg("mol"),
+              python::arg("reportAllFailures") = false),
+             "");
+
+    python::class_<MolStandardize::RDKitValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("RDKitValidation")
+        .def(python::init<bool>(python::arg("allowEmptyMolecules") = false))
+        .def_readwrite("allowEmptyMolecules",
+                       &MolStandardize::RDKitValidation::allowEmptyMolecules);
+
+    python::class_<MolStandardize::NoAtomValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("NoAtomValidation");
+
+    python::class_<MolStandardize::FragmentValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("FragmentValidation");
+
+    python::class_<MolStandardize::NeutralValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("NeutralValidation");
+
+    python::class_<MolStandardize::IsotopeValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("IsotopeValidation")
+        .def(python::init<bool>(python::arg("strict") = false))
+        .def_readwrite("strict", &MolStandardize::IsotopeValidation::strict);
+
+    python::class_<MolStandardize::MolVSValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("MolVSValidation")
+        .def("__init__", python::make_constructor(&getMolVSValidation));
+
+    python::class_<MolStandardize::AllowedAtomsValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("AllowedAtomsValidation",
+                                       python::no_init)
+        .def("__init__", python::make_constructor(&getAllowedAtomsValidation));
+
+    python::class_<MolStandardize::DisallowedAtomsValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("DisallowedAtomsValidation",
+                                       python::no_init)
+        .def("__init__",
+             python::make_constructor(&getDisallowedAtomsValidation));
+
+    python::class_<MolStandardize::FeaturesValidation,
+                   python::bases<MolStandardize::ValidationMethod>>(
+        "FeaturesValidation")
+        .def(python::init<bool, bool, bool, bool, bool, bool>(
+            (python::arg("allowEnhancedStereo") = false,
+             python::arg("allowAromaticBondType") = false,
+             python::arg("allowDativeBondType") = false,
+             python::arg("allowQueries") = false,
+             python::arg("allowDummmies") = false,
+             python::arg("allowAtomAliases") = false)))
+        .def_readwrite("allowEnhancedStereo",
+                       &MolStandardize::FeaturesValidation::allowEnhancedStereo)
+        .def_readwrite(
+            "allowAromaticBondType",
+            &MolStandardize::FeaturesValidation::allowAromaticBondType)
+        .def_readwrite("allowDativeBondType",
+                       &MolStandardize::FeaturesValidation::allowDativeBondType)
+        .def_readwrite("allowQueries",
+                       &MolStandardize::FeaturesValidation::allowQueries)
+        .def_readwrite("allowDummies",
+                       &MolStandardize::FeaturesValidation::allowDummies)
+        .def_readwrite("allowAtomAliases",
+                       &MolStandardize::FeaturesValidation::allowAtomAliases);
+
+    python::class_<MolStandardize::DisallowedRadicalValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("DisallowedRadicalValidation");
+
+    python::class_<MolStandardize::Is2DValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("Is2DValidation")
+        .def(python::init<double>(python::arg("threshold") = 1e-3))
+        .def_readwrite("threshold", &MolStandardize::Is2DValidation::threshold);
+
+    python::class_<MolStandardize::Layout2DValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("Layout2DValidation")
+        .def(python::init<double, double, bool, bool, double>(
+            (python::arg("clashLimit") = 0.15,
+             python::arg("bondLengthLimit") = 25.,
+             python::arg("allowLongBondsInRings") = true,
+             python::arg("allowAtomBondClashExemption") = true,
+             python::arg("minMedianBondLength") = false)))
+        .def_readwrite("clashLimit",
+                       &MolStandardize::Layout2DValidation::clashLimit)
+        .def_readwrite("bondLengthLimit",
+                       &MolStandardize::Layout2DValidation::bondLengthLimit)
+        .def_readwrite(
+            "allowLongBondsInRings",
+            &MolStandardize::Layout2DValidation::allowLongBondsInRings)
+        .def_readwrite(
+            "allowAtomBondClashExemption",
+            &MolStandardize::Layout2DValidation::allowAtomBondClashExemption)
+        .def_readwrite(
+            "minMedianBondLength",
+            &MolStandardize::Layout2DValidation::minMedianBondLength);
+
+    python::class_<MolStandardize::StereoValidation,
+                   python::bases<MolStandardize::ValidationMethod>,
+                   boost::noncopyable>("StereoValidation");
+
+    python::def("ValidateSmiles", standardizeSmilesHelper, (python::arg("mol")),
+                docString.c_str());
+  }
+};
+
+void wrap_validate() { validate_wrapper::wrap(); }

--- a/Code/GraphMol/MolStandardize/nbWrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/Validate.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Susan H. Leung
+//  Copyright (C) 2018-2026 Susan H. Leung and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,34 +7,39 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/trampoline.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/Validate.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 using namespace RDKit;
 
 namespace {
 
-struct ValidationMethodWrap
-    : MolStandardize::ValidationMethod,
-      python::wrapper<MolStandardize::ValidationMethod> {
+struct ValidationMethodTrampoline : MolStandardize::ValidationMethod {
+  NB_TRAMPOLINE(MolStandardize::ValidationMethod, 2);
+
   std::vector<MolStandardize::ValidationErrorInfo> validate(
       const ROMol &mol, bool reportAllFailures) const override {
-    return this->get_override("validate")(mol, reportAllFailures);
+    NB_OVERRIDE_PURE(validate, mol, reportAllFailures);
   }
 
   std::shared_ptr<MolStandardize::ValidationMethod> copy() const override {
-    return this->get_override("copy")();
+    NB_OVERRIDE_PURE(copy);
   }
 };
 
 // Wrap ValidationMethod::validate and convert the returned
-// vector into a python list of strings
-python::list pythonValidateMethod(const MolStandardize::ValidationMethod &self,
-                                  const ROMol &mol, bool reportAllFailures) {
-  python::list res;
+// vector into a Python list of strings
+nb::list pythonValidateMethod(const MolStandardize::ValidationMethod &self,
+                              const ROMol &mol, bool reportAllFailures) {
+  nb::list res;
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
   for (const auto &msg : errout) {
@@ -43,50 +48,46 @@ python::list pythonValidateMethod(const MolStandardize::ValidationMethod &self,
   return res;
 }
 
-MolStandardize::MolVSValidation *getMolVSValidation(
-    python::object validations) {
+MolStandardize::MolVSValidation *getMolVSValidation(nb::object validations) {
   std::vector<std::shared_ptr<MolStandardize::ValidationMethod>> vs;
-
-  auto pvect =
-      pythonObjectToVect<std::shared_ptr<MolStandardize::ValidationMethod>>(
-          validations);
-  if (!pvect) {
-    throw_value_error("validations argument must be non-empty");
-  }
-  for (auto v : *pvect) {
+  for (nb::handle h : validations) {
+    auto v = nb::cast<std::shared_ptr<MolStandardize::ValidationMethod>>(h);
     vs.push_back(v->copy());
+  }
+  if (vs.empty()) {
+    throw nb::value_error("validations argument must be non-empty");
   }
   return new MolStandardize::MolVSValidation(vs);
 }
 
 MolStandardize::AllowedAtomsValidation *getAllowedAtomsValidation(
-    python::object atoms) {
-  auto p_atomList = pythonObjectToVect<Atom *>(atoms);
-  if (!p_atomList) {
-    throw_value_error("allowedAtoms argument must be non-empty");
-  }
+    nb::object atoms) {
   std::vector<std::shared_ptr<Atom>> satoms;
-  for (auto ap : *p_atomList) {
+  for (nb::handle h : atoms) {
+    auto ap = nb::cast<Atom *>(h);
     satoms.push_back(std::shared_ptr<Atom>(ap->copy()));
+  }
+  if (satoms.empty()) {
+    throw nb::value_error("allowedAtoms argument must be non-empty");
   }
   return new MolStandardize::AllowedAtomsValidation(satoms);
 }
 
 MolStandardize::DisallowedAtomsValidation *getDisallowedAtomsValidation(
-    python::object atoms) {
-  auto p_atomList = pythonObjectToVect<Atom *>(atoms);
-  if (!p_atomList) {
-    throw_value_error("disallowedAtoms must be non-empty");
-  }
+    nb::object atoms) {
   std::vector<std::shared_ptr<Atom>> satoms;
-  for (auto ap : *p_atomList) {
+  for (nb::handle h : atoms) {
+    auto ap = nb::cast<Atom *>(h);
     satoms.push_back(std::shared_ptr<Atom>(ap->copy()));
+  }
+  if (satoms.empty()) {
+    throw nb::value_error("disallowedAtoms must be non-empty");
   }
   return new MolStandardize::DisallowedAtomsValidation(satoms);
 }
 
-python::list standardizeSmilesHelper(const std::string &smiles) {
-  python::list res;
+nb::list standardizeSmilesHelper(const std::string &smiles) {
+  nb::list res;
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       MolStandardize::validateSmiles(smiles);
   for (const auto &msg : errout) {
@@ -97,123 +98,119 @@ python::list standardizeSmilesHelper(const std::string &smiles) {
 
 }  // namespace
 
-struct validate_wrapper {
-  static void wrap() {
-    std::string docString = "";
+void wrap_validate(nb::module_ &m) {
+  nb::class_<MolStandardize::ValidationMethod, ValidationMethodTrampoline>(
+      m, "ValidationMethod")
+      .def(nb::init<>())
+      .def("validate", pythonValidateMethod, "mol"_a,
+           "reportAllFailures"_a = false, "");
 
-    python::class_<ValidationMethodWrap, boost::noncopyable>("ValidationMethod")
-        .def("validate", pythonValidateMethod,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures") = false),
-             "");
+  nb::class_<MolStandardize::RDKitValidation,
+             MolStandardize::ValidationMethod>(m, "RDKitValidation")
+      .def(nb::init<bool>(), "allowEmptyMolecules"_a = false)
+      .def_rw("allowEmptyMolecules",
+               &MolStandardize::RDKitValidation::allowEmptyMolecules);
 
-    python::class_<MolStandardize::RDKitValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("RDKitValidation")
-        .def(python::init<bool>(python::arg("allowEmptyMolecules") = false))
-        .def_readwrite("allowEmptyMolecules",
-                       &MolStandardize::RDKitValidation::allowEmptyMolecules);
+  nb::class_<MolStandardize::NoAtomValidation,
+             MolStandardize::ValidationMethod>(m, "NoAtomValidation")
+      .def(nb::init<>());
 
-    python::class_<MolStandardize::NoAtomValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("NoAtomValidation");
+  nb::class_<MolStandardize::FragmentValidation,
+             MolStandardize::ValidationMethod>(m, "FragmentValidation")
+      .def(nb::init<>());
 
-    python::class_<MolStandardize::FragmentValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("FragmentValidation");
+  nb::class_<MolStandardize::NeutralValidation,
+             MolStandardize::ValidationMethod>(m, "NeutralValidation")
+      .def(nb::init<>());
 
-    python::class_<MolStandardize::NeutralValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("NeutralValidation");
+  nb::class_<MolStandardize::IsotopeValidation,
+             MolStandardize::ValidationMethod>(m, "IsotopeValidation")
+      .def(nb::init<bool>(), "strict"_a = false)
+      .def_rw("strict", &MolStandardize::IsotopeValidation::strict);
 
-    python::class_<MolStandardize::IsotopeValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("IsotopeValidation")
-        .def(python::init<bool>(python::arg("strict") = false))
-        .def_readwrite("strict", &MolStandardize::IsotopeValidation::strict);
+  nb::class_<MolStandardize::MolVSValidation,
+             MolStandardize::ValidationMethod>(m, "MolVSValidation")
+      .def(nb::init<>())
+      .def("__init__",
+           [](MolStandardize::MolVSValidation *self, nb::object validations) {
+             std::unique_ptr<MolStandardize::MolVSValidation> v(
+                 getMolVSValidation(validations));
+             new (self) MolStandardize::MolVSValidation(*v);
+           },
+           "validations"_a);
 
-    python::class_<MolStandardize::MolVSValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("MolVSValidation")
-        .def("__init__", python::make_constructor(&getMolVSValidation));
+  nb::class_<MolStandardize::AllowedAtomsValidation,
+             MolStandardize::ValidationMethod>(m, "AllowedAtomsValidation")
+      .def("__init__",
+           [](MolStandardize::AllowedAtomsValidation *self,
+              nb::object atoms) {
+             std::unique_ptr<MolStandardize::AllowedAtomsValidation> v(
+                 getAllowedAtomsValidation(atoms));
+             new (self) MolStandardize::AllowedAtomsValidation(*v);
+           },
+           "atoms"_a);
 
-    python::class_<MolStandardize::AllowedAtomsValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("AllowedAtomsValidation",
-                                       python::no_init)
-        .def("__init__", python::make_constructor(&getAllowedAtomsValidation));
+  nb::class_<MolStandardize::DisallowedAtomsValidation,
+             MolStandardize::ValidationMethod>(m, "DisallowedAtomsValidation")
+      .def("__init__",
+           [](MolStandardize::DisallowedAtomsValidation *self,
+              nb::object atoms) {
+             std::unique_ptr<MolStandardize::DisallowedAtomsValidation> v(
+                 getDisallowedAtomsValidation(atoms));
+             new (self) MolStandardize::DisallowedAtomsValidation(*v);
+           },
+           "atoms"_a);
 
-    python::class_<MolStandardize::DisallowedAtomsValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("DisallowedAtomsValidation",
-                                       python::no_init)
-        .def("__init__",
-             python::make_constructor(&getDisallowedAtomsValidation));
+  nb::class_<MolStandardize::FeaturesValidation,
+             MolStandardize::ValidationMethod>(m, "FeaturesValidation")
+      .def(nb::init<bool, bool, bool, bool, bool, bool>(),
+           "allowEnhancedStereo"_a = false, "allowAromaticBondType"_a = false,
+           "allowDativeBondType"_a = false, "allowQueries"_a = false,
+           "allowDummies"_a = false, "allowAtomAliases"_a = false)
+      .def_rw("allowEnhancedStereo",
+               &MolStandardize::FeaturesValidation::allowEnhancedStereo)
+      .def_rw("allowAromaticBondType",
+               &MolStandardize::FeaturesValidation::allowAromaticBondType)
+      .def_rw("allowDativeBondType",
+               &MolStandardize::FeaturesValidation::allowDativeBondType)
+      .def_rw("allowQueries",
+               &MolStandardize::FeaturesValidation::allowQueries)
+      .def_rw("allowDummies",
+               &MolStandardize::FeaturesValidation::allowDummies)
+      .def_rw("allowAtomAliases",
+               &MolStandardize::FeaturesValidation::allowAtomAliases);
 
-    python::class_<MolStandardize::FeaturesValidation,
-                   python::bases<MolStandardize::ValidationMethod>>(
-        "FeaturesValidation")
-        .def(python::init<bool, bool, bool, bool, bool, bool>(
-            (python::arg("allowEnhancedStereo") = false,
-             python::arg("allowAromaticBondType") = false,
-             python::arg("allowDativeBondType") = false,
-             python::arg("allowQueries") = false,
-             python::arg("allowDummmies") = false,
-             python::arg("allowAtomAliases") = false)))
-        .def_readwrite("allowEnhancedStereo",
-                       &MolStandardize::FeaturesValidation::allowEnhancedStereo)
-        .def_readwrite(
-            "allowAromaticBondType",
-            &MolStandardize::FeaturesValidation::allowAromaticBondType)
-        .def_readwrite("allowDativeBondType",
-                       &MolStandardize::FeaturesValidation::allowDativeBondType)
-        .def_readwrite("allowQueries",
-                       &MolStandardize::FeaturesValidation::allowQueries)
-        .def_readwrite("allowDummies",
-                       &MolStandardize::FeaturesValidation::allowDummies)
-        .def_readwrite("allowAtomAliases",
-                       &MolStandardize::FeaturesValidation::allowAtomAliases);
+  nb::class_<MolStandardize::DisallowedRadicalValidation,
+             MolStandardize::ValidationMethod>(m,
+                                               "DisallowedRadicalValidation")
+      .def(nb::init<>());
 
-    python::class_<MolStandardize::DisallowedRadicalValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("DisallowedRadicalValidation");
+  nb::class_<MolStandardize::Is2DValidation,
+             MolStandardize::ValidationMethod>(m, "Is2DValidation")
+      .def(nb::init<double>(), "threshold"_a = 1e-3)
+      .def_rw("threshold", &MolStandardize::Is2DValidation::threshold);
 
-    python::class_<MolStandardize::Is2DValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("Is2DValidation")
-        .def(python::init<double>(python::arg("threshold") = 1e-3))
-        .def_readwrite("threshold", &MolStandardize::Is2DValidation::threshold);
+  nb::class_<MolStandardize::Layout2DValidation,
+             MolStandardize::ValidationMethod>(m, "Layout2DValidation")
+      .def(nb::init<double, double, bool, bool, double>(),
+           "clashLimit"_a = 0.15, "bondLengthLimit"_a = 25.,
+           "allowLongBondsInRings"_a = true,
+           "allowAtomBondClashExemption"_a = true,
+           "minMedianBondLength"_a = false)
+      .def_rw("clashLimit", &MolStandardize::Layout2DValidation::clashLimit)
+      .def_rw("bondLengthLimit",
+               &MolStandardize::Layout2DValidation::bondLengthLimit)
+      .def_rw("allowLongBondsInRings",
+               &MolStandardize::Layout2DValidation::allowLongBondsInRings)
+      .def_rw(
+          "allowAtomBondClashExemption",
+          &MolStandardize::Layout2DValidation::allowAtomBondClashExemption)
+      .def_rw("minMedianBondLength",
+               &MolStandardize::Layout2DValidation::minMedianBondLength);
 
-    python::class_<MolStandardize::Layout2DValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("Layout2DValidation")
-        .def(python::init<double, double, bool, bool, double>(
-            (python::arg("clashLimit") = 0.15,
-             python::arg("bondLengthLimit") = 25.,
-             python::arg("allowLongBondsInRings") = true,
-             python::arg("allowAtomBondClashExemption") = true,
-             python::arg("minMedianBondLength") = false)))
-        .def_readwrite("clashLimit",
-                       &MolStandardize::Layout2DValidation::clashLimit)
-        .def_readwrite("bondLengthLimit",
-                       &MolStandardize::Layout2DValidation::bondLengthLimit)
-        .def_readwrite(
-            "allowLongBondsInRings",
-            &MolStandardize::Layout2DValidation::allowLongBondsInRings)
-        .def_readwrite(
-            "allowAtomBondClashExemption",
-            &MolStandardize::Layout2DValidation::allowAtomBondClashExemption)
-        .def_readwrite(
-            "minMedianBondLength",
-            &MolStandardize::Layout2DValidation::minMedianBondLength);
+  nb::class_<MolStandardize::StereoValidation,
+             MolStandardize::ValidationMethod>(m, "StereoValidation")
+      .def(nb::init<>());
 
-    python::class_<MolStandardize::StereoValidation,
-                   python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("StereoValidation");
-
-    python::def("ValidateSmiles", standardizeSmilesHelper, (python::arg("mol")),
-                docString.c_str());
-  }
-};
-
-void wrap_validate() { validate_wrapper::wrap(); }
+  m.def("ValidateSmiles", standardizeSmilesHelper, "mol"_a, "");
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/rdMolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/rdMolStandardize.cpp
@@ -1,0 +1,673 @@
+//
+//  Copyright (C) 2018-2023 Susan H. Leung and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolStandardize/MolStandardize.h>
+
+#include <vector>
+
+namespace python = boost::python;
+
+namespace {
+template <typename FUNCTYPE>
+RDKit::ROMol *msHelper(const RDKit::ROMol *mol, python::object params,
+                       FUNCTYPE func) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
+  const RDKit::MolStandardize::CleanupParameters *ps =
+      &RDKit::MolStandardize::defaultCleanupParameters;
+  if (params) {
+    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  }
+  return static_cast<RDKit::ROMol *>(
+      func(static_cast<const RDKit::RWMol *>(mol), *ps));
+}
+
+RDKit::ROMol *cleanupHelper(const RDKit::ROMol *mol, python::object params) {
+  return msHelper(
+      mol, params,
+      static_cast<
+          RDKit::RWMol *(*)(const RDKit::RWMol *,
+                            const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::cleanup));
+}
+
+RDKit::ROMol *normalizeHelper(const RDKit::ROMol *mol, python::object params) {
+  return msHelper(mol, params, RDKit::MolStandardize::normalize);
+}
+
+RDKit::ROMol *reionizeHelper(const RDKit::ROMol *mol, python::object params) {
+  return msHelper(mol, params, RDKit::MolStandardize::reionize);
+}
+
+RDKit::ROMol *removeFragsHelper(const RDKit::ROMol *mol,
+                                python::object params) {
+  return msHelper(mol, params, RDKit::MolStandardize::removeFragments);
+}
+
+RDKit::ROMol *canonicalTautomerHelper(const RDKit::ROMol *mol,
+                                      python::object params) {
+  return msHelper(mol, params, RDKit::MolStandardize::canonicalTautomer);
+}
+
+template <typename FUNCTYPE>
+void inPlaceHelper(RDKit::ROMol *mol, python::object params, FUNCTYPE func) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
+  const RDKit::MolStandardize::CleanupParameters *ps =
+      &RDKit::MolStandardize::defaultCleanupParameters;
+  if (params) {
+    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  }
+  func(*static_cast<RDKit::RWMol *>(mol), *ps);
+}
+
+template <typename FUNCTYPE>
+void inPlaceHelper2(RDKit::ROMol *mol, python::object params,
+                    bool skip_standardize, FUNCTYPE func) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
+  const RDKit::MolStandardize::CleanupParameters *ps =
+      &RDKit::MolStandardize::defaultCleanupParameters;
+  if (params) {
+    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  }
+  func(*static_cast<RDKit::RWMol *>(mol), *ps, skip_standardize);
+}
+void cleanupInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+  inPlaceHelper(
+      mol, params,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::cleanupInPlace));
+}
+
+void normalizeInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+  inPlaceHelper(
+      mol, params,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::normalizeInPlace));
+}
+
+void reionizeInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+  inPlaceHelper(
+      mol, params,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::reionizeInPlace));
+}
+
+void removeFragmentsInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+  inPlaceHelper(
+      mol, params,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::removeFragmentsInPlace));
+}
+
+void fragmentParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+                                 bool skip_standardize) {
+  inPlaceHelper2(
+      mol, params, skip_standardize,
+      static_cast<void (*)(
+          RDKit::RWMol &, const RDKit::MolStandardize::CleanupParameters &,
+          bool)>(RDKit::MolStandardize::fragmentParentInPlace));
+}
+
+void stereoParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+                               bool skip_standardize) {
+  inPlaceHelper2(
+      mol, params, skip_standardize,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::stereoParentInPlace));
+}
+
+void isotopeParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+                                bool skip_standardize) {
+  inPlaceHelper2(
+      mol, params, skip_standardize,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::isotopeParentInPlace));
+}
+
+void chargeParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+                               bool skip_standardize) {
+  inPlaceHelper2(
+      mol, params, skip_standardize,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::chargeParentInPlace));
+}
+
+void superParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+                              bool skip_standardize) {
+  inPlaceHelper2(
+      mol, params, skip_standardize,
+      static_cast<void (*)(RDKit::RWMol &,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::superParentInPlace));
+}
+
+void tautomerParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+                                 bool skip_standardize) {
+  inPlaceHelper2(
+      mol, params, skip_standardize,
+      static_cast<void (*)(
+          RDKit::RWMol &, const RDKit::MolStandardize::CleanupParameters &,
+          bool)>(RDKit::MolStandardize::tautomerParentInPlace));
+}
+
+template <typename FUNCTYPE>
+void mtinPlaceHelper(python::object pymols, int numThreads,
+                     python::object params, FUNCTYPE func) {
+  const RDKit::MolStandardize::CleanupParameters *ps =
+      &RDKit::MolStandardize::defaultCleanupParameters;
+  if (params) {
+    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  }
+  unsigned int nmols = python::len(pymols);
+  std::vector<RDKit::RWMol *> mols(nmols);
+  for (auto i = 0u; i < nmols; ++i) {
+    auto mol = static_cast<RDKit::RWMol *>(
+        python::extract<RDKit::ROMol *>(pymols[i])());
+    mols[i] = mol;
+  }
+  {
+    NOGIL gil;
+    func(mols, numThreads, *ps);
+  }
+}
+template <typename FUNCTYPE>
+void mtinPlaceHelper2(python::object pymols, int numThreads,
+                      python::object params, bool skip_standardize,
+                      FUNCTYPE func) {
+  const auto *ps = &RDKit::MolStandardize::defaultCleanupParameters;
+  if (params) {
+    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  }
+  unsigned int nmols = python::len(pymols);
+  std::vector<RDKit::RWMol *> mols(nmols);
+  for (auto i = 0u; i < nmols; ++i) {
+    auto mol = static_cast<RDKit::RWMol *>(
+        python::extract<RDKit::ROMol *>(pymols[i])());
+    mols[i] = mol;
+  }
+  {
+    NOGIL gil;
+    func(mols, numThreads, *ps, skip_standardize);
+  }
+}
+
+void mtcleanupInPlaceHelper(python::object mols, int numThreads,
+                            python::object params) {
+  mtinPlaceHelper(
+      mols, numThreads, params,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::cleanupInPlace));
+}
+
+void mtnormalizeInPlaceHelper(python::object mols, int numThreads,
+                              python::object params) {
+  mtinPlaceHelper(
+      mols, numThreads, params,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::normalizeInPlace));
+}
+
+void mtreionizeInPlaceHelper(python::object mols, int numThreads,
+                             python::object params) {
+  mtinPlaceHelper(
+      mols, numThreads, params,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::reionizeInPlace));
+}
+
+void mtremoveFragmentsInPlaceHelper(python::object mols, int numThreads,
+                                    python::object params) {
+  mtinPlaceHelper(
+      mols, numThreads, params,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &)>(
+          RDKit::MolStandardize::removeFragmentsInPlace));
+}
+
+void mtfragmentParentInPlaceHelper(python::object mols, int numThreads,
+                                   python::object params,
+                                   bool skip_standardize) {
+  mtinPlaceHelper2(mols, numThreads, params, skip_standardize,
+                   static_cast<void (*)(
+                       std::vector<RDKit::RWMol *> &, int,
+                       const RDKit::MolStandardize::CleanupParameters &, bool)>(
+                       RDKit::MolStandardize::fragmentParentInPlace));
+}
+
+void mtstereoParentInPlaceHelper(python::object mols, int numThreads,
+                                 python::object params, bool skip_standardize) {
+  mtinPlaceHelper2(
+      mols, numThreads, params, skip_standardize,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::stereoParentInPlace));
+}
+
+void mtisotopeParentInPlaceHelper(python::object mols, int numThreads,
+                                  python::object params,
+                                  bool skip_standardize) {
+  mtinPlaceHelper2(
+      mols, numThreads, params, skip_standardize,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::isotopeParentInPlace));
+}
+
+void mtchargeParentInPlaceHelper(python::object mols, int numThreads,
+                                 python::object params, bool skip_standardize) {
+  mtinPlaceHelper2(
+      mols, numThreads, params, skip_standardize,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::chargeParentInPlace));
+}
+
+void mtsuperParentInPlaceHelper(python::object mols, int numThreads,
+                                python::object params, bool skip_standardize) {
+  mtinPlaceHelper2(
+      mols, numThreads, params, skip_standardize,
+      static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
+                           const RDKit::MolStandardize::CleanupParameters &,
+                           bool)>(RDKit::MolStandardize::superParentInPlace));
+}
+
+void mttautomerParentInPlaceHelper(python::object mols, int numThreads,
+                                   python::object params,
+                                   bool skip_standardize) {
+  mtinPlaceHelper2(mols, numThreads, params, skip_standardize,
+                   static_cast<void (*)(
+                       std::vector<RDKit::RWMol *> &, int,
+                       const RDKit::MolStandardize::CleanupParameters &, bool)>(
+                       RDKit::MolStandardize::tautomerParentInPlace));
+}
+
+template <typename FUNCTYPE>
+RDKit::ROMol *parentHelper(const RDKit::ROMol *mol, python::object params,
+                           bool skip_standardize, FUNCTYPE func) {
+  if (!mol) {
+    throw_value_error("Molecule is None");
+  }
+  const RDKit::MolStandardize::CleanupParameters *ps =
+      &RDKit::MolStandardize::defaultCleanupParameters;
+  if (params) {
+    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  }
+  return static_cast<RDKit::ROMol *>(
+      func(static_cast<const RDKit::RWMol &>(*mol), *ps, skip_standardize));
+}
+
+RDKit::ROMol *tautomerParentHelper(const RDKit::ROMol *mol,
+                                   python::object params,
+                                   bool skip_standardize) {
+  return parentHelper(mol, params, skip_standardize,
+                      RDKit::MolStandardize::tautomerParent);
+}
+RDKit::ROMol *fragmentParentHelper(const RDKit::ROMol *mol,
+                                   python::object params,
+                                   bool skip_standardize) {
+  return parentHelper(mol, params, skip_standardize,
+                      RDKit::MolStandardize::fragmentParent);
+}
+RDKit::ROMol *stereoParentHelper(const RDKit::ROMol *mol, python::object params,
+                                 bool skip_standardize) {
+  return parentHelper(mol, params, skip_standardize,
+                      RDKit::MolStandardize::stereoParent);
+}
+RDKit::ROMol *isotopeParentHelper(const RDKit::ROMol *mol,
+                                  python::object params,
+                                  bool skip_standardize) {
+  return parentHelper(mol, params, skip_standardize,
+                      RDKit::MolStandardize::isotopeParent);
+}
+RDKit::ROMol *chargeParentHelper(const RDKit::ROMol *mol, python::object params,
+                                 bool skip_standardize) {
+  return parentHelper(mol, params, skip_standardize,
+                      RDKit::MolStandardize::chargeParent);
+}
+RDKit::ROMol *superParentHelper(const RDKit::ROMol *mol, python::object params,
+                                bool skip_standardize) {
+  return parentHelper(mol, params, skip_standardize,
+                      RDKit::MolStandardize::superParent);
+}
+RDKit::ROMol *disconnectOrganometallicsHelper(RDKit::ROMol &mol,
+                                              python::object params) {
+  if (params) {
+    RDKit::MolStandardize::MetalDisconnectorOptions *mdo =
+        python::extract<RDKit::MolStandardize::MetalDisconnectorOptions *>(
+            params);
+    return RDKit::MolStandardize::disconnectOrganometallics(mol, *mdo);
+  } else {
+    return RDKit::MolStandardize::disconnectOrganometallics(mol);
+  }
+}
+void disconnectOrganometallicsInPlaceHelper(RDKit::ROMol *mol,
+                                            python::object params) {
+  if (params) {
+    RDKit::MolStandardize::MetalDisconnectorOptions *mdo =
+        python::extract<RDKit::MolStandardize::MetalDisconnectorOptions *>(
+            params);
+    return RDKit::MolStandardize::disconnectOrganometallicsInPlace(
+        *static_cast<RDKit::RWMol *>(mol), *mdo);
+  } else {
+    return RDKit::MolStandardize::disconnectOrganometallicsInPlace(
+        *static_cast<RDKit::RWMol *>(mol));
+  }
+}
+
+}  // namespace
+
+void wrap_validate();
+void wrap_charge();
+void wrap_metal();
+void wrap_fragment();
+void wrap_normalize();
+void wrap_tautomer();
+void wrap_pipeline();
+
+BOOST_PYTHON_MODULE(rdMolStandardize) {
+  python::scope().attr("__doc__") =
+      "Module containing functions for molecular standardization";
+
+  bool noproxy = true;
+  RegisterVectorConverter<RDKit::ROMOL_SPTR>("MOL_SPTR_VECT", noproxy);
+
+  std::string docString = "";
+
+  python::class_<RDKit::MolStandardize::CleanupParameters, boost::noncopyable>(
+      "CleanupParameters", "Parameters controlling molecular standardization")
+      .def_readwrite("normalizationsFile",
+                     &RDKit::MolStandardize::CleanupParameters::normalizations,
+                     "file containing the normalization transformations")
+      .def_readwrite("acidbaseFile",
+                     &RDKit::MolStandardize::CleanupParameters::acidbaseFile,
+                     "file containing the acid and base definitions")
+      .def_readwrite("fragmentFile",
+                     &RDKit::MolStandardize::CleanupParameters::fragmentFile,
+                     "file containing the acid and base definitions")
+      .def_readwrite(
+          "tautomerTransformsFile",
+          &RDKit::MolStandardize::CleanupParameters::tautomerTransforms,
+          "file containing the tautomer transformations")
+      .def_readwrite("maxRestarts",
+                     &RDKit::MolStandardize::CleanupParameters::maxRestarts,
+                     "maximum number of restarts")
+      .def_readwrite("preferOrganic",
+                     &RDKit::MolStandardize::CleanupParameters::preferOrganic,
+                     "prefer organic fragments to inorganic ones when deciding "
+                     "what to keep")
+      .def_readwrite("doCanonical",
+                     &RDKit::MolStandardize::CleanupParameters::doCanonical,
+                     "apply atom-order dependent normalizations (like "
+                     "uncharging) in a canonical order")
+      .def_readwrite("maxTautomers",
+                     &RDKit::MolStandardize::CleanupParameters::maxTautomers,
+                     "maximum number of tautomers to generate (defaults to "
+                     "1000)")
+      .def_readwrite("maxTransforms",
+                     &RDKit::MolStandardize::CleanupParameters::maxTransforms,
+                     "maximum number of transforms to apply during tautomer "
+                     "enumeration (defaults to 1000)")
+      .def_readwrite(
+          "tautomerRemoveSp3Stereo",
+          &RDKit::MolStandardize::CleanupParameters::tautomerRemoveSp3Stereo,
+          "remove stereochemistry from sp3 centers involved in "
+          "tautomerism (defaults to True)")
+      .def_readwrite(
+          "tautomerRemoveBondStereo",
+          &RDKit::MolStandardize::CleanupParameters::tautomerRemoveBondStereo,
+          "remove stereochemistry from double bonds involved in "
+          "tautomerism (defaults to True)")
+      .def_readwrite(
+          "tautomerRemoveIsotopicHs",
+          &RDKit::MolStandardize::CleanupParameters::tautomerRemoveIsotopicHs,
+          "remove isotopic Hs from centers involved in "
+          "tautomerism (defaults to True)")
+      .def_readwrite(
+          "tautomerReassignStereo",
+          &RDKit::MolStandardize::CleanupParameters::tautomerReassignStereo,
+          "call AssignStereochemistry on all generated tautomers "
+          "(defaults to True)")
+      .def_readwrite("largestFragmentChooserUseAtomCount",
+                     &RDKit::MolStandardize::CleanupParameters::
+                         largestFragmentChooserUseAtomCount,
+                     "Whether LargestFragmentChooser should use atom "
+                     "count as main criterion before MW (defaults to True)")
+      .def_readwrite("largestFragmentChooserCountHeavyAtomsOnly",
+                     &RDKit::MolStandardize::CleanupParameters::
+                         largestFragmentChooserCountHeavyAtomsOnly,
+                     "whether LargestFragmentChooser should only count "
+                     "heavy atoms (defaults to False)")
+      .def("__setattr__", &safeSetattr);
+
+  python::def("UpdateParamsFromJSON",
+              &RDKit::MolStandardize::updateCleanupParamsFromJSON,
+              python::args("params", "json"),
+              "updates the cleanup parameters from the provided JSON string");
+
+  docString = "Standardizes a molecule";
+  python::def("Cleanup", cleanupHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Standardizes a molecule in place";
+  python::def("CleanupInPlace", cleanupInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Standardizes multiple molecules in place";
+  python::def("CleanupInPlace", mtcleanupInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Convenience function for standardizing a SMILES";
+  python::def("StandardizeSmiles", RDKit::MolStandardize::standardizeSmiles,
+              (python::arg("smiles")), docString.c_str());
+  docString =
+      "Returns the tautomer parent of a given molecule. The fragment parent is "
+      "the standardized canonical tautomer of the molecule";
+  python::def("TautomerParent", tautomerParentHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Generates the tautomer parent in place";
+  python::def("TautomerParentInPlace", tautomerParentInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "Generates the tautomer parent in place for multiple molecules";
+  python::def("TautomerParentInPlace", mttautomerParentInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+
+  docString = "Returns the largest fragment after doing a cleanup";
+  python::def("FragmentParent", fragmentParentHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Generates the largest fragment in place";
+  python::def("FragmentParentInPlace", fragmentParentInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "Generates the largest fragment in place for multiple molecules";
+  python::def("FragmentParentInPlace", mtfragmentParentInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+
+  python::def("StereoParent", stereoParentHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Generates the stereo parent in place";
+  python::def("StereoParentInPlace", stereoParentInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "Generates the stereo parent in place for multiple molecules";
+  python::def("StereoParentInPlace", mtstereoParentInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "removes all isotopes specifications from the given molecule";
+  python::def("IsotopeParent", isotopeParentHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Generates the isotope parent in place";
+  python::def("IsotopeParentInPlace", isotopeParentInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "Generates the isotope parent in place for multiple molecules";
+  python::def("IsotopeParentInPlace", mtisotopeParentInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "Returns the uncharged version of the largest fragment";
+  python::def("ChargeParent", chargeParentHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Generates the charge parent in place";
+  python::def("ChargeParentInPlace", chargeParentInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "Generates the chargeparent in place for multiple molecules";
+  python::def("ChargeParentInPlace", mtchargeParentInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+
+  docString =
+      "Returns the super parent. The super parent is the fragment, charge, "
+      "isotope, stereo, and tautomer parent of the molecule.";
+  python::def("SuperParent", superParentHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString = "Generates the super parent in place";
+  python::def("SuperParentInPlace", superParentInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+  docString = "Generates the super parent in place for multiple molecules";
+  python::def("SuperParentInPlace", mtsuperParentInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object(),
+               python::arg("skipStandardize") = false),
+              docString.c_str());
+
+  docString =
+      "Applies a series of standard transformations to correct functional "
+      "groups and recombine charges";
+  python::def("Normalize", normalizeHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString =
+      "Applies a series of standard transformations to correct functional "
+      "groups and recombine charges, modifies the input molecule";
+  python::def("NormalizeInPlace", normalizeInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Normalizes multiple molecules in place";
+  python::def("NormalizeInPlace", mtnormalizeInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Ensures the strongest acid groups are charged first";
+  python::def("Reionize", reionizeHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString =
+      "Ensures the strongest acid groups are charged first, modifies the input molecule";
+  python::def("ReionizeInPlace", reionizeInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Reionizes multiple molecules in place";
+  python::def("ReionizeInPlace", mtreionizeInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Removes fragments from the molecule";
+  python::def("RemoveFragments", removeFragsHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString =
+      "Removes fragments from the molecule, modifies the input molecule";
+  python::def("RemoveFragmentsInPlace", removeFragmentsInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Removes fragments from multiple molecules in place";
+  python::def("RemoveFragmentsInPlace", mtremoveFragmentsInPlaceHelper,
+              (python::arg("mols"), python::arg("numThreads"),
+               python::arg("params") = python::object()),
+              docString.c_str());
+  docString = "Returns the canonical tautomer for the molecule";
+  python::def("CanonicalTautomer", canonicalTautomerHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+
+  docString =
+      "Returns the molecule disconnected using the organometallics"
+      " rules.";
+  python::def("DisconnectOrganometallics", disconnectOrganometallicsHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str(),
+              python::return_value_policy<python::manage_new_object>());
+  docString =
+      "Disconnects the molecule using the organometallics"
+      " rules, modifies the input molecule";
+  python::def("DisconnectOrganometallicsInPlace",
+              disconnectOrganometallicsInPlaceHelper,
+              (python::arg("mol"), python::arg("params") = python::object()),
+              docString.c_str());
+
+  wrap_validate();
+  wrap_charge();
+  wrap_metal();
+  wrap_fragment();
+  wrap_normalize();
+  wrap_tautomer();
+  wrap_pipeline();
+}

--- a/Code/GraphMol/MolStandardize/nbWrap/rdMolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/nbWrap/rdMolStandardize.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018-2023 Susan H. Leung and other RDKit contributors
+//  Copyright (C) 2018-2026 Susan H. Leung and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,32 +7,35 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/Wrap.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/MolStandardize.h>
+#include <RDBoost/Wrap_nb.h>
 
 #include <vector>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace {
 template <typename FUNCTYPE>
-RDKit::ROMol *msHelper(const RDKit::ROMol *mol, python::object params,
-                       FUNCTYPE func) {
-  if (!mol) {
-    throw_value_error("Molecule is None");
+RDKit::ROMol *msHelper(nb::object pymol, nb::object params, FUNCTYPE func) {
+  if (pymol.is_none()) {
+    throw nb::value_error("Molecule is None");
   }
+  const RDKit::ROMol *mol = nb::cast<RDKit::ROMol *>(pymol);
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
-  if (params) {
-    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  if (!params.is_none()) {
+    ps = nb::cast<RDKit::MolStandardize::CleanupParameters *>(params);
   }
   return static_cast<RDKit::ROMol *>(
       func(static_cast<const RDKit::RWMol *>(mol), *ps));
 }
 
-RDKit::ROMol *cleanupHelper(const RDKit::ROMol *mol, python::object params) {
+RDKit::ROMol *cleanupHelper(nb::object mol, nb::object params) {
   return msHelper(
       mol, params,
       static_cast<
@@ -41,51 +44,50 @@ RDKit::ROMol *cleanupHelper(const RDKit::ROMol *mol, python::object params) {
           RDKit::MolStandardize::cleanup));
 }
 
-RDKit::ROMol *normalizeHelper(const RDKit::ROMol *mol, python::object params) {
+RDKit::ROMol *normalizeHelper(nb::object mol, nb::object params) {
   return msHelper(mol, params, RDKit::MolStandardize::normalize);
 }
 
-RDKit::ROMol *reionizeHelper(const RDKit::ROMol *mol, python::object params) {
+RDKit::ROMol *reionizeHelper(nb::object mol, nb::object params) {
   return msHelper(mol, params, RDKit::MolStandardize::reionize);
 }
 
-RDKit::ROMol *removeFragsHelper(const RDKit::ROMol *mol,
-                                python::object params) {
+RDKit::ROMol *removeFragsHelper(nb::object mol, nb::object params) {
   return msHelper(mol, params, RDKit::MolStandardize::removeFragments);
 }
 
-RDKit::ROMol *canonicalTautomerHelper(const RDKit::ROMol *mol,
-                                      python::object params) {
+RDKit::ROMol *canonicalTautomerHelper(nb::object mol, nb::object params) {
   return msHelper(mol, params, RDKit::MolStandardize::canonicalTautomer);
 }
 
 template <typename FUNCTYPE>
-void inPlaceHelper(RDKit::ROMol *mol, python::object params, FUNCTYPE func) {
+void inPlaceHelper(RDKit::ROMol *mol, nb::object params, FUNCTYPE func) {
   if (!mol) {
-    throw_value_error("Molecule is None");
+    throw nb::value_error("Molecule is None");
   }
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
-  if (params) {
-    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  if (!params.is_none()) {
+    ps = nb::cast<RDKit::MolStandardize::CleanupParameters *>(params);
   }
   func(*static_cast<RDKit::RWMol *>(mol), *ps);
 }
 
 template <typename FUNCTYPE>
-void inPlaceHelper2(RDKit::ROMol *mol, python::object params,
+void inPlaceHelper2(RDKit::ROMol *mol, nb::object params,
                     bool skip_standardize, FUNCTYPE func) {
   if (!mol) {
-    throw_value_error("Molecule is None");
+    throw nb::value_error("Molecule is None");
   }
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
-  if (params) {
-    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  if (!params.is_none()) {
+    ps = nb::cast<RDKit::MolStandardize::CleanupParameters *>(params);
   }
   func(*static_cast<RDKit::RWMol *>(mol), *ps, skip_standardize);
 }
-void cleanupInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+
+void cleanupInPlaceHelper(RDKit::ROMol *mol, nb::object params) {
   inPlaceHelper(
       mol, params,
       static_cast<void (*)(RDKit::RWMol &,
@@ -93,7 +95,7 @@ void cleanupInPlaceHelper(RDKit::ROMol *mol, python::object params) {
           RDKit::MolStandardize::cleanupInPlace));
 }
 
-void normalizeInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+void normalizeInPlaceHelper(RDKit::ROMol *mol, nb::object params) {
   inPlaceHelper(
       mol, params,
       static_cast<void (*)(RDKit::RWMol &,
@@ -101,7 +103,7 @@ void normalizeInPlaceHelper(RDKit::ROMol *mol, python::object params) {
           RDKit::MolStandardize::normalizeInPlace));
 }
 
-void reionizeInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+void reionizeInPlaceHelper(RDKit::ROMol *mol, nb::object params) {
   inPlaceHelper(
       mol, params,
       static_cast<void (*)(RDKit::RWMol &,
@@ -109,7 +111,7 @@ void reionizeInPlaceHelper(RDKit::ROMol *mol, python::object params) {
           RDKit::MolStandardize::reionizeInPlace));
 }
 
-void removeFragmentsInPlaceHelper(RDKit::ROMol *mol, python::object params) {
+void removeFragmentsInPlaceHelper(RDKit::ROMol *mol, nb::object params) {
   inPlaceHelper(
       mol, params,
       static_cast<void (*)(RDKit::RWMol &,
@@ -117,7 +119,7 @@ void removeFragmentsInPlaceHelper(RDKit::ROMol *mol, python::object params) {
           RDKit::MolStandardize::removeFragmentsInPlace));
 }
 
-void fragmentParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+void fragmentParentInPlaceHelper(RDKit::ROMol *mol, nb::object params,
                                  bool skip_standardize) {
   inPlaceHelper2(
       mol, params, skip_standardize,
@@ -126,7 +128,7 @@ void fragmentParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
           bool)>(RDKit::MolStandardize::fragmentParentInPlace));
 }
 
-void stereoParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+void stereoParentInPlaceHelper(RDKit::ROMol *mol, nb::object params,
                                bool skip_standardize) {
   inPlaceHelper2(
       mol, params, skip_standardize,
@@ -135,7 +137,7 @@ void stereoParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
                            bool)>(RDKit::MolStandardize::stereoParentInPlace));
 }
 
-void isotopeParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+void isotopeParentInPlaceHelper(RDKit::ROMol *mol, nb::object params,
                                 bool skip_standardize) {
   inPlaceHelper2(
       mol, params, skip_standardize,
@@ -144,7 +146,7 @@ void isotopeParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
                            bool)>(RDKit::MolStandardize::isotopeParentInPlace));
 }
 
-void chargeParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+void chargeParentInPlaceHelper(RDKit::ROMol *mol, nb::object params,
                                bool skip_standardize) {
   inPlaceHelper2(
       mol, params, skip_standardize,
@@ -153,7 +155,7 @@ void chargeParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
                            bool)>(RDKit::MolStandardize::chargeParentInPlace));
 }
 
-void superParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+void superParentInPlaceHelper(RDKit::ROMol *mol, nb::object params,
                               bool skip_standardize) {
   inPlaceHelper2(
       mol, params, skip_standardize,
@@ -162,7 +164,7 @@ void superParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
                            bool)>(RDKit::MolStandardize::superParentInPlace));
 }
 
-void tautomerParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
+void tautomerParentInPlaceHelper(RDKit::ROMol *mol, nb::object params,
                                  bool skip_standardize) {
   inPlaceHelper2(
       mol, params, skip_standardize,
@@ -172,18 +174,19 @@ void tautomerParentInPlaceHelper(RDKit::ROMol *mol, python::object params,
 }
 
 template <typename FUNCTYPE>
-void mtinPlaceHelper(python::object pymols, int numThreads,
-                     python::object params, FUNCTYPE func) {
+void mtinPlaceHelper(nb::object pymols, int numThreads, nb::object params,
+                     FUNCTYPE func) {
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
-  if (params) {
-    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  if (!params.is_none()) {
+    ps = nb::cast<RDKit::MolStandardize::CleanupParameters *>(params);
   }
-  unsigned int nmols = python::len(pymols);
+  nb::list molList(pymols);
+  unsigned int nmols = (unsigned int)nb::len(molList);
   std::vector<RDKit::RWMol *> mols(nmols);
   for (auto i = 0u; i < nmols; ++i) {
-    auto mol = static_cast<RDKit::RWMol *>(
-        python::extract<RDKit::ROMol *>(pymols[i])());
+    auto mol =
+        static_cast<RDKit::RWMol *>(nb::cast<RDKit::ROMol *>(molList[i]));
     mols[i] = mol;
   }
   {
@@ -191,19 +194,20 @@ void mtinPlaceHelper(python::object pymols, int numThreads,
     func(mols, numThreads, *ps);
   }
 }
+
 template <typename FUNCTYPE>
-void mtinPlaceHelper2(python::object pymols, int numThreads,
-                      python::object params, bool skip_standardize,
-                      FUNCTYPE func) {
+void mtinPlaceHelper2(nb::object pymols, int numThreads, nb::object params,
+                      bool skip_standardize, FUNCTYPE func) {
   const auto *ps = &RDKit::MolStandardize::defaultCleanupParameters;
-  if (params) {
-    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  if (!params.is_none()) {
+    ps = nb::cast<RDKit::MolStandardize::CleanupParameters *>(params);
   }
-  unsigned int nmols = python::len(pymols);
+  nb::list molList(pymols);
+  unsigned int nmols = (unsigned int)nb::len(molList);
   std::vector<RDKit::RWMol *> mols(nmols);
   for (auto i = 0u; i < nmols; ++i) {
-    auto mol = static_cast<RDKit::RWMol *>(
-        python::extract<RDKit::ROMol *>(pymols[i])());
+    auto mol =
+        static_cast<RDKit::RWMol *>(nb::cast<RDKit::ROMol *>(molList[i]));
     mols[i] = mol;
   }
   {
@@ -212,8 +216,8 @@ void mtinPlaceHelper2(python::object pymols, int numThreads,
   }
 }
 
-void mtcleanupInPlaceHelper(python::object mols, int numThreads,
-                            python::object params) {
+void mtcleanupInPlaceHelper(nb::object mols, int numThreads,
+                            nb::object params) {
   mtinPlaceHelper(
       mols, numThreads, params,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -221,8 +225,8 @@ void mtcleanupInPlaceHelper(python::object mols, int numThreads,
           RDKit::MolStandardize::cleanupInPlace));
 }
 
-void mtnormalizeInPlaceHelper(python::object mols, int numThreads,
-                              python::object params) {
+void mtnormalizeInPlaceHelper(nb::object mols, int numThreads,
+                              nb::object params) {
   mtinPlaceHelper(
       mols, numThreads, params,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -230,8 +234,8 @@ void mtnormalizeInPlaceHelper(python::object mols, int numThreads,
           RDKit::MolStandardize::normalizeInPlace));
 }
 
-void mtreionizeInPlaceHelper(python::object mols, int numThreads,
-                             python::object params) {
+void mtreionizeInPlaceHelper(nb::object mols, int numThreads,
+                             nb::object params) {
   mtinPlaceHelper(
       mols, numThreads, params,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -239,8 +243,8 @@ void mtreionizeInPlaceHelper(python::object mols, int numThreads,
           RDKit::MolStandardize::reionizeInPlace));
 }
 
-void mtremoveFragmentsInPlaceHelper(python::object mols, int numThreads,
-                                    python::object params) {
+void mtremoveFragmentsInPlaceHelper(nb::object mols, int numThreads,
+                                    nb::object params) {
   mtinPlaceHelper(
       mols, numThreads, params,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -248,9 +252,8 @@ void mtremoveFragmentsInPlaceHelper(python::object mols, int numThreads,
           RDKit::MolStandardize::removeFragmentsInPlace));
 }
 
-void mtfragmentParentInPlaceHelper(python::object mols, int numThreads,
-                                   python::object params,
-                                   bool skip_standardize) {
+void mtfragmentParentInPlaceHelper(nb::object mols, int numThreads,
+                                   nb::object params, bool skip_standardize) {
   mtinPlaceHelper2(mols, numThreads, params, skip_standardize,
                    static_cast<void (*)(
                        std::vector<RDKit::RWMol *> &, int,
@@ -258,8 +261,8 @@ void mtfragmentParentInPlaceHelper(python::object mols, int numThreads,
                        RDKit::MolStandardize::fragmentParentInPlace));
 }
 
-void mtstereoParentInPlaceHelper(python::object mols, int numThreads,
-                                 python::object params, bool skip_standardize) {
+void mtstereoParentInPlaceHelper(nb::object mols, int numThreads,
+                                 nb::object params, bool skip_standardize) {
   mtinPlaceHelper2(
       mols, numThreads, params, skip_standardize,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -267,9 +270,8 @@ void mtstereoParentInPlaceHelper(python::object mols, int numThreads,
                            bool)>(RDKit::MolStandardize::stereoParentInPlace));
 }
 
-void mtisotopeParentInPlaceHelper(python::object mols, int numThreads,
-                                  python::object params,
-                                  bool skip_standardize) {
+void mtisotopeParentInPlaceHelper(nb::object mols, int numThreads,
+                                  nb::object params, bool skip_standardize) {
   mtinPlaceHelper2(
       mols, numThreads, params, skip_standardize,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -277,8 +279,8 @@ void mtisotopeParentInPlaceHelper(python::object mols, int numThreads,
                            bool)>(RDKit::MolStandardize::isotopeParentInPlace));
 }
 
-void mtchargeParentInPlaceHelper(python::object mols, int numThreads,
-                                 python::object params, bool skip_standardize) {
+void mtchargeParentInPlaceHelper(nb::object mols, int numThreads,
+                                 nb::object params, bool skip_standardize) {
   mtinPlaceHelper2(
       mols, numThreads, params, skip_standardize,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -286,8 +288,8 @@ void mtchargeParentInPlaceHelper(python::object mols, int numThreads,
                            bool)>(RDKit::MolStandardize::chargeParentInPlace));
 }
 
-void mtsuperParentInPlaceHelper(python::object mols, int numThreads,
-                                python::object params, bool skip_standardize) {
+void mtsuperParentInPlaceHelper(nb::object mols, int numThreads,
+                                nb::object params, bool skip_standardize) {
   mtinPlaceHelper2(
       mols, numThreads, params, skip_standardize,
       static_cast<void (*)(std::vector<RDKit::RWMol *> &, int,
@@ -295,9 +297,8 @@ void mtsuperParentInPlaceHelper(python::object mols, int numThreads,
                            bool)>(RDKit::MolStandardize::superParentInPlace));
 }
 
-void mttautomerParentInPlaceHelper(python::object mols, int numThreads,
-                                   python::object params,
-                                   bool skip_standardize) {
+void mttautomerParentInPlaceHelper(nb::object mols, int numThreads,
+                                   nb::object params, bool skip_standardize) {
   mtinPlaceHelper2(mols, numThreads, params, skip_standardize,
                    static_cast<void (*)(
                        std::vector<RDKit::RWMol *> &, int,
@@ -306,70 +307,73 @@ void mttautomerParentInPlaceHelper(python::object mols, int numThreads,
 }
 
 template <typename FUNCTYPE>
-RDKit::ROMol *parentHelper(const RDKit::ROMol *mol, python::object params,
+RDKit::ROMol *parentHelper(nb::object pymol, nb::object params,
                            bool skip_standardize, FUNCTYPE func) {
-  if (!mol) {
-    throw_value_error("Molecule is None");
+  if (pymol.is_none()) {
+    throw nb::value_error("Molecule is None");
   }
+  const RDKit::ROMol *mol = nb::cast<RDKit::ROMol *>(pymol);
   const RDKit::MolStandardize::CleanupParameters *ps =
       &RDKit::MolStandardize::defaultCleanupParameters;
-  if (params) {
-    ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
+  if (!params.is_none()) {
+    ps = nb::cast<RDKit::MolStandardize::CleanupParameters *>(params);
   }
   return static_cast<RDKit::ROMol *>(
       func(static_cast<const RDKit::RWMol &>(*mol), *ps, skip_standardize));
 }
 
-RDKit::ROMol *tautomerParentHelper(const RDKit::ROMol *mol,
-                                   python::object params,
+RDKit::ROMol *tautomerParentHelper(nb::object mol, nb::object params,
                                    bool skip_standardize) {
   return parentHelper(mol, params, skip_standardize,
                       RDKit::MolStandardize::tautomerParent);
 }
-RDKit::ROMol *fragmentParentHelper(const RDKit::ROMol *mol,
-                                   python::object params,
+
+RDKit::ROMol *fragmentParentHelper(nb::object mol, nb::object params,
                                    bool skip_standardize) {
   return parentHelper(mol, params, skip_standardize,
                       RDKit::MolStandardize::fragmentParent);
 }
-RDKit::ROMol *stereoParentHelper(const RDKit::ROMol *mol, python::object params,
+
+RDKit::ROMol *stereoParentHelper(nb::object mol, nb::object params,
                                  bool skip_standardize) {
   return parentHelper(mol, params, skip_standardize,
                       RDKit::MolStandardize::stereoParent);
 }
-RDKit::ROMol *isotopeParentHelper(const RDKit::ROMol *mol,
-                                  python::object params,
+
+RDKit::ROMol *isotopeParentHelper(nb::object mol, nb::object params,
                                   bool skip_standardize) {
   return parentHelper(mol, params, skip_standardize,
                       RDKit::MolStandardize::isotopeParent);
 }
-RDKit::ROMol *chargeParentHelper(const RDKit::ROMol *mol, python::object params,
+
+RDKit::ROMol *chargeParentHelper(nb::object mol, nb::object params,
                                  bool skip_standardize) {
   return parentHelper(mol, params, skip_standardize,
                       RDKit::MolStandardize::chargeParent);
 }
-RDKit::ROMol *superParentHelper(const RDKit::ROMol *mol, python::object params,
+
+RDKit::ROMol *superParentHelper(nb::object mol, nb::object params,
                                 bool skip_standardize) {
   return parentHelper(mol, params, skip_standardize,
                       RDKit::MolStandardize::superParent);
 }
+
 RDKit::ROMol *disconnectOrganometallicsHelper(RDKit::ROMol &mol,
-                                              python::object params) {
-  if (params) {
+                                              nb::object params) {
+  if (!params.is_none()) {
     RDKit::MolStandardize::MetalDisconnectorOptions *mdo =
-        python::extract<RDKit::MolStandardize::MetalDisconnectorOptions *>(
-            params);
+        nb::cast<RDKit::MolStandardize::MetalDisconnectorOptions *>(params);
     return RDKit::MolStandardize::disconnectOrganometallics(mol, *mdo);
   } else {
     return RDKit::MolStandardize::disconnectOrganometallics(mol);
   }
 }
+
 void disconnectOrganometallicsInPlaceHelper(RDKit::ROMol *mol,
-                                            python::object params) {
-  if (params) {
+                                            nb::object params) {
+  if (!params.is_none()) {
     RDKit::MolStandardize::MetalDisconnectorOptions *mdo =
-        python::extract<RDKit::MolStandardize::MetalDisconnectorOptions *>(
-            params);
+        nb::cast<RDKit::MolStandardize::MetalDisconnectorOptions *>(params);
     return RDKit::MolStandardize::disconnectOrganometallicsInPlace(
         *static_cast<RDKit::RWMol *>(mol), *mdo);
   } else {
@@ -380,294 +384,215 @@ void disconnectOrganometallicsInPlaceHelper(RDKit::ROMol *mol,
 
 }  // namespace
 
-void wrap_validate();
-void wrap_charge();
-void wrap_metal();
-void wrap_fragment();
-void wrap_normalize();
-void wrap_tautomer();
-void wrap_pipeline();
+void wrap_validate(nb::module_ &m);
+void wrap_charge(nb::module_ &m);
+void wrap_metal(nb::module_ &m);
+void wrap_fragment(nb::module_ &m);
+void wrap_normalize(nb::module_ &m);
+void wrap_tautomer(nb::module_ &m);
+void wrap_pipeline(nb::module_ &m);
 
-BOOST_PYTHON_MODULE(rdMolStandardize) {
-  python::scope().attr("__doc__") =
-      "Module containing functions for molecular standardization";
+NB_MODULE(rdMolStandardize, m) {
+  m.doc() = "Module containing functions for molecular standardization";
 
-  bool noproxy = true;
-  RegisterVectorConverter<RDKit::ROMOL_SPTR>("MOL_SPTR_VECT", noproxy);
-
-  std::string docString = "";
-
-  python::class_<RDKit::MolStandardize::CleanupParameters, boost::noncopyable>(
-      "CleanupParameters", "Parameters controlling molecular standardization")
-      .def_readwrite("normalizationsFile",
-                     &RDKit::MolStandardize::CleanupParameters::normalizations,
-                     "file containing the normalization transformations")
-      .def_readwrite("acidbaseFile",
-                     &RDKit::MolStandardize::CleanupParameters::acidbaseFile,
-                     "file containing the acid and base definitions")
-      .def_readwrite("fragmentFile",
-                     &RDKit::MolStandardize::CleanupParameters::fragmentFile,
-                     "file containing the acid and base definitions")
-      .def_readwrite(
-          "tautomerTransformsFile",
-          &RDKit::MolStandardize::CleanupParameters::tautomerTransforms,
-          "file containing the tautomer transformations")
-      .def_readwrite("maxRestarts",
-                     &RDKit::MolStandardize::CleanupParameters::maxRestarts,
-                     "maximum number of restarts")
-      .def_readwrite("preferOrganic",
-                     &RDKit::MolStandardize::CleanupParameters::preferOrganic,
-                     "prefer organic fragments to inorganic ones when deciding "
-                     "what to keep")
-      .def_readwrite("doCanonical",
-                     &RDKit::MolStandardize::CleanupParameters::doCanonical,
-                     "apply atom-order dependent normalizations (like "
-                     "uncharging) in a canonical order")
-      .def_readwrite("maxTautomers",
-                     &RDKit::MolStandardize::CleanupParameters::maxTautomers,
-                     "maximum number of tautomers to generate (defaults to "
-                     "1000)")
-      .def_readwrite("maxTransforms",
-                     &RDKit::MolStandardize::CleanupParameters::maxTransforms,
-                     "maximum number of transforms to apply during tautomer "
-                     "enumeration (defaults to 1000)")
-      .def_readwrite(
-          "tautomerRemoveSp3Stereo",
-          &RDKit::MolStandardize::CleanupParameters::tautomerRemoveSp3Stereo,
-          "remove stereochemistry from sp3 centers involved in "
-          "tautomerism (defaults to True)")
-      .def_readwrite(
-          "tautomerRemoveBondStereo",
-          &RDKit::MolStandardize::CleanupParameters::tautomerRemoveBondStereo,
-          "remove stereochemistry from double bonds involved in "
-          "tautomerism (defaults to True)")
-      .def_readwrite(
-          "tautomerRemoveIsotopicHs",
-          &RDKit::MolStandardize::CleanupParameters::tautomerRemoveIsotopicHs,
-          "remove isotopic Hs from centers involved in "
-          "tautomerism (defaults to True)")
-      .def_readwrite(
-          "tautomerReassignStereo",
-          &RDKit::MolStandardize::CleanupParameters::tautomerReassignStereo,
-          "call AssignStereochemistry on all generated tautomers "
-          "(defaults to True)")
-      .def_readwrite("largestFragmentChooserUseAtomCount",
-                     &RDKit::MolStandardize::CleanupParameters::
-                         largestFragmentChooserUseAtomCount,
-                     "Whether LargestFragmentChooser should use atom "
-                     "count as main criterion before MW (defaults to True)")
-      .def_readwrite("largestFragmentChooserCountHeavyAtomsOnly",
-                     &RDKit::MolStandardize::CleanupParameters::
-                         largestFragmentChooserCountHeavyAtomsOnly,
-                     "whether LargestFragmentChooser should only count "
-                     "heavy atoms (defaults to False)")
+  nb::class_<RDKit::MolStandardize::CleanupParameters>(
+      m, "CleanupParameters",
+      "Parameters controlling molecular standardization")
+      .def(nb::init<>())
+      .def_rw("normalizationsFile",
+               &RDKit::MolStandardize::CleanupParameters::normalizations,
+               "file containing the normalization transformations")
+      .def_rw("acidbaseFile",
+               &RDKit::MolStandardize::CleanupParameters::acidbaseFile,
+               "file containing the acid and base definitions")
+      .def_rw("fragmentFile",
+               &RDKit::MolStandardize::CleanupParameters::fragmentFile,
+               "file containing the acid and base definitions")
+      .def_rw("tautomerTransformsFile",
+               &RDKit::MolStandardize::CleanupParameters::tautomerTransforms,
+               "file containing the tautomer transformations")
+      .def_rw("maxRestarts",
+               &RDKit::MolStandardize::CleanupParameters::maxRestarts,
+               "maximum number of restarts")
+      .def_rw("preferOrganic",
+               &RDKit::MolStandardize::CleanupParameters::preferOrganic,
+               "prefer organic fragments to inorganic ones when deciding "
+               "what to keep")
+      .def_rw("doCanonical",
+               &RDKit::MolStandardize::CleanupParameters::doCanonical,
+               "apply atom-order dependent normalizations (like "
+               "uncharging) in a canonical order")
+      .def_rw("maxTautomers",
+               &RDKit::MolStandardize::CleanupParameters::maxTautomers,
+               "maximum number of tautomers to generate (defaults to 1000)")
+      .def_rw("maxTransforms",
+               &RDKit::MolStandardize::CleanupParameters::maxTransforms,
+               "maximum number of transforms to apply during tautomer "
+               "enumeration (defaults to 1000)")
+      .def_rw("tautomerRemoveSp3Stereo",
+               &RDKit::MolStandardize::CleanupParameters::
+                   tautomerRemoveSp3Stereo,
+               "remove stereochemistry from sp3 centers involved in "
+               "tautomerism (defaults to True)")
+      .def_rw("tautomerRemoveBondStereo",
+               &RDKit::MolStandardize::CleanupParameters::
+                   tautomerRemoveBondStereo,
+               "remove stereochemistry from double bonds involved in "
+               "tautomerism (defaults to True)")
+      .def_rw("tautomerRemoveIsotopicHs",
+               &RDKit::MolStandardize::CleanupParameters::
+                   tautomerRemoveIsotopicHs,
+               "remove isotopic Hs from centers involved in "
+               "tautomerism (defaults to True)")
+      .def_rw("tautomerReassignStereo",
+               &RDKit::MolStandardize::CleanupParameters::
+                   tautomerReassignStereo,
+               "call AssignStereochemistry on all generated tautomers "
+               "(defaults to True)")
+      .def_rw("largestFragmentChooserUseAtomCount",
+               &RDKit::MolStandardize::CleanupParameters::
+                   largestFragmentChooserUseAtomCount,
+               "Whether LargestFragmentChooser should use atom "
+               "count as main criterion before MW (defaults to True)")
+      .def_rw("largestFragmentChooserCountHeavyAtomsOnly",
+               &RDKit::MolStandardize::CleanupParameters::
+                   largestFragmentChooserCountHeavyAtomsOnly,
+               "whether LargestFragmentChooser should only count "
+               "heavy atoms (defaults to False)")
       .def("__setattr__", &safeSetattr);
 
-  python::def("UpdateParamsFromJSON",
-              &RDKit::MolStandardize::updateCleanupParamsFromJSON,
-              python::args("params", "json"),
-              "updates the cleanup parameters from the provided JSON string");
+  m.def("UpdateParamsFromJSON",
+        &RDKit::MolStandardize::updateCleanupParamsFromJSON, "params"_a,
+        "json"_a,
+        "updates the cleanup parameters from the provided JSON string");
 
-  docString = "Standardizes a molecule";
-  python::def("Cleanup", cleanupHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString = "Standardizes a molecule in place";
-  python::def("CleanupInPlace", cleanupInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Standardizes multiple molecules in place";
-  python::def("CleanupInPlace", mtcleanupInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Convenience function for standardizing a SMILES";
-  python::def("StandardizeSmiles", RDKit::MolStandardize::standardizeSmiles,
-              (python::arg("smiles")), docString.c_str());
-  docString =
-      "Returns the tautomer parent of a given molecule. The fragment parent is "
-      "the standardized canonical tautomer of the molecule";
-  python::def("TautomerParent", tautomerParentHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString = "Generates the tautomer parent in place";
-  python::def("TautomerParentInPlace", tautomerParentInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "Generates the tautomer parent in place for multiple molecules";
-  python::def("TautomerParentInPlace", mttautomerParentInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
+  m.def("Cleanup", cleanupHelper, nb::arg("mol").none(), "params"_a = nb::none(),
+        "Standardizes a molecule", nb::rv_policy::take_ownership);
+  m.def("CleanupInPlace", cleanupInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(), "Standardizes a molecule in place");
+  m.def("CleanupInPlace", mtcleanupInPlaceHelper, "mols"_a, "numThreads"_a,
+        "params"_a = nb::none(), "Standardizes multiple molecules in place");
+  m.def("StandardizeSmiles", RDKit::MolStandardize::standardizeSmiles,
+        "smiles"_a, "Convenience function for standardizing a SMILES");
+  m.def("TautomerParent", tautomerParentHelper, nb::arg("mol").none(),
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        R"DOC(Returns the tautomer parent of a given molecule. The fragment parent is
+the standardized canonical tautomer of the molecule)DOC",
+        nb::rv_policy::take_ownership);
+  m.def("TautomerParentInPlace", tautomerParentInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the tautomer parent in place");
+  m.def("TautomerParentInPlace", mttautomerParentInPlaceHelper, "mols"_a,
+        "numThreads"_a, "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the tautomer parent in place for multiple molecules");
 
-  docString = "Returns the largest fragment after doing a cleanup";
-  python::def("FragmentParent", fragmentParentHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString = "Generates the largest fragment in place";
-  python::def("FragmentParentInPlace", fragmentParentInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "Generates the largest fragment in place for multiple molecules";
-  python::def("FragmentParentInPlace", mtfragmentParentInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
+  m.def("FragmentParent", fragmentParentHelper, nb::arg("mol").none(),
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Returns the largest fragment after doing a cleanup",
+        nb::rv_policy::take_ownership);
+  m.def("FragmentParentInPlace", fragmentParentInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the largest fragment in place");
+  m.def("FragmentParentInPlace", mtfragmentParentInPlaceHelper, "mols"_a,
+        "numThreads"_a, "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the largest fragment in place for multiple molecules");
 
-  python::def("StereoParent", stereoParentHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString = "Generates the stereo parent in place";
-  python::def("StereoParentInPlace", stereoParentInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "Generates the stereo parent in place for multiple molecules";
-  python::def("StereoParentInPlace", mtstereoParentInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "removes all isotopes specifications from the given molecule";
-  python::def("IsotopeParent", isotopeParentHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString = "Generates the isotope parent in place";
-  python::def("IsotopeParentInPlace", isotopeParentInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "Generates the isotope parent in place for multiple molecules";
-  python::def("IsotopeParentInPlace", mtisotopeParentInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "Returns the uncharged version of the largest fragment";
-  python::def("ChargeParent", chargeParentHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString = "Generates the charge parent in place";
-  python::def("ChargeParentInPlace", chargeParentInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "Generates the chargeparent in place for multiple molecules";
-  python::def("ChargeParentInPlace", mtchargeParentInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
+  m.def("StereoParent", stereoParentHelper, nb::arg("mol").none(), "params"_a = nb::none(),
+        "skipStandardize"_a = false,
+        "Returns the stereo parent of the molecule",
+        nb::rv_policy::take_ownership);
+  m.def("StereoParentInPlace", stereoParentInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the stereo parent in place");
+  m.def("StereoParentInPlace", mtstereoParentInPlaceHelper, "mols"_a,
+        "numThreads"_a, "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the stereo parent in place for multiple molecules");
 
-  docString =
-      "Returns the super parent. The super parent is the fragment, charge, "
-      "isotope, stereo, and tautomer parent of the molecule.";
-  python::def("SuperParent", superParentHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString = "Generates the super parent in place";
-  python::def("SuperParentInPlace", superParentInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
-  docString = "Generates the super parent in place for multiple molecules";
-  python::def("SuperParentInPlace", mtsuperParentInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object(),
-               python::arg("skipStandardize") = false),
-              docString.c_str());
+  m.def("IsotopeParent", isotopeParentHelper, nb::arg("mol").none(),
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "removes all isotopes specifications from the given molecule",
+        nb::rv_policy::take_ownership);
+  m.def("IsotopeParentInPlace", isotopeParentInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the isotope parent in place");
+  m.def("IsotopeParentInPlace", mtisotopeParentInPlaceHelper, "mols"_a,
+        "numThreads"_a, "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the isotope parent in place for multiple molecules");
 
-  docString =
-      "Applies a series of standard transformations to correct functional "
-      "groups and recombine charges";
-  python::def("Normalize", normalizeHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString =
-      "Applies a series of standard transformations to correct functional "
-      "groups and recombine charges, modifies the input molecule";
-  python::def("NormalizeInPlace", normalizeInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Normalizes multiple molecules in place";
-  python::def("NormalizeInPlace", mtnormalizeInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Ensures the strongest acid groups are charged first";
-  python::def("Reionize", reionizeHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString =
-      "Ensures the strongest acid groups are charged first, modifies the input molecule";
-  python::def("ReionizeInPlace", reionizeInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Reionizes multiple molecules in place";
-  python::def("ReionizeInPlace", mtreionizeInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Removes fragments from the molecule";
-  python::def("RemoveFragments", removeFragsHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString =
-      "Removes fragments from the molecule, modifies the input molecule";
-  python::def("RemoveFragmentsInPlace", removeFragmentsInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Removes fragments from multiple molecules in place";
-  python::def("RemoveFragmentsInPlace", mtremoveFragmentsInPlaceHelper,
-              (python::arg("mols"), python::arg("numThreads"),
-               python::arg("params") = python::object()),
-              docString.c_str());
-  docString = "Returns the canonical tautomer for the molecule";
-  python::def("CanonicalTautomer", canonicalTautomerHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
+  m.def("ChargeParent", chargeParentHelper, nb::arg("mol").none(), "params"_a = nb::none(),
+        "skipStandardize"_a = false,
+        "Returns the uncharged version of the largest fragment",
+        nb::rv_policy::take_ownership);
+  m.def("ChargeParentInPlace", chargeParentInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the charge parent in place");
+  m.def("ChargeParentInPlace", mtchargeParentInPlaceHelper, "mols"_a,
+        "numThreads"_a, "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the chargeparent in place for multiple molecules");
 
-  docString =
-      "Returns the molecule disconnected using the organometallics"
-      " rules.";
-  python::def("DisconnectOrganometallics", disconnectOrganometallicsHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str(),
-              python::return_value_policy<python::manage_new_object>());
-  docString =
-      "Disconnects the molecule using the organometallics"
-      " rules, modifies the input molecule";
-  python::def("DisconnectOrganometallicsInPlace",
-              disconnectOrganometallicsInPlaceHelper,
-              (python::arg("mol"), python::arg("params") = python::object()),
-              docString.c_str());
+  m.def("SuperParent", superParentHelper, nb::arg("mol").none(), "params"_a = nb::none(),
+        "skipStandardize"_a = false,
+        R"DOC(Returns the super parent. The super parent is the fragment, charge,
+isotope, stereo, and tautomer parent of the molecule.)DOC",
+        nb::rv_policy::take_ownership);
+  m.def("SuperParentInPlace", superParentInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the super parent in place");
+  m.def("SuperParentInPlace", mtsuperParentInPlaceHelper, "mols"_a,
+        "numThreads"_a, "params"_a = nb::none(), "skipStandardize"_a = false,
+        "Generates the super parent in place for multiple molecules");
 
-  wrap_validate();
-  wrap_charge();
-  wrap_metal();
-  wrap_fragment();
-  wrap_normalize();
-  wrap_tautomer();
-  wrap_pipeline();
+  m.def("Normalize", normalizeHelper, nb::arg("mol").none(), "params"_a = nb::none(),
+        R"DOC(Applies a series of standard transformations to correct functional
+groups and recombine charges)DOC",
+        nb::rv_policy::take_ownership);
+  m.def("NormalizeInPlace", normalizeInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(),
+        R"DOC(Applies a series of standard transformations to correct functional
+groups and recombine charges, modifies the input molecule)DOC");
+  m.def("NormalizeInPlace", mtnormalizeInPlaceHelper, "mols"_a, "numThreads"_a,
+        "params"_a = nb::none(), "Normalizes multiple molecules in place");
+
+  m.def("Reionize", reionizeHelper, nb::arg("mol").none(), "params"_a = nb::none(),
+        "Ensures the strongest acid groups are charged first",
+        nb::rv_policy::take_ownership);
+  m.def("ReionizeInPlace", reionizeInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(),
+        "Ensures the strongest acid groups are charged first, modifies the "
+        "input molecule");
+  m.def("ReionizeInPlace", mtreionizeInPlaceHelper, "mols"_a, "numThreads"_a,
+        "params"_a = nb::none(), "Reionizes multiple molecules in place");
+
+  m.def("RemoveFragments", removeFragsHelper, nb::arg("mol").none(),
+        "params"_a = nb::none(), "Removes fragments from the molecule",
+        nb::rv_policy::take_ownership);
+  m.def("RemoveFragmentsInPlace", removeFragmentsInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(),
+        "Removes fragments from the molecule, modifies the input molecule");
+  m.def("RemoveFragmentsInPlace", mtremoveFragmentsInPlaceHelper, "mols"_a,
+        "numThreads"_a, "params"_a = nb::none(),
+        "Removes fragments from multiple molecules in place");
+
+  m.def("CanonicalTautomer", canonicalTautomerHelper, nb::arg("mol").none(),
+        "params"_a = nb::none(),
+        "Returns the canonical tautomer for the molecule",
+        nb::rv_policy::take_ownership);
+
+  m.def("DisconnectOrganometallics", disconnectOrganometallicsHelper, "mol"_a,
+        "params"_a = nb::none(),
+        "Returns the molecule disconnected using the organometallics rules.",
+        nb::rv_policy::take_ownership);
+  m.def("DisconnectOrganometallicsInPlace",
+        disconnectOrganometallicsInPlaceHelper, "mol"_a,
+        "params"_a = nb::none(),
+        "Disconnects the molecule using the organometallics rules, modifies "
+        "the input molecule");
+
+  wrap_validate(m);
+  wrap_charge(m);
+  wrap_metal(m);
+  wrap_fragment(m);
+  wrap_normalize(m);
+  wrap_tautomer(m);
+  wrap_pipeline(m);
 }


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to MolStandardize.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.