### PR TITLE
pr/SHARED-12457: Implement nanobind for CoordGen

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -109,6 +109,9 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
   if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
     add_subdirectory(Wrap)
   endif(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
+  if(RDK_BUILD_NANOBIND_WRAPPERS)
+    add_subdirectory(nbWrap)
+  endif(RDK_BUILD_NANOBIND_WRAPPERS)
 
   rdkit_test(testCoordGen test.cpp
     LINK_LIBRARIES

--- a/External/CoordGen/nbWrap/CMakeLists.txt
+++ b/External/CoordGen/nbWrap/CMakeLists.txt
@@ -1,0 +1,7 @@
+rdkit_python_extension(rdCoordGen
+                       rdCoordGen.cpp
+                       DEST Chem
+                       LINK_LIBRARIES
+                       coordgen MolAlign SubstructMatch GraphMol DataStructs RDGeometryLib RDGeneral RDBoost)
+add_pytest(pyCoordGen
+         ${CMAKE_CURRENT_SOURCE_DIR}/testCoordGen.py)

--- a/External/CoordGen/nbWrap/CMakeLists.txt
+++ b/External/CoordGen/nbWrap/CMakeLists.txt
@@ -1,7 +1,7 @@
-rdkit_python_extension(rdCoordGen
-                       rdCoordGen.cpp
-                       DEST Chem
-                       LINK_LIBRARIES
-                       coordgen MolAlign SubstructMatch GraphMol DataStructs RDGeometryLib RDGeneral RDBoost)
+rdkit_nanobind_extension(rdCoordGen
+                         rdCoordGen.cpp
+                         DEST Chem
+                         LINK_LIBRARIES
+                         coordgen MolAlign SubstructMatch GraphMol DataStructs RDGeometryLib RDGeneral)
 add_pytest(pyCoordGen
-         ${CMAKE_CURRENT_SOURCE_DIR}/testCoordGen.py)
+         ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testCoordGen.py)

--- a/External/CoordGen/nbWrap/rdCoordGen.cpp
+++ b/External/CoordGen/nbWrap/rdCoordGen.cpp
@@ -1,0 +1,117 @@
+//
+//  Copyright (C) 2017 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#define NO_IMPORT_ARRAY
+#include <RDBoost/python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+#include <boost/python/list.hpp>
+#include <RDGeneral/Exceptions.h>
+#include <GraphMol/RDKitBase.h>
+#include <CoordGen/CoordGen.h>
+#include <RDBoost/Wrap.h>
+
+namespace python = boost::python;
+
+namespace RDKit {
+
+namespace {
+void SetCoordMap(CoordGen::CoordGenParams *self, python::dict &coordMap) {
+  self->coordMap.clear();
+  python::list ks = coordMap.keys();
+  for (unsigned int i = 0; i < boost::python::len(ks); ++i) {
+    unsigned int id = python::extract<unsigned int>(ks[i]);
+    self->coordMap[id] = python::extract<RDGeom::Point2D>(coordMap[id]);
+  }
+}
+void addCoordsHelper(ROMol &mol, python::object &params) {
+  CoordGen::CoordGenParams *ps = nullptr;
+  if (params != python::object()) {
+    ps = python::extract<CoordGen::CoordGenParams *>(params);
+  }
+  CoordGen::addCoords(mol, ps);
+}
+void SetTemplateMol(CoordGen::CoordGenParams *self, const ROMol *templ) {
+  self->templateMol = templ;
+}
+void SetDefaultTemplateFileDir(const std::string &dir) {
+  CoordGen::defaultParams.templateFileDir = dir;
+}
+}  // end of anonymous namespace
+
+struct coordgen_wrapper {
+  static void wrap() {
+    std::string docString = "";
+
+    python::class_<CoordGen::CoordGenParams>(
+        "CoordGenParams", "Parameters controlling coordinate generation")
+        .def(
+            "SetCoordMap", SetCoordMap, python::args("self", "coordMap"),
+            "expects a dictionary of Point2D objects with template coordinates")
+        .def("SetTemplateMol", SetTemplateMol,
+             python::with_custodian_and_ward<1, 2>(),
+             python::args("self", "templ"),
+             "sets a molecule to be used as the template")
+        .def_readwrite("coordgenScaling",
+                       &CoordGen::CoordGenParams::coordgenScaling,
+                       "scaling factor for a single bond")
+        .def_readwrite("dbg_useConstrained",
+                       &CoordGen::CoordGenParams::dbg_useConstrained,
+                       "for debugging use")
+        .def_readwrite("dbg_useFixed", &CoordGen::CoordGenParams::dbg_useFixed,
+                       "for debugging use")
+        .def_readwrite("templateFileDir",
+                       &CoordGen::CoordGenParams::templateFileDir,
+                       "directory containing the templates.mae file")
+        .def_readonly("sketcherBestPrecision",
+                      &CoordGen::CoordGenParams::sketcherBestPrecision,
+                      "highest quality (and slowest) precision setting")
+        .def_readonly("sketcherStandardPrecision",
+                      &CoordGen::CoordGenParams::sketcherStandardPrecision,
+                      "standard quality precision setting, the default for the "
+                      "coordgen project")
+        .def_readonly("sketcherQuickPrecision",
+                      &CoordGen::CoordGenParams::sketcherQuickPrecision,
+                      "faster precision setting")
+        .def_readonly(
+            "sketcherCoarsePrecision",
+            &CoordGen::CoordGenParams::sketcherCoarsePrecision,
+            "\"coarse\" (fastest) precision setting, produces good-quality "
+            "coordinates"
+            " most of the time, this is the default setting for the RDKit")
+        .def_readwrite("minimizerPrecision",
+                       &CoordGen::CoordGenParams::minimizerPrecision,
+                       "controls sketcher precision")
+        .def_readwrite(
+            "treatNonterminalBondsToMetalAsZOBs",
+            &CoordGen::CoordGenParams::treatNonterminalBondsToMetalAsZeroOrder)
+        .def("__setattr__", &safeSetattr);
+
+    python::def("SetDefaultTemplateFileDir", SetDefaultTemplateFileDir,
+                python::args("dir"));
+    docString =
+        "Add 2D coordinates.\n"
+        "ARGUMENTS:\n"
+        "   - mol: molecule to modify\n"
+        "   - params: (optional) parameters controlling the coordinate "
+        "generation\n"
+        "\n";
+    python::def("AddCoords", addCoordsHelper,
+                (python::arg("mol"), python::arg("params") = python::object()),
+                docString.c_str());
+  }
+};
+
+}  // end of namespace RDKit
+BOOST_PYTHON_MODULE(rdCoordGen) {
+  python::scope().attr("__doc__") =
+      "Module containing interface to the CoordGen library.";
+  RDKit::coordgen_wrapper::wrap();
+}

--- a/External/CoordGen/nbWrap/rdCoordGen.cpp
+++ b/External/CoordGen/nbWrap/rdCoordGen.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2017 Greg Landrum
+//  Copyright (C) 2017-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,110 +8,98 @@
 //  of the RDKit source tree.
 //
 
-#define NO_IMPORT_ARRAY
-#include <RDBoost/python.h>
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
-#include <boost/python/list.hpp>
-#include <RDGeneral/Exceptions.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+
 #include <GraphMol/RDKitBase.h>
 #include <CoordGen/CoordGen.h>
-#include <RDBoost/Wrap.h>
+#include <RDBoost/Wrap_nb.h>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace RDKit {
 
 namespace {
-void SetCoordMap(CoordGen::CoordGenParams *self, python::dict &coordMap) {
+
+void SetCoordMap(CoordGen::CoordGenParams *self, nb::dict coordMap) {
   self->coordMap.clear();
-  python::list ks = coordMap.keys();
-  for (unsigned int i = 0; i < boost::python::len(ks); ++i) {
-    unsigned int id = python::extract<unsigned int>(ks[i]);
-    self->coordMap[id] = python::extract<RDGeom::Point2D>(coordMap[id]);
+  for (auto item : coordMap) {
+    unsigned int id = nb::cast<unsigned int>(item.first);
+    self->coordMap[id] = nb::cast<RDGeom::Point2D>(item.second);
   }
 }
-void addCoordsHelper(ROMol &mol, python::object &params) {
+
+void addCoordsHelper(ROMol &mol, nb::object params) {
   CoordGen::CoordGenParams *ps = nullptr;
-  if (params != python::object()) {
-    ps = python::extract<CoordGen::CoordGenParams *>(params);
+  if (!params.is_none()) {
+    ps = nb::cast<CoordGen::CoordGenParams *>(params);
   }
   CoordGen::addCoords(mol, ps);
 }
+
 void SetTemplateMol(CoordGen::CoordGenParams *self, const ROMol *templ) {
   self->templateMol = templ;
 }
+
 void SetDefaultTemplateFileDir(const std::string &dir) {
   CoordGen::defaultParams.templateFileDir = dir;
 }
+
 }  // end of anonymous namespace
 
-struct coordgen_wrapper {
-  static void wrap() {
-    std::string docString = "";
-
-    python::class_<CoordGen::CoordGenParams>(
-        "CoordGenParams", "Parameters controlling coordinate generation")
-        .def(
-            "SetCoordMap", SetCoordMap, python::args("self", "coordMap"),
-            "expects a dictionary of Point2D objects with template coordinates")
-        .def("SetTemplateMol", SetTemplateMol,
-             python::with_custodian_and_ward<1, 2>(),
-             python::args("self", "templ"),
-             "sets a molecule to be used as the template")
-        .def_readwrite("coordgenScaling",
-                       &CoordGen::CoordGenParams::coordgenScaling,
-                       "scaling factor for a single bond")
-        .def_readwrite("dbg_useConstrained",
-                       &CoordGen::CoordGenParams::dbg_useConstrained,
-                       "for debugging use")
-        .def_readwrite("dbg_useFixed", &CoordGen::CoordGenParams::dbg_useFixed,
-                       "for debugging use")
-        .def_readwrite("templateFileDir",
-                       &CoordGen::CoordGenParams::templateFileDir,
-                       "directory containing the templates.mae file")
-        .def_readonly("sketcherBestPrecision",
-                      &CoordGen::CoordGenParams::sketcherBestPrecision,
-                      "highest quality (and slowest) precision setting")
-        .def_readonly("sketcherStandardPrecision",
-                      &CoordGen::CoordGenParams::sketcherStandardPrecision,
-                      "standard quality precision setting, the default for the "
-                      "coordgen project")
-        .def_readonly("sketcherQuickPrecision",
-                      &CoordGen::CoordGenParams::sketcherQuickPrecision,
-                      "faster precision setting")
-        .def_readonly(
-            "sketcherCoarsePrecision",
-            &CoordGen::CoordGenParams::sketcherCoarsePrecision,
-            "\"coarse\" (fastest) precision setting, produces good-quality "
-            "coordinates"
-            " most of the time, this is the default setting for the RDKit")
-        .def_readwrite("minimizerPrecision",
-                       &CoordGen::CoordGenParams::minimizerPrecision,
-                       "controls sketcher precision")
-        .def_readwrite(
-            "treatNonterminalBondsToMetalAsZOBs",
-            &CoordGen::CoordGenParams::treatNonterminalBondsToMetalAsZeroOrder)
-        .def("__setattr__", &safeSetattr);
-
-    python::def("SetDefaultTemplateFileDir", SetDefaultTemplateFileDir,
-                python::args("dir"));
-    docString =
-        "Add 2D coordinates.\n"
-        "ARGUMENTS:\n"
-        "   - mol: molecule to modify\n"
-        "   - params: (optional) parameters controlling the coordinate "
-        "generation\n"
-        "\n";
-    python::def("AddCoords", addCoordsHelper,
-                (python::arg("mol"), python::arg("params") = python::object()),
-                docString.c_str());
-  }
-};
-
 }  // end of namespace RDKit
-BOOST_PYTHON_MODULE(rdCoordGen) {
-  python::scope().attr("__doc__") =
-      "Module containing interface to the CoordGen library.";
-  RDKit::coordgen_wrapper::wrap();
+
+NB_MODULE(rdCoordGen, m) {
+  m.doc() = "Module containing interface to the CoordGen library.";
+
+  nb::class_<RDKit::CoordGen::CoordGenParams>(m, "CoordGenParams",
+                                               "Parameters controlling coordinate generation")
+      .def(nb::init<>())
+      .def("SetCoordMap", &RDKit::SetCoordMap, "coordMap"_a,
+           "expects a dictionary of Point2D objects with template coordinates")
+      .def("SetTemplateMol", &RDKit::SetTemplateMol, nb::keep_alive<1, 2>(),
+           "templ"_a, "sets a molecule to be used as the template")
+      .def_rw("coordgenScaling",
+              &RDKit::CoordGen::CoordGenParams::coordgenScaling,
+              "scaling factor for a single bond")
+      .def_rw("dbg_useConstrained",
+              &RDKit::CoordGen::CoordGenParams::dbg_useConstrained,
+              "for debugging use")
+      .def_rw("dbg_useFixed", &RDKit::CoordGen::CoordGenParams::dbg_useFixed,
+              "for debugging use")
+      .def_rw("templateFileDir",
+              &RDKit::CoordGen::CoordGenParams::templateFileDir,
+              "directory containing the templates.mae file")
+      .def_ro("sketcherBestPrecision",
+              &RDKit::CoordGen::CoordGenParams::sketcherBestPrecision,
+              "highest quality (and slowest) precision setting")
+      .def_ro("sketcherStandardPrecision",
+              &RDKit::CoordGen::CoordGenParams::sketcherStandardPrecision,
+              "standard quality precision setting, the default for the coordgen project")
+      .def_ro("sketcherQuickPrecision",
+              &RDKit::CoordGen::CoordGenParams::sketcherQuickPrecision,
+              "faster precision setting")
+      .def_ro("sketcherCoarsePrecision",
+              &RDKit::CoordGen::CoordGenParams::sketcherCoarsePrecision,
+              R"DOC("coarse" (fastest) precision setting, produces good-quality
+coordinates most of the time, this is the default setting for the RDKit)DOC")
+      .def_rw("minimizerPrecision",
+              &RDKit::CoordGen::CoordGenParams::minimizerPrecision,
+              "controls sketcher precision")
+      .def_rw("treatNonterminalBondsToMetalAsZOBs",
+              &RDKit::CoordGen::CoordGenParams::treatNonterminalBondsToMetalAsZeroOrder)
+      .def("__setattr__", &safeSetattr);
+
+  m.def("SetDefaultTemplateFileDir", &RDKit::SetDefaultTemplateFileDir,
+        "dir"_a);
+
+  m.def(
+      "AddCoords", &RDKit::addCoordsHelper,
+      "mol"_a, "params"_a = nb::none(),
+      R"DOC(Add 2D coordinates.
+ARGUMENTS:
+   - mol: molecule to modify
+   - params: (optional) parameters controlling the coordinate generation
+)DOC");
 }


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to CoordGen.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.