### PR TITLE
pr/SHARED-12459: Implement nanobind for INCHI-API

### DIFF
--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -87,6 +87,9 @@ if(RDK_BUILD_INCHI_SUPPORT)
   if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
     add_subdirectory(Wrap)
   endif(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
+  if(RDK_BUILD_NANOBIND_WRAPPERS)
+    add_subdirectory(nbWrap)
+  endif()
 
   add_definitions(-DRDK_BUILD_INCHI_SUPPORT)
 

--- a/External/INCHI-API/nbWrap/CMakeLists.txt
+++ b/External/INCHI-API/nbWrap/CMakeLists.txt
@@ -1,0 +1,5 @@
+rdkit_python_extension(rdinchi
+                       pyInchi.cpp
+		       DEST Chem
+                       LINK_LIBRARIES 
+                       RDInchiLib )

--- a/External/INCHI-API/nbWrap/CMakeLists.txt
+++ b/External/INCHI-API/nbWrap/CMakeLists.txt
@@ -1,5 +1,7 @@
-rdkit_python_extension(rdinchi
-                       pyInchi.cpp
-		       DEST Chem
-                       LINK_LIBRARIES 
-                       RDInchiLib )
+rdkit_nanobind_extension(rdinchi
+                        pyInchi.cpp
+                        DEST Chem
+                        LINK_LIBRARIES
+                        RDInchiLib)
+
+add_pytest(pyInchiWrap ${CMAKE_SOURCE_DIR}/rdkit/Chem/UnitTestInchi.py)

--- a/External/INCHI-API/nbWrap/pyInchi.cpp
+++ b/External/INCHI-API/nbWrap/pyInchi.cpp
@@ -1,0 +1,153 @@
+//
+//  Copyright (c) 2011-2014, Novartis Institutes for BioMedical Research Inc.
+//  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+//       nor the names of its contributors may be used to endorse or promote
+//       products derived from this software without specific prior written
+//       permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <boost/python.hpp>
+#include "../inchi.h"
+
+namespace {
+boost::python::tuple MolToInchi(const RDKit::ROMol &mol, std::string options) {
+  RDKit::ExtraInchiReturnValues rv;
+  const char *_options = nullptr;
+  if (options.size()) {
+    _options = options.c_str();
+  }
+  std::string inchi = RDKit::MolToInchi(mol, rv, _options);
+  return boost::python::make_tuple(inchi, rv.returnCode, rv.messagePtr,
+                                   rv.logPtr, rv.auxInfoPtr);
+}
+
+boost::python::tuple MolBlockToInchi(const std::string &molblock,
+                                     std::string options) {
+  RDKit::ExtraInchiReturnValues rv;
+  const char *_options = nullptr;
+  if (options.size()) {
+    _options = options.c_str();
+  }
+  std::string inchi = RDKit::MolBlockToInchi(molblock, rv, _options);
+  return boost::python::make_tuple(inchi, rv.returnCode, rv.messagePtr,
+                                   rv.logPtr, rv.auxInfoPtr);
+}
+boost::python::tuple InchiToMol(const std::string &inchi, bool sanitize,
+                                bool removeHs) {
+  RDKit::ExtraInchiReturnValues rv;
+  RDKit::ROMol *mol = RDKit::InchiToMol(inchi, rv, sanitize, removeHs);
+  if (mol == nullptr) {
+    return boost::python::make_tuple(boost::python::object(), rv.returnCode,
+                                     rv.messagePtr, rv.logPtr);
+  } else {
+    return boost::python::make_tuple(RDKit::ROMOL_SPTR(mol), rv.returnCode,
+                                     rv.messagePtr, rv.logPtr);
+  }
+}
+}  // namespace
+
+BOOST_PYTHON_MODULE(rdinchi) {
+  std::string docString =
+      "return a ROMol for a InChI string\n\
+  Returns:\n\
+    a tuple with:\n\
+      - the molecule\n\
+      - the return code from the InChI conversion\n\
+      - a string with any messages from the InChI conversion\n\
+      - a string with any log messages from the InChI conversion\n";
+  boost::python::def(
+      "InchiToMol", InchiToMol,
+      (boost::python::arg("inchi"), boost::python::arg("sanitize") = true,
+       boost::python::arg("removeHs") = true),
+      docString.c_str());
+  docString =
+      "return the InChI for a ROMol molecule.\n\
+\n\
+  Arguments:\n\
+    - mol: the molecule to use.\n\
+    - options: the InChI generation options.\n\
+      Options should be prefixed with either a - or a /\n\
+      Available options are explained in the InChI technical FAQ:\n\
+      https://www.inchi-trust.org/technical-faq/#15.14\n\
+      and the User Guide:\n\
+      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf\n\
+  Returns:\n\
+    a tuple with:\n\
+      - the InChI\n\
+      - the return code from the InChI conversion\n\
+      - a string with any messages from the InChI conversion\n\
+      - a string with any log messages from the InChI conversion\n\
+      - a string with the InChI AuxInfo\n";
+  boost::python::def("MolToInchi", MolToInchi,
+                     (boost::python::arg("mol"),
+                      boost::python::arg("options") = std::string()),
+                     docString.c_str());
+  docString =
+      "return the InChI for a ROMol molecule.\n\
+\n\
+  Arguments:\n\
+    - molblock: the mol block to use.\n\
+    - options: the InChI generation options.\n\
+      Options should be prefixed with either a - or a /\n\
+      Available options are explained in the InChI technical FAQ:\n\
+      https://www.inchi-trust.org/technical-faq/#15.14\n\
+      and the User Guide:\n\
+      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf\n\
+  Returns:\n\
+    a tuple with:\n\
+      - the InChI\n\
+      - the return code from the InChI conversion\n\
+      - a string with any messages from the InChI conversion\n\
+      - a string with any log messages from the InChI conversion\n\
+      - a string with the InChI AuxInfo\n";
+  boost::python::def("MolBlockToInchi", MolBlockToInchi,
+                     (boost::python::arg("molblock"),
+                      boost::python::arg("options") = std::string()),
+                     docString.c_str());
+  docString = "return the InChI key for an InChI string";
+  boost::python::def("InchiToInchiKey", RDKit::InchiToInchiKey,
+                     (boost::python::arg("inchi")), docString.c_str());
+  docString =
+      "return the InChI key for a ROMol molecule.\n\
+\n\
+  Arguments:\n\
+    - mol: the molecule to use.\n\
+    - options: the InChI generation options.\n\
+      Options should be prefixed with either a - or a /\n\
+      Available options are explained in the InChI technical FAQ:\n\
+      https://www.inchi-trust.org/technical-faq/#15.14\n\
+      and the User Guide available from:\n\
+      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf\n\
+  Returns: the InChI key\n";
+  boost::python::def(
+      "MolToInchiKey", RDKit::MolToInchiKey,
+      (boost::python::arg("mol"), boost::python::arg("options") = ""),
+      docString.c_str());
+
+  boost::python::def("GetInchiVersion", RDKit::getInchiVersion,
+                     "returns the version of the InChI software being used");
+}

--- a/External/INCHI-API/nbWrap/pyInchi.cpp
+++ b/External/INCHI-API/nbWrap/pyInchi.cpp
@@ -1,5 +1,6 @@
 //
-//  Copyright (c) 2011-2014, Novartis Institutes for BioMedical Research Inc.
+//  Copyright (c) 2011-2026 Novartis Institutes for BioMedical Research Inc.
+//    and other RDKit contributors
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -30,124 +31,120 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include <boost/python.hpp>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+
+#include <GraphMol/GraphMol.h>
+#include <RDBoost/boost_shared_ptr.h>
 #include "../inchi.h"
 
-namespace {
-boost::python::tuple MolToInchi(const RDKit::ROMol &mol, std::string options) {
-  RDKit::ExtraInchiReturnValues rv;
-  const char *_options = nullptr;
-  if (options.size()) {
-    _options = options.c_str();
-  }
-  std::string inchi = RDKit::MolToInchi(mol, rv, _options);
-  return boost::python::make_tuple(inchi, rv.returnCode, rv.messagePtr,
-                                   rv.logPtr, rv.auxInfoPtr);
-}
+namespace nb = nanobind;
+using namespace nb::literals;
 
-boost::python::tuple MolBlockToInchi(const std::string &molblock,
-                                     std::string options) {
-  RDKit::ExtraInchiReturnValues rv;
-  const char *_options = nullptr;
-  if (options.size()) {
-    _options = options.c_str();
-  }
-  std::string inchi = RDKit::MolBlockToInchi(molblock, rv, _options);
-  return boost::python::make_tuple(inchi, rv.returnCode, rv.messagePtr,
-                                   rv.logPtr, rv.auxInfoPtr);
-}
-boost::python::tuple InchiToMol(const std::string &inchi, bool sanitize,
-                                bool removeHs) {
-  RDKit::ExtraInchiReturnValues rv;
-  RDKit::ROMol *mol = RDKit::InchiToMol(inchi, rv, sanitize, removeHs);
-  if (mol == nullptr) {
-    return boost::python::make_tuple(boost::python::object(), rv.returnCode,
-                                     rv.messagePtr, rv.logPtr);
-  } else {
-    return boost::python::make_tuple(RDKit::ROMOL_SPTR(mol), rv.returnCode,
-                                     rv.messagePtr, rv.logPtr);
-  }
-}
-}  // namespace
+NB_MODULE(rdinchi, m) {
+  m.def(
+      "InchiToMol",
+      [](const std::string &inchi, bool sanitize, bool removeHs) {
+        RDKit::ExtraInchiReturnValues rv;
+        RDKit::ROMol *mol = RDKit::InchiToMol(inchi, rv, sanitize, removeHs);
+        if (mol == nullptr) {
+          return std::make_tuple(RDKit::ROMOL_SPTR(), rv.returnCode,
+                                 rv.messagePtr, rv.logPtr);
+        } else {
+          return std::make_tuple(RDKit::ROMOL_SPTR(mol), rv.returnCode,
+                                 rv.messagePtr, rv.logPtr);
+        }
+      },
+      "inchi"_a, "sanitize"_a = true, "removeHs"_a = true,
+      R"DOC(return a ROMol for a InChI string
+  Returns:
+    a tuple with:
+      - the molecule
+      - the return code from the InChI conversion
+      - a string with any messages from the InChI conversion
+      - a string with any log messages from the InChI conversion)DOC");
 
-BOOST_PYTHON_MODULE(rdinchi) {
-  std::string docString =
-      "return a ROMol for a InChI string\n\
-  Returns:\n\
-    a tuple with:\n\
-      - the molecule\n\
-      - the return code from the InChI conversion\n\
-      - a string with any messages from the InChI conversion\n\
-      - a string with any log messages from the InChI conversion\n";
-  boost::python::def(
-      "InchiToMol", InchiToMol,
-      (boost::python::arg("inchi"), boost::python::arg("sanitize") = true,
-       boost::python::arg("removeHs") = true),
-      docString.c_str());
-  docString =
-      "return the InChI for a ROMol molecule.\n\
-\n\
-  Arguments:\n\
-    - mol: the molecule to use.\n\
-    - options: the InChI generation options.\n\
-      Options should be prefixed with either a - or a /\n\
-      Available options are explained in the InChI technical FAQ:\n\
-      https://www.inchi-trust.org/technical-faq/#15.14\n\
-      and the User Guide:\n\
-      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf\n\
-  Returns:\n\
-    a tuple with:\n\
-      - the InChI\n\
-      - the return code from the InChI conversion\n\
-      - a string with any messages from the InChI conversion\n\
-      - a string with any log messages from the InChI conversion\n\
-      - a string with the InChI AuxInfo\n";
-  boost::python::def("MolToInchi", MolToInchi,
-                     (boost::python::arg("mol"),
-                      boost::python::arg("options") = std::string()),
-                     docString.c_str());
-  docString =
-      "return the InChI for a ROMol molecule.\n\
-\n\
-  Arguments:\n\
-    - molblock: the mol block to use.\n\
-    - options: the InChI generation options.\n\
-      Options should be prefixed with either a - or a /\n\
-      Available options are explained in the InChI technical FAQ:\n\
-      https://www.inchi-trust.org/technical-faq/#15.14\n\
-      and the User Guide:\n\
-      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf\n\
-  Returns:\n\
-    a tuple with:\n\
-      - the InChI\n\
-      - the return code from the InChI conversion\n\
-      - a string with any messages from the InChI conversion\n\
-      - a string with any log messages from the InChI conversion\n\
-      - a string with the InChI AuxInfo\n";
-  boost::python::def("MolBlockToInchi", MolBlockToInchi,
-                     (boost::python::arg("molblock"),
-                      boost::python::arg("options") = std::string()),
-                     docString.c_str());
-  docString = "return the InChI key for an InChI string";
-  boost::python::def("InchiToInchiKey", RDKit::InchiToInchiKey,
-                     (boost::python::arg("inchi")), docString.c_str());
-  docString =
-      "return the InChI key for a ROMol molecule.\n\
-\n\
-  Arguments:\n\
-    - mol: the molecule to use.\n\
-    - options: the InChI generation options.\n\
-      Options should be prefixed with either a - or a /\n\
-      Available options are explained in the InChI technical FAQ:\n\
-      https://www.inchi-trust.org/technical-faq/#15.14\n\
-      and the User Guide available from:\n\
-      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf\n\
-  Returns: the InChI key\n";
-  boost::python::def(
-      "MolToInchiKey", RDKit::MolToInchiKey,
-      (boost::python::arg("mol"), boost::python::arg("options") = ""),
-      docString.c_str());
+  m.def(
+      "MolToInchi",
+      [](const RDKit::ROMol &mol, std::string options) {
+        RDKit::ExtraInchiReturnValues rv;
+        const char *_options = nullptr;
+        if (options.size()) {
+          _options = options.c_str();
+        }
+        std::string inchi = RDKit::MolToInchi(mol, rv, _options);
+        return std::make_tuple(inchi, rv.returnCode, rv.messagePtr, rv.logPtr,
+                               rv.auxInfoPtr);
+      },
+      "mol"_a, "options"_a = std::string(),
+      R"DOC(return the InChI for a ROMol molecule.
 
-  boost::python::def("GetInchiVersion", RDKit::getInchiVersion,
-                     "returns the version of the InChI software being used");
+  Arguments:
+    - mol: the molecule to use.
+    - options: the InChI generation options.
+      Options should be prefixed with either a - or a /
+      Available options are explained in the InChI technical FAQ:
+      https://www.inchi-trust.org/technical-faq/#15.14
+      and the User Guide:
+      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf
+  Returns:
+    a tuple with:
+      - the InChI
+      - the return code from the InChI conversion
+      - a string with any messages from the InChI conversion
+      - a string with any log messages from the InChI conversion
+      - a string with the InChI AuxInfo)DOC");
+
+  m.def(
+      "MolBlockToInchi",
+      [](const std::string &molblock, std::string options) {
+        RDKit::ExtraInchiReturnValues rv;
+        const char *_options = nullptr;
+        if (options.size()) {
+          _options = options.c_str();
+        }
+        std::string inchi = RDKit::MolBlockToInchi(molblock, rv, _options);
+        return std::make_tuple(inchi, rv.returnCode, rv.messagePtr, rv.logPtr,
+                               rv.auxInfoPtr);
+      },
+      "molblock"_a, "options"_a = std::string(),
+      R"DOC(return the InChI for a ROMol molecule.
+
+  Arguments:
+    - molblock: the mol block to use.
+    - options: the InChI generation options.
+      Options should be prefixed with either a - or a /
+      Available options are explained in the InChI technical FAQ:
+      https://www.inchi-trust.org/technical-faq/#15.14
+      and the User Guide:
+      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf
+  Returns:
+    a tuple with:
+      - the InChI
+      - the return code from the InChI conversion
+      - a string with any messages from the InChI conversion
+      - a string with any log messages from the InChI conversion
+      - a string with the InChI AuxInfo)DOC");
+
+  m.def("InchiToInchiKey", RDKit::InchiToInchiKey, "inchi"_a,
+        "return the InChI key for an InChI string");
+
+  m.def(
+      "MolToInchiKey", RDKit::MolToInchiKey, "mol"_a,
+      "options"_a = std::string(),
+      R"DOC(return the InChI key for a ROMol molecule.
+
+  Arguments:
+    - mol: the molecule to use.
+    - options: the InChI generation options.
+      Options should be prefixed with either a - or a /
+      Available options are explained in the InChI technical FAQ:
+      https://www.inchi-trust.org/technical-faq/#15.14
+      and the User Guide available from:
+      https://github.com/IUPAC-InChI/InChI/blob/main/INCHI-1-DOC/UserGuide/InChI_UserGuide.pdf
+  Returns: the InChI key)DOC");
+
+  m.def("GetInchiVersion", RDKit::getInchiVersion,
+        "returns the version of the InChI software being used");
 }


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to INCHI-API.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.