### PR TITLE
pr/SHARED-12389: Implement nanobind for MolDraw2DQt

### DIFF
--- a/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
@@ -72,3 +72,7 @@ endif(RDK_BUILD_QT_DEMO)
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)
 endif()
+
+if(RDK_BUILD_NANOBIND_WRAPPERS)
+  add_subdirectory(nbWrap)
+endif()

--- a/Code/GraphMol/MolDraw2D/Qt/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/nbWrap/CMakeLists.txt
@@ -1,0 +1,8 @@
+remove_definitions(-DRDKIT_MOLDRAW2DQT_BUILD)
+
+rdkit_python_extension(rdMolDraw2DQt
+                       rdMolDraw2DQt.cpp
+                       DEST Chem/Draw
+                       LINK_LIBRARIES MolDraw2DQt)
+
+add_pytest(pyMolDraw2DQt ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2DQt.py)

--- a/Code/GraphMol/MolDraw2D/Qt/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/nbWrap/CMakeLists.txt
@@ -1,8 +1,8 @@
 remove_definitions(-DRDKIT_MOLDRAW2DQT_BUILD)
 
-rdkit_python_extension(rdMolDraw2DQt
-                       rdMolDraw2DQt.cpp
-                       DEST Chem/Draw
-                       LINK_LIBRARIES MolDraw2DQt)
+rdkit_nanobind_extension(rdMolDraw2DQt
+                         rdMolDraw2DQt.cpp
+                         DEST Chem/Draw
+                         LINK_LIBRARIES MolDraw2DQt)
 
-add_pytest(pyMolDraw2DQt ${CMAKE_CURRENT_SOURCE_DIR}/testMolDraw2DQt.py)
+add_pytest(pyMolDraw2DQt ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/testMolDraw2DQt.py)

--- a/Code/GraphMol/MolDraw2D/Qt/nbWrap/rdMolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/nbWrap/rdMolDraw2DQt.cpp
@@ -1,0 +1,51 @@
+//
+//  Copyright (C) 2015-2019 Greg Landrum
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDBoost/python.h>
+#include <RDBoost/Wrap.h>
+
+#include <GraphMol/ROMol.h>
+#include <GraphMol/MolDraw2D/MolDraw2D.h>
+
+#include <GraphMol/MolDraw2D/Qt/MolDraw2DQt.h>
+#include <QPainter>
+
+namespace python = boost::python;
+
+namespace RDKit {
+MolDraw2DQt *moldrawFromQPainter(int width, int height, size_t ptr,
+                                 int panelWidth, int panelHeight) {
+  if (!ptr) {
+    throw_value_error("QPainter pointer is null");
+  }
+  QPainter *qptr = reinterpret_cast<QPainter *>(ptr);
+  return new MolDraw2DQt(width, height, qptr, panelWidth, panelHeight);
+}
+
+}  // namespace RDKit
+
+BOOST_PYTHON_MODULE(rdMolDraw2DQt) {
+  python::scope().attr("__doc__") =
+      "Module containing a C++ implementation of 2D molecule drawing using Qt";
+
+  python::scope().attr("rdkitQtVersion") = RDKit::rdkitQtVersion;
+
+  std::string docString = "Qt molecule drawer";
+  python::class_<RDKit::MolDraw2DQt, python::bases<RDKit::MolDraw2D>,
+                 boost::noncopyable>("MolDraw2DQt", docString.c_str(),
+                                     python::no_init);
+  python::def("MolDraw2DFromQPainter_", RDKit::moldrawFromQPainter,
+              (python::arg("width"), python::arg("height"),
+               python::arg("pointer_to_QPainter"),
+               python::arg("panelWidth") = -1, python::arg("panelHeight") = -1),
+              "Returns a MolDraw2DQt instance set to use a QPainter.\nUse "
+              "sip.unwrapinstance(qptr) to get the required pointer "
+              "information. Please note that this is somewhat fragile.",
+              python::return_value_policy<python::manage_new_object>());
+}

--- a/Code/GraphMol/MolDraw2D/Qt/nbWrap/rdMolDraw2DQt.cpp
+++ b/Code/GraphMol/MolDraw2D/Qt/nbWrap/rdMolDraw2DQt.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2015-2019 Greg Landrum
+//  Copyright (C) 2015-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,22 +7,21 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDBoost/python.h>
-#include <RDBoost/Wrap.h>
-
+#include <nanobind/nanobind.h>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
 
 #include <GraphMol/MolDraw2D/Qt/MolDraw2DQt.h>
 #include <QPainter>
 
-namespace python = boost::python;
+namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace RDKit {
-MolDraw2DQt *moldrawFromQPainter(int width, int height, size_t ptr,
-                                 int panelWidth, int panelHeight) {
+static MolDraw2DQt *moldrawFromQPainter(int width, int height, size_t ptr,
+                                        int panelWidth, int panelHeight) {
   if (!ptr) {
-    throw_value_error("QPainter pointer is null");
+    throw nb::value_error("QPainter pointer is null");
   }
   QPainter *qptr = reinterpret_cast<QPainter *>(ptr);
   return new MolDraw2DQt(width, height, qptr, panelWidth, panelHeight);
@@ -30,22 +29,22 @@ MolDraw2DQt *moldrawFromQPainter(int width, int height, size_t ptr,
 
 }  // namespace RDKit
 
-BOOST_PYTHON_MODULE(rdMolDraw2DQt) {
-  python::scope().attr("__doc__") =
+NB_MODULE(rdMolDraw2DQt, m) {
+  m.doc() =
       "Module containing a C++ implementation of 2D molecule drawing using Qt";
 
-  python::scope().attr("rdkitQtVersion") = RDKit::rdkitQtVersion;
+  m.attr("rdkitQtVersion") = RDKit::rdkitQtVersion;
 
-  std::string docString = "Qt molecule drawer";
-  python::class_<RDKit::MolDraw2DQt, python::bases<RDKit::MolDraw2D>,
-                 boost::noncopyable>("MolDraw2DQt", docString.c_str(),
-                                     python::no_init);
-  python::def("MolDraw2DFromQPainter_", RDKit::moldrawFromQPainter,
-              (python::arg("width"), python::arg("height"),
-               python::arg("pointer_to_QPainter"),
-               python::arg("panelWidth") = -1, python::arg("panelHeight") = -1),
-              "Returns a MolDraw2DQt instance set to use a QPainter.\nUse "
-              "sip.unwrapinstance(qptr) to get the required pointer "
-              "information. Please note that this is somewhat fragile.",
-              python::return_value_policy<python::manage_new_object>());
+  nb::class_<RDKit::MolDraw2DQt, RDKit::MolDraw2D>(m, "MolDraw2DQt",
+                                                    "Qt molecule drawer",
+                                                    nb::dynamic_attr());
+
+  m.def(
+      "MolDraw2DFromQPainter_", &RDKit::moldrawFromQPainter,
+      "width"_a, "height"_a, "pointer_to_QPainter"_a,
+      "panelWidth"_a = -1, "panelHeight"_a = -1,
+      R"DOC(Returns a MolDraw2DQt instance set to use a QPainter.
+Use sip.unwrapinstance(qptr) to get the required pointer information.
+Please note that this is somewhat fragile.)DOC",
+      nb::rv_policy::take_ownership);
 }


### PR DESCRIPTION
#### Reference Issue
Discussion: https://github.com/rdkit/rdkit/discussions/9031
PR: https://github.com/rdkit/rdkit/pull/9030

#### What does this implement/fix? Explain your changes.
Use [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) for the Python wrappers in RDKit. These changes are specific to MolDraw2DQt.

#### Any other comments?
If you look at the changes between the first and second commits you will be able to see a diff between the boost and nanobind wrappings.